### PR TITLE
PIL-1335: Implement OpenAPI specification generator

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,6 @@
-import com.typesafe.sbt.web.PathMapping
-import com.typesafe.sbt.web.pipeline.Pipeline
 import play.sbt.PlayImport.PlayKeys.playDefaultPort
-import uk.gov.hmrc.DefaultBuildSettings._
 import scoverage.ScoverageKeys
+import uk.gov.hmrc.DefaultBuildSettings._
 import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin.publishingSettings
 
 val scalafixSettings = Seq(
@@ -11,7 +9,7 @@ val scalafixSettings = Seq(
 )
 
 lazy val microservice = Project("pillar2-submission-api", file("."))
-  .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin, ScalafixPlugin)
+  .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin, ScalafixPlugin, SwaggerPlugin)
   .settings(
     majorVersion := 0,
     ScoverageKeys.coverageExcludedFiles :=
@@ -61,6 +59,8 @@ lazy val microservice = Project("pillar2-submission-api", file("."))
   )
   .settings(resolvers += Resolver.jcenterRepo)
   .settings(resolvers += "emueller-bintray" at "https://dl.bintray.com/emueller/maven")
+  .settings(JsonToYaml.settings *)
+  .settings(PlaySwagger.settings *)
   .disablePlugins(JUnitXmlReportPlugin)
 
 addCommandAlias("prePrChecks", ";scalafmtCheckAll;scalafmtSbtCheck;scalafixAll --check")

--- a/conf/swagger.yml
+++ b/conf/swagger.yml
@@ -1,0 +1,4 @@
+openapi: 3.0.3
+info:
+  title: Pillar 2 Submission
+  description: An API for managing and retrieving Pillar 2 submissions

--- a/project/JsonToYaml.scala
+++ b/project/JsonToYaml.scala
@@ -1,0 +1,39 @@
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.{YAMLFactory, YAMLGenerator}
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import sbt.Keys._
+import sbt._
+
+import scala.collection.mutable
+import scala.util.Try
+
+object JsonToYaml {
+  val toYaml = taskKey[Unit]("Generate YAML OpenAPI specification from JSON")
+  def settings: Seq[Setting[_]] = Seq(
+    toYaml := {
+
+      val yamlFactory = new YAMLFactory().configure(YAMLGenerator.Feature.WRITE_DOC_START_MARKER, false)
+      val jsonMapper  = new ObjectMapper().registerModule(DefaultScalaModule)
+      val yamlMapper  = new ObjectMapper(yamlFactory).registerModule(DefaultScalaModule)
+
+      val jsonFile: File = baseDirectory.value / "target/swagger/swagger.json"
+      val yamlFile: File = baseDirectory.value / "target/swagger/application.yaml"
+
+      Try {
+        val jsonString = IO.read(jsonFile)
+        val jsonMap    = jsonMapper.readValue(jsonString, classOf[Map[String, Any]])
+
+        val specification = mutable.LinkedHashMap(
+          "openapi"    -> jsonMap("openapi"),
+          "info"       -> (jsonMap("info").asInstanceOf[Map[String, Any]] + ("version" -> version.value.stripSuffix("-SNAPSHOT"))),
+          "tags"       -> jsonMap("tags"),
+          "paths"      -> jsonMap("paths"),
+          "components" -> jsonMap("components")
+        )
+
+        val yamlString = yamlMapper.writeValueAsString(specification)
+        IO.write(yamlFile, yamlString)
+      }.recover { case ex: Exception => streams.value.log.error(s"Failed to convert JSON to YAML: $ex") }
+    }
+  )
+}

--- a/project/PlaySwagger.scala
+++ b/project/PlaySwagger.scala
@@ -1,0 +1,11 @@
+import com.iheart.sbtPlaySwagger.SwaggerPlugin.autoImport._
+import sbt.Def
+
+object PlaySwagger {
+  lazy val settings: Seq[Def.Setting[_]] = Seq(
+    swaggerDomainNameSpaces := Seq("app/models"),
+    swaggerRoutesFile := "app.routes",
+    swaggerV3 := true,
+    swaggerPrettyJson := true
+  )
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,15 @@
 resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
 resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 resolvers += Resolver.typesafeRepo("releases")
+libraryDependencies ++= Seq(
+  "com.fasterxml.jackson.module"    %% "jackson-module-scala"    % "2.17.2",
+  "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % "2.17.2"
+)
 
-addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"     % "3.20.0")
-addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables" % "2.5.0")
-addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.0")
-addSbtPlugin("org.scoverage"     % "sbt-scoverage"      % "2.0.9")
-addSbtPlugin("org.scalameta"     % "sbt-scalafmt"       % "2.4.0")
-addSbtPlugin("ch.epfl.scala"     % "sbt-scalafix"       % "0.13.0")
+addSbtPlugin("uk.gov.hmrc"            % "sbt-auto-build"     % "3.20.0")
+addSbtPlugin("uk.gov.hmrc"            % "sbt-distributables" % "2.5.0")
+addSbtPlugin("org.playframework"      % "sbt-plugin"         % "3.0.0")
+addSbtPlugin("org.scoverage"          % "sbt-scoverage"      % "2.0.9")
+addSbtPlugin("org.scalameta"          % "sbt-scalafmt"       % "2.4.0")
+addSbtPlugin("ch.epfl.scala"          % "sbt-scalafix"       % "0.13.0")
+addSbtPlugin("io.github.play-swagger" % "sbt-play-swagger"   % "2.0.0")


### PR DESCRIPTION
Changes:

Generation of the OpenAPI specification from routes  - Step 1 of 3: generator implementation

Following this PR, an OpenAPI specification (version configurable, 3.0.3 by default) can be generated from a routes file. Play-swagger is used to generate a JSON specification and a custom sbt task object is then used to build a YAML specification.