### PR TITLE
[PIL-1467-make-url-nicer] Make url nicer

### DIFF
--- a/conf/app.routes
+++ b/conf/app.routes
@@ -11,4 +11,4 @@
 #   201:
 #     description: created
 ###
-POST       /RESTAdapter/PLR/UKTaxReturn              uk.gov.hmrc.pillar2submissionapi.controllers.UktrSubmissionController.submitUktr
+POST       /uk-tax-return              uk.gov.hmrc.pillar2submissionapi.controllers.UktrSubmissionController.submitUktr


### PR DESCRIPTION
The URL when going through API platform is a little verbose:
```
POST https://api.development.tax.service.gov.uk/organisations/pillar-two/RESTAdapter/PLR/UKTaxReturn
```

After making this change, it will be:
```
POST https://api.development.tax.service.gov.uk/organisations/pillar-two/uk-tax-return
```