### PR TITLE
PIL-1336: Validate generated OpenAPI specification

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -58,6 +58,7 @@ lazy val microservice = Project("pillar2-submission-api", file("."))
   .settings(resolvers += Resolver.jcenterRepo)
   .settings(resolvers += "emueller-bintray" at "https://dl.bintray.com/emueller/maven")
   .settings(JsonToYaml.settings *)
+  .settings(Validate.settings *)
   .settings(PlaySwagger.settings *)
   .disablePlugins(JUnitXmlReportPlugin)
 

--- a/project/JsonToYaml.scala
+++ b/project/JsonToYaml.scala
@@ -9,9 +9,9 @@ import scala.collection.mutable
 import scala.util.Try
 
 object JsonToYaml {
-  val routesToYamlSpec = taskKey[Unit]("Generate YAML OpenAPI specification from JSON")
+  val routesToYamlOas = taskKey[Unit]("Generate YAML OpenAPI specification from JSON")
   def settings: Seq[Setting[_]] = Seq(
-    routesToYamlSpec := {
+    routesToYamlOas := {
       swagger.value
 
       val yamlFactory = new YAMLFactory()

--- a/project/Validate.scala
+++ b/project/Validate.scala
@@ -1,0 +1,19 @@
+import _root_.io.swagger.v3.parser.OpenAPIV3Parser
+import sbt.Keys._
+import sbt._
+
+import scala.jdk.CollectionConverters.asScalaBufferConverter
+
+object Validate {
+  val validateOas = taskKey[Unit]("Validate OpenAPI specification")
+  def settings: Seq[Setting[_]] = Seq(
+    validateOas := {
+      val openApiFilePath = baseDirectory.value / "target/swagger/application.yaml"
+      val parser          = new OpenAPIV3Parser()
+      val result          = parser.readLocation(openApiFilePath.toString, null, null)
+
+      if (!result.getMessages.isEmpty) sys.error(s"Validation failed:\n${result.getMessages.asScala.mkString("\n")}")
+
+    }
+  )
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,8 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
 resolvers += Resolver.typesafeRepo("releases")
 libraryDependencies ++= Seq(
   "com.fasterxml.jackson.module"    %% "jackson-module-scala"    % "2.18.1",
-  "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % "2.17.2"
+  "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % "2.17.2",
+  "io.swagger.parser.v3"             % "swagger-parser"          % "2.1.23"
 )
 
 addSbtPlugin("uk.gov.hmrc"            % "sbt-auto-build"     % "3.22.0")


### PR DESCRIPTION
Added a layer of validation to minimise errors in the generated specification. It is still recommended to run a manual check on [editor.swagger](https://editor.swagger.io/) each time we want to publish ([API Platform Team advice](https://hmrcdigital.slack.com/archives/C0J8UQWDV/p1730809497799049)).

There are good options in [description validataors](https://openapi.tools/#description-validators), but as far as I could tell, they do not integrate into SBT projects cleanly. They require pip/npm/npx installation and some effort to integrate with Jenkins.