### PR TITLE
[PIL-1347-error-handling] Add error handling and change existing errors

### DIFF
--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandler.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandler.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2submissionapi.controllers
+
+import play.api.http.HttpErrorHandler
+import play.api.libs.json.Json
+import play.api.mvc.{RequestHeader, Result, Results}
+import uk.gov.hmrc.pillar2submissionapi.controllers.error._
+
+import scala.concurrent.Future
+
+class Pillar2ErrorHandler extends HttpErrorHandler {
+
+  override def onClientError(request: RequestHeader, statusCode: Int, message: String): Future[Result] = ???
+
+  override def onServerError(request: RequestHeader, exception: Throwable): Future[Result] =
+    exception match {
+      case e if e.isInstanceOf[Pillar2Error] =>
+        val pillar2Error: Pillar2Error = e.asInstanceOf[Pillar2Error]
+        pillar2Error match {
+          case e @ InvalidJson =>
+            Future.successful(Results.BadRequest(Json.toJson(Pillar2ErrorResponse(e.code, "Invalid JSON Payload"))))
+          case e @ EmptyRequestBody => Future.successful(Results.BadRequest(Json.toJson(Pillar2ErrorResponse(e.code, "Empty body in request"))))
+          case e @ AuthenticationError(message) => Future.successful(Results.Unauthorized(Json.toJson(Pillar2ErrorResponse(e.code, message))))
+        }
+      case _ =>
+        Future.successful(Results.InternalServerError(Json.toJson((Pillar2ErrorResponse("500", "Internal Server Error")))))
+    }
+}

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandler.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandler.scala
@@ -25,7 +25,8 @@ import scala.concurrent.Future
 
 class Pillar2ErrorHandler extends HttpErrorHandler {
 
-  override def onClientError(request: RequestHeader, statusCode: Int, message: String): Future[Result] = ???
+  override def onClientError(request: RequestHeader, statusCode: Int, message: String): Future[Result] =
+    Future.successful(Results.BadRequest(Json.toJson(Pillar2ErrorResponse(statusCode.toString, message))))
 
   override def onServerError(request: RequestHeader, exception: Throwable): Future[Result] =
     exception match {

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandler.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandler.scala
@@ -34,11 +34,12 @@ class Pillar2ErrorHandler extends HttpErrorHandler {
         val pillar2Error: Pillar2Error = e.asInstanceOf[Pillar2Error]
         pillar2Error match {
           case e @ InvalidJson =>
-            Future.successful(Results.BadRequest(Json.toJson(Pillar2ErrorResponse(e.code, "Invalid JSON Payload"))))
-          case e @ EmptyRequestBody => Future.successful(Results.BadRequest(Json.toJson(Pillar2ErrorResponse(e.code, "Empty body in request"))))
-          case e @ AuthenticationError(message) => Future.successful(Results.Unauthorized(Json.toJson(Pillar2ErrorResponse(e.code, message))))
+            Future.successful(Results.BadRequest(Pillar2ErrorResponse(e.code, "Invalid JSON Payload")))
+          case e @ EmptyRequestBody             => Future.successful(Results.BadRequest(Pillar2ErrorResponse(e.code, "Empty body in request")))
+          case e @ AuthenticationError(message) => Future.successful(Results.Unauthorized(Pillar2ErrorResponse(e.code, message)))
+          case e @ NoSubscriptionData(_)        => Future.successful(Results.InternalServerError(Pillar2ErrorResponse(e.code, e.message)))
         }
       case _ =>
-        Future.successful(Results.InternalServerError(Json.toJson((Pillar2ErrorResponse("500", "Internal Server Error")))))
+        Future.successful(Results.InternalServerError(Pillar2ErrorResponse("500", "Internal Server Error")))
     }
 }

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/UktrSubmissionController.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/UktrSubmissionController.scala
@@ -17,11 +17,9 @@
 package uk.gov.hmrc.pillar2submissionapi.controllers
 
 import play.api.libs.json.Json
-import play.api.libs.json.{JsError, JsSuccess}
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
-import uk.gov.hmrc.pillar2submissionapi.controllers.actions.IdentifierAction
-import uk.gov.hmrc.pillar2submissionapi.controllers.error.{EmptyRequestBody, InvalidJson}
 import uk.gov.hmrc.pillar2submissionapi.controllers.actions.{IdentifierAction, SubscriptionDataRetrievalAction}
+import uk.gov.hmrc.pillar2submissionapi.controllers.error.{EmptyRequestBody, InvalidJson}
 import uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.UktrSubmission
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/actions/SubscriptionDataRetrievalAction.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/actions/SubscriptionDataRetrievalAction.scala
@@ -20,6 +20,7 @@ import play.api.Logging
 import play.api.mvc.ActionTransformer
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2submissionapi.connectors.SubscriptionConnector
+import uk.gov.hmrc.pillar2submissionapi.controllers.error.NoSubscriptionData
 import uk.gov.hmrc.pillar2submissionapi.models.requests.{IdentifierRequest, SubscriptionDataRequest}
 import uk.gov.hmrc.play.http.HeaderCarrierConverter
 
@@ -36,7 +37,7 @@ class SubscriptionDataRetrievalActionImpl @Inject() (
     implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequest(request)
 
     subscriptionConnector.readSubscription(request.clientPillar2Id).flatMap {
-      case Left(_) => Future.failed(new RuntimeException("No subscription data"))
+      case Left(_) => Future.failed(NoSubscriptionData(request.clientPillar2Id))
       case Right(subscriptionData) =>
         Future.successful(
           SubscriptionDataRequest(

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/error/Pillar2Error.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/error/Pillar2Error.scala
@@ -38,3 +38,9 @@ case class AuthenticationError(message: String) extends Pillar2Error {
 
   val code = "003"
 }
+
+case class NoSubscriptionData(pillar2Id: String) extends Pillar2Error {
+  val message: String = s"No Pillar2 subscription found for $pillar2Id"
+
+  val code = "004"
+}

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/error/Pillar2Error.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/error/Pillar2Error.scala
@@ -14,12 +14,27 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.pillar2submissionapi.controllers.actions
+package uk.gov.hmrc.pillar2submissionapi.controllers.error
 
-import play.api.mvc._
-import uk.gov.hmrc.pillar2submissionapi.models.requests.IdentifierRequest
+sealed trait Pillar2Error extends Exception {
+  val code:    String
+  val message: String
+}
 
-trait IdentifierAction
-    extends ActionTransformer[Request, IdentifierRequest]
-    with ActionBuilder[IdentifierRequest, AnyContent]
-    with ActionFunction[Request, IdentifierRequest]
+case object InvalidJson extends Pillar2Error {
+
+  val message = "Invalid JSON payload"
+
+  val code = "001"
+}
+
+case object EmptyRequestBody extends Pillar2Error {
+  val message = "No body provided in request"
+
+  val code = "002"
+}
+
+case class AuthenticationError(message: String) extends Pillar2Error {
+
+  val code = "003"
+}

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/error/Pillar2ErrorResponse.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/error/Pillar2ErrorResponse.scala
@@ -16,10 +16,13 @@
 
 package uk.gov.hmrc.pillar2submissionapi.controllers.error
 
-import play.api.libs.json.{Json, OFormat}
+import play.api.http.Writeable
+import play.api.libs.json.{JsValue, Json, OFormat}
 
 case class Pillar2ErrorResponse(code: String, message: String)
 
 object Pillar2ErrorResponse {
   implicit val format: OFormat[Pillar2ErrorResponse] = Json.format[Pillar2ErrorResponse]
+
+  implicit val writable: Writeable[Pillar2ErrorResponse] = implicitly[Writeable[JsValue]].map(r => Json.toJson(r))
 }

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/error/Pillar2ErrorResponse.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/error/Pillar2ErrorResponse.scala
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.pillar2submissionapi.controllers.actions
+package uk.gov.hmrc.pillar2submissionapi.controllers.error
 
-import play.api.mvc._
-import uk.gov.hmrc.pillar2submissionapi.models.requests.IdentifierRequest
+import play.api.libs.json.{Json, OFormat}
 
-trait IdentifierAction
-    extends ActionTransformer[Request, IdentifierRequest]
-    with ActionBuilder[IdentifierRequest, AnyContent]
-    with ActionFunction[Request, IdentifierRequest]
+case class Pillar2ErrorResponse(code: String, message: String)
+
+object Pillar2ErrorResponse {
+  implicit val format: OFormat[Pillar2ErrorResponse] = Json.format[Pillar2ErrorResponse]
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -22,13 +22,10 @@ appName = pillar2-submission-api
 # Default http client
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
 
-# Json error handler
-play.http.errorHandler = "uk.gov.hmrc.play.bootstrap.backend.http.JsonErrorHandler"
-
 # Play Modules
 play.modules.enabled += "uk.gov.hmrc.pillar2submissionapi.config.Module"
 
-
+play.http.errorHandler = "uk.gov.hmrc.pillar2submissionapi.controllers.Pillar2ErrorHandler"
 # The application languages
 # ~~~~~
 play.i18n.langs = ["en"]

--- a/it/test/uk/gov/hmrc/pillar2submissionapi/UktrSubmissionISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2submissionapi/UktrSubmissionISpec.scala
@@ -102,8 +102,8 @@ class UktrSubmissionISpec extends IntegrationSpecBase {
           val result = Await.result(request.execute[HttpResponse], 5.seconds)
           result.status mustEqual 500
           val errorResponse = result.json.as[Pillar2ErrorResponse]
-          errorResponse.code mustEqual "500"
-          errorResponse.message mustEqual "Internal Server Error"
+          errorResponse.code mustEqual "004"
+          errorResponse.message mustEqual "No Pillar2 subscription found for XCCVRUGFJG788"
         }
       }
     }

--- a/it/test/uk/gov/hmrc/pillar2submissionapi/base/IntegrationSpecBase.scala
+++ b/it/test/uk/gov/hmrc/pillar2submissionapi/base/IntegrationSpecBase.scala
@@ -25,7 +25,7 @@ import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
-import play.api.inject
+import play.api.{Application, inject}
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc._
 import play.api.test.FakeRequest
@@ -36,7 +36,7 @@ import uk.gov.hmrc.auth.core.retrieve.{Credentials, Retrieval, ~}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2submissionapi.base.TestAuthRetrievals.Ops
 import uk.gov.hmrc.pillar2submissionapi.connectors.SubscriptionConnector
-import uk.gov.hmrc.pillar2submissionapi.controllers.actions.IdentifierActionSpec.{enrolmentKey, identifierName, identifierValue}
+import uk.gov.hmrc.pillar2submissionapi.controllers.actions.AuthenticatedIdentifierActionSpec.{enrolmentKey, identifierName, identifierValue}
 import uk.gov.hmrc.pillar2submissionapi.controllers.actions.{AuthenticatedIdentifierAction, IdentifierAction}
 import uk.gov.hmrc.pillar2submissionapi.helpers.SubscriptionDataFixture
 
@@ -82,11 +82,12 @@ trait IntegrationSpecBase
       Future.successful(Right(subscriptionData))
     )
 
-  protected def applicationBuilder(): GuiceApplicationBuilder =
+  override def fakeApplication(): Application =
     new GuiceApplicationBuilder()
-      .configure()
       .overrides(
         inject.bind[IdentifierAction].toInstance(new AuthenticatedIdentifierAction(mockAuthConnector, new BodyParsers.Default())),
         inject.bind[SubscriptionConnector].toInstance(mockSubscriptionConnector)
       )
+      .build()
+
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -13,13 +13,13 @@ object AppDependencies {
   )
 
   val test = Seq(
-    "uk.gov.hmrc"            %% "bootstrap-test-play-30"   % bootstrapVersion % "test, it",
-    "org.scalatest"          %% "scalatest"                % "3.2.19"         % Test,
-    "com.vladsch.flexmark"    % "flexmark-all"             % "0.35.10"        % "test, it",
-    "org.mockito"             % "mockito-core"             % "3.7.7"          % "test,it",
-    "org.scalatestplus"      %% "mockito-3-4"              % "3.2.7.0"        % "test, it",
-    "org.scalatestplus.play" %% "scalatestplus-play"       % "7.0.1"          % "test, it",
-    "org.scalatestplus"      %% "scalatestplus-scalacheck" % "3.1.0.0-RC2"    % "test, it"
+    "uk.gov.hmrc"            %% "bootstrap-test-play-30" % bootstrapVersion % "test, it",
+    "org.scalatest"          %% "scalatest"              % "3.2.19"         % Test,
+    "com.vladsch.flexmark"    % "flexmark-all"           % "0.35.10"        % "test, it",
+    "org.mockito"             % "mockito-core"           % "3.7.7"          % "test,it",
+    "org.scalatestplus"      %% "mockito-3-4"            % "3.2.7.0"        % "test, it",
+    "org.scalatestplus.play" %% "scalatestplus-play"     % "7.0.1"          % "test, it",
+    "org.scalatestplus"      %% "scalacheck-1-18"        % "3.2.19.0"       % "test"
   )
 
   val it: Seq[ModuleID] = Seq(

--- a/test/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandlerTest.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandlerTest.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2submissionapi.controllers
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
+import play.api.mvc.AnyContentAsEmpty
+import play.api.test.FakeRequest
+import play.api.test.Helpers.{contentAsJson, defaultAwaitTimeout, status}
+import uk.gov.hmrc.pillar2submissionapi.controllers.error._
+
+class Pillar2ErrorHandlerTest extends AnyFunSuite {
+
+  val classUnderTest = new Pillar2ErrorHandler
+  val dummyRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest()
+  test("Catch-all error response") {
+    val response = classUnderTest.onServerError(dummyRequest, new RuntimeException("Generic Error"))
+    status(response) mustEqual 500
+    val result = contentAsJson(response).as[Pillar2ErrorResponse]
+    result.code mustEqual "500"
+    result.message mustEqual "Internal Server Error"
+  }
+
+  test("EmptyRequestBody error response") {
+    val response = classUnderTest.onServerError(dummyRequest, EmptyRequestBody)
+    status(response) mustEqual 400
+    val result = contentAsJson(response).as[Pillar2ErrorResponse]
+    result.code mustEqual "002"
+    result.message mustEqual "Empty body in request"
+  }
+
+  test("InvalidJson error response") {
+    val response = classUnderTest.onServerError(dummyRequest, InvalidJson)
+    status(response) mustEqual 400
+    val result = contentAsJson(response).as[Pillar2ErrorResponse]
+    result.code mustEqual "001"
+    result.message mustEqual "Invalid JSON Payload"
+  }
+
+  test("AuthenticationError error response") {
+    val response = classUnderTest.onServerError(dummyRequest, AuthenticationError("Authentication Error"))
+    status(response) mustEqual 401
+    val result = contentAsJson(response).as[Pillar2ErrorResponse]
+    result.code mustEqual "003"
+    result.message mustEqual "Authentication Error"
+  }
+}

--- a/test/uk/gov/hmrc/pillar2submissionapi/controllers/UktrSubmissionControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/controllers/UktrSubmissionControllerSpec.scala
@@ -16,12 +16,13 @@
 
 package uk.gov.hmrc.pillar2submissionapi.controllers
 
-import play.api.http.Status.{BAD_REQUEST, CREATED}
+import play.api.http.Status.CREATED
 import play.api.libs.json.{JsObject, JsValue, Json}
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{defaultAwaitTimeout, status}
 import uk.gov.hmrc.pillar2submissionapi.controllers.UktrSubmissionControllerSpec._
 import uk.gov.hmrc.pillar2submissionapi.controllers.base.ControllerBaseSpec
+import uk.gov.hmrc.pillar2submissionapi.controllers.error.{EmptyRequestBody, InvalidJson}
 
 class UktrSubmissionControllerSpec extends ControllerBaseSpec {
 
@@ -54,7 +55,7 @@ class UktrSubmissionControllerSpec extends ControllerBaseSpec {
           FakeRequest(method = "", path = "")
             .withJsonBody(invalidRequestJson_data)
         )
-        status(result) mustEqual BAD_REQUEST
+        result shouldFailWith InvalidJson
       }
     }
 
@@ -64,7 +65,7 @@ class UktrSubmissionControllerSpec extends ControllerBaseSpec {
           FakeRequest(method = "", path = "")
             .withJsonBody(invalidRequestJson_nilReturn)
         )
-        status(result) mustEqual BAD_REQUEST
+        result shouldFailWith InvalidJson
       }
     }
 
@@ -74,7 +75,7 @@ class UktrSubmissionControllerSpec extends ControllerBaseSpec {
           FakeRequest(method = "", path = "")
             .withJsonBody(invalidRequest_Json)
         )
-        status(result) mustEqual BAD_REQUEST
+        result shouldFailWith InvalidJson
       }
     }
 
@@ -84,7 +85,7 @@ class UktrSubmissionControllerSpec extends ControllerBaseSpec {
           FakeRequest(method = "", path = "")
             .withJsonBody(invalidRequest_nilReturn_onlyContainsLiabilities)
         )
-        status(result) mustEqual BAD_REQUEST
+        result shouldFailWith InvalidJson
       }
     }
 
@@ -94,7 +95,7 @@ class UktrSubmissionControllerSpec extends ControllerBaseSpec {
           FakeRequest(method = "", path = "")
             .withJsonBody(invalidRequest_nilReturn_onlyLiabilitiesButInvalidReturnType)
         )
-        status(result) mustEqual BAD_REQUEST
+        result shouldFailWith InvalidJson
       }
     }
 
@@ -104,17 +105,17 @@ class UktrSubmissionControllerSpec extends ControllerBaseSpec {
           FakeRequest(method = "", path = "")
             .withJsonBody(invalidRequest_noLiabilities)
         )
-        status(result) mustEqual BAD_REQUEST
+        result shouldFailWith InvalidJson
       }
     }
 
-    "submitUktr() called with an empty request body" should {
+    "submitUktr() called with an empty json object" should {
       "return 400 BAD_REQUEST response" in {
         val result = uktrSubmissionController.submitUktr()(
           FakeRequest(method = "", path = "")
             .withJsonBody(invalidRequest_emptyBody)
         )
-        status(result) mustEqual BAD_REQUEST
+        result shouldFailWith InvalidJson
       }
     }
 
@@ -124,7 +125,7 @@ class UktrSubmissionControllerSpec extends ControllerBaseSpec {
           FakeRequest(method = "", path = "")
             .withTextBody(invalidRequest_wrongType)
         )
-        status(result) mustEqual BAD_REQUEST
+        result shouldFailWith EmptyRequestBody
       }
     }
 
@@ -133,7 +134,7 @@ class UktrSubmissionControllerSpec extends ControllerBaseSpec {
         val result = uktrSubmissionController.submitUktr()(
           FakeRequest(method = "", path = "")
         )
-        status(result) mustEqual BAD_REQUEST
+        result shouldFailWith EmptyRequestBody
       }
     }
 

--- a/test/uk/gov/hmrc/pillar2submissionapi/controllers/actions/AuthenticatedIdentifierActionSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/controllers/actions/AuthenticatedIdentifierActionSpec.scala
@@ -30,14 +30,15 @@ import uk.gov.hmrc.auth.core.authorise.Predicate
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
 import uk.gov.hmrc.auth.core.retrieve.{Credentials, Retrieval, ~}
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.pillar2submissionapi.controllers.actions.IdentifierActionSpec._
+import uk.gov.hmrc.pillar2submissionapi.controllers.actions.AuthenticatedIdentifierActionSpec._
 import uk.gov.hmrc.pillar2submissionapi.controllers.actions.base.ActionBaseSpec
 import uk.gov.hmrc.pillar2submissionapi.controllers.base.TestAuthRetrievals.Ops
+import uk.gov.hmrc.pillar2submissionapi.controllers.error.AuthenticationError
 
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 
-class IdentifierActionSpec extends ActionBaseSpec {
+class AuthenticatedIdentifierActionSpec extends ActionBaseSpec {
 
   val identifierAction: AuthenticatedIdentifierAction = new AuthenticatedIdentifierAction(
     mockAuthConnector,
@@ -61,7 +62,6 @@ class IdentifierActionSpec extends ActionBaseSpec {
 
         val result = await(identifierAction.refine(fakeRequest))
 
-        result.isRight.must(be(true))
         result.map { identifierRequest =>
           identifierRequest.userId             must be(id)
           identifierRequest.groupId            must be(Some(groupId))
@@ -82,11 +82,9 @@ class IdentifierActionSpec extends ActionBaseSpec {
           .thenReturn(
             Future.successful(Some(id) ~ Some(groupId) ~ pillar2Enrolments ~ Some(Agent) ~ Some(User) ~ Some(Credentials(providerId, providerType)))
           )
+        val result = intercept[AuthenticationError](await(identifierAction.refine(fakeRequest)))
 
-        val result = await(identifierAction.refine(fakeRequest))
-
-        result.isRight            must be(false)
-        result.left.getOrElse("") must be(Unauthorized("Invalid credentials"))
+        result.message mustEqual "Invalid credentials"
       }
     }
   }
@@ -105,12 +103,13 @@ class IdentifierActionSpec extends ActionBaseSpec {
           )
         )
 
-      val result = await(
-        identifierAction.refine(fakeRequest)
+      val result = intercept[AuthenticationError](
+        await(
+          identifierAction.refine(fakeRequest)
+        )
       )
 
-      result.isRight            must be(false)
-      result.left.getOrElse("") must be(Unauthorized("Invalid credentials"))
+      result.message mustEqual "Invalid credentials"
     }
   }
 
@@ -129,12 +128,13 @@ class IdentifierActionSpec extends ActionBaseSpec {
             )
           )
 
-        val result = await(
-          identifierAction.refine(fakeRequest)
+        val result = intercept[AuthenticationError](
+          await(
+            identifierAction.refine(fakeRequest)
+          )
         )
 
-        result.isRight            must be(false)
-        result.left.getOrElse("") must be(Unauthorized("Invalid credentials"))
+        result.message mustEqual "Invalid credentials"
       }
     }
 
@@ -150,12 +150,13 @@ class IdentifierActionSpec extends ActionBaseSpec {
             Future.successful(Some(id) ~ None ~ pillar2Enrolments ~ Some(Organisation) ~ Some(User) ~ Some(Credentials(providerId, providerType)))
           )
 
-        val result = await(
-          identifierAction.refine(fakeRequest)
+        val result = intercept[AuthenticationError](
+          await(
+            identifierAction.refine(fakeRequest)
+          )
         )
 
-        result.isRight            must be(false)
-        result.left.getOrElse("") must be(Unauthorized("Invalid credentials"))
+        result.message mustEqual "Invalid credentials"
       }
     }
 
@@ -171,12 +172,13 @@ class IdentifierActionSpec extends ActionBaseSpec {
             Future.successful(Some(id) ~ Some(groupId) ~ pillar2Enrolments ~ None ~ Some(User) ~ Some(Credentials(providerId, providerType)))
           )
 
-        val result = await(
-          identifierAction.refine(fakeRequest)
+        val result = intercept[AuthenticationError](
+          await(
+            identifierAction.refine(fakeRequest)
+          )
         )
 
-        result.isRight            must be(false)
-        result.left.getOrElse("") must be(Unauthorized("Invalid credentials"))
+        result.message mustEqual "Invalid credentials"
       }
     }
 
@@ -192,12 +194,13 @@ class IdentifierActionSpec extends ActionBaseSpec {
             Future.successful(Some(id) ~ Some(groupId) ~ pillar2Enrolments ~ Some(Organisation) ~ None ~ Some(Credentials(providerId, providerType)))
           )
 
-        val result = await(
-          identifierAction.refine(fakeRequest)
+        val result = intercept[AuthenticationError](
+          await(
+            identifierAction.refine(fakeRequest)
+          )
         )
 
-        result.isRight            must be(false)
-        result.left.getOrElse("") must be(Unauthorized("Invalid credentials"))
+        result.message mustEqual "Invalid credentials"
       }
     }
   }
@@ -217,12 +220,13 @@ class IdentifierActionSpec extends ActionBaseSpec {
             )
           )
 
-        val result = await(
-          identifierAction.refine(fakeRequest)
+        val result = intercept[AuthenticationError](
+          await(
+            identifierAction.refine(fakeRequest)
+          )
         )
 
-        result.isRight            must be(false)
-        result.left.getOrElse("") must be(Unauthorized("Pillar2 ID not found in enrolments"))
+        result.message mustEqual "Pillar2 ID not found in enrolments"
       }
     }
   }
@@ -235,12 +239,13 @@ class IdentifierActionSpec extends ActionBaseSpec {
           new BodyParsers.Default
         )(ec)
 
-        val result = await(
-          identifierAction.refine(fakeRequest)
+        val result = intercept[AuthenticationError](
+          await(
+            identifierAction.refine(fakeRequest)
+          )
         )
 
-        result.isRight            must be(false)
-        result.left.getOrElse("") must be(Unauthorized("Not authorized"))
+        result.message mustEqual "Not authorized"
       }
     }
   }
@@ -252,7 +257,7 @@ class IdentifierActionSpec extends ActionBaseSpec {
 
 }
 
-object IdentifierActionSpec {
+object AuthenticatedIdentifierActionSpec {
   type RetrievalsType = Option[String] ~ Option[String] ~ Enrolments ~ Option[AffinityGroup] ~ Option[CredentialRole] ~ Option[Credentials]
 
   val fakeRequest: Request[AnyContent] = FakeRequest(method = "", path = "")

--- a/test/uk/gov/hmrc/pillar2submissionapi/controllers/actions/SubscriptionDataRetrievalActionSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/controllers/actions/SubscriptionDataRetrievalActionSpec.scala
@@ -23,6 +23,7 @@ import play.api.test.FakeRequest
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2submissionapi.connectors.SubscriptionConnector
 import uk.gov.hmrc.pillar2submissionapi.controllers.actions.base.ActionBaseSpec
+import uk.gov.hmrc.pillar2submissionapi.controllers.error.NoSubscriptionData
 import uk.gov.hmrc.pillar2submissionapi.helpers.SubscriptionDataFixture
 import uk.gov.hmrc.pillar2submissionapi.models.requests.{IdentifierRequest, SubscriptionDataRequest}
 
@@ -61,11 +62,9 @@ class SubscriptionDataRetrievalActionSpec extends ActionBaseSpec with Subscripti
       val result = action
         .callTransform(IdentifierRequest(FakeRequest(), "id", Some("groupID"), userIdForEnrolment = "userId", clientPillar2Id = "pillar2Id"))
 
-      val thrown = intercept[RuntimeException] {
+      intercept[NoSubscriptionData] {
         Await.result(result, 5.seconds)
       }
-
-      thrown mustBe a[RuntimeException]
     }
   }
 }


### PR DESCRIPTION
Add an error handler. Now, when we encounter an error, we simply use `Future.failed(...)` and then handle the error in the ErrorHandler, creating the specific Result that is required.

I have also adjusted the integration test, which now spins up a HTTP Server on a port, using http-verbs to call the server directly. This was done to make use of the ErrorHandler, which is not done when using a simple `Application`