### PR TITLE
PIL-1513: Obscure verbose parsing errors

### DIFF
--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandler.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandler.scala
@@ -20,7 +20,7 @@ import play.api.Logging
 import play.api.http.HttpErrorHandler
 import play.api.libs.json.Json
 import play.api.mvc.{RequestHeader, Result, Results}
-import uk.gov.hmrc.pillar2submissionapi.controllers.error.{UnexpectedResponse, _}
+import uk.gov.hmrc.pillar2submissionapi.controllers.error._
 
 import scala.concurrent.Future
 
@@ -34,7 +34,7 @@ class Pillar2ErrorHandler extends HttpErrorHandler with Logging {
       case e if e.isInstanceOf[Pillar2Error] =>
         val pillar2Error: Pillar2Error = e.asInstanceOf[Pillar2Error]
         val ret = pillar2Error match {
-          case e @ InvalidJson => Results.BadRequest(Pillar2ErrorResponse(e.code, "Invalid JSON Payload"))
+          case e @ InvalidJson                  => Results.BadRequest(Pillar2ErrorResponse(e.code, "Invalid JSON Payload"))
           case e @ EmptyRequestBody             => Results.BadRequest(Pillar2ErrorResponse(e.code, "Empty body in request"))
           case e @ AuthenticationError(message) => Results.Unauthorized(Pillar2ErrorResponse(e.code, message))
           case e @ NoSubscriptionData(_)        => Results.InternalServerError(Pillar2ErrorResponse(e.code, e.message))

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandler.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandler.scala
@@ -34,8 +34,7 @@ class Pillar2ErrorHandler extends HttpErrorHandler with Logging {
       case e if e.isInstanceOf[Pillar2Error] =>
         val pillar2Error: Pillar2Error = e.asInstanceOf[Pillar2Error]
         val ret = pillar2Error match {
-          case e @ InvalidJson =>
-            Results.BadRequest(Pillar2ErrorResponse(e.code, "Invalid JSON Payload"))
+          case e @ InvalidJson => Results.BadRequest(Pillar2ErrorResponse(e.code, "Invalid JSON Payload"))
           case e @ EmptyRequestBody             => Results.BadRequest(Pillar2ErrorResponse(e.code, "Empty body in request"))
           case e @ AuthenticationError(message) => Results.Unauthorized(Pillar2ErrorResponse(e.code, message))
           case e @ NoSubscriptionData(_)        => Results.InternalServerError(Pillar2ErrorResponse(e.code, e.message))

--- a/app/uk/gov/hmrc/pillar2submissionapi/services/UKTaxReturnService.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/services/UKTaxReturnService.scala
@@ -19,12 +19,10 @@ package uk.gov.hmrc.pillar2submissionapi.services
 import com.google.inject.{Inject, Singleton}
 import play.api.Logging
 import play.api.http.Status.{CREATED, UNPROCESSABLE_ENTITY}
-import play.api.libs.json.{JsError, JsSuccess}
-import play.api.http.Status.{CREATED, UNPROCESSABLE_ENTITY}
 import play.api.libs.json._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2submissionapi.connectors.UKTaxReturnConnector
-import uk.gov.hmrc.pillar2submissionapi.controllers.error.{UktrValidationError, UnexpectedResponse, UnparsableResponse}
+import uk.gov.hmrc.pillar2submissionapi.controllers.error.{UktrValidationError, UnexpectedResponse}
 import uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.UKTRSubmission
 import uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.responses.{UKTRSubmitErrorResponse, UKTRSubmitSuccessResponse}
 

--- a/test/uk/gov/hmrc/pillar2submissionapi/services/UKTaxReturnServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/services/UKTaxReturnServiceSpec.scala
@@ -79,7 +79,10 @@ class UKTaxReturnServiceSpec extends UnitTestBaseSpec {
         when(mockUKTaxReturnConnector.submitUKTR(any[UKTRSubmissionData])(any[HeaderCarrier]))
           .thenReturn(Future.successful(HttpResponse.apply(CREATED, Json.toJson("unparsable success response"), Map.empty)))
 
-        intercept[UnparsableResponse](await(mockUkTaxReturnService.submitUKTR(validNilSubmission)))
+        intercept[UnexpectedResponse.type](await(mockUkTaxReturnService.submitUKTR(validNilSubmission)))
+        val result = intercept[UnexpectedResponse.type](await(mockUkTaxReturnService.submitUKTR(validLiabilitySubmission)))
+        result.code.toInt mustEqual INTERNAL_SERVER_ERROR
+        result.message mustEqual "Internal Server Error"
       }
     }
 
@@ -97,11 +100,14 @@ class UKTaxReturnServiceSpec extends UnitTestBaseSpec {
     }
 
     "submitUKTR() unparsable 422 response back" should {
-      "Runtime exception thrown (To be updated to 500 Internal server error exception)" in {
+      "Runtime exception thrown" in {
         when(mockUKTaxReturnConnector.submitUKTR(any[UKTRSubmissionData])(any[HeaderCarrier]))
           .thenReturn(Future.successful(HttpResponse.apply(UNPROCESSABLE_ENTITY, Json.toJson("unparsable error response"), Map.empty)))
 
-        intercept[UnparsableResponse](await(mockUkTaxReturnService.submitUKTR(validLiabilitySubmission)))
+        intercept[UnexpectedResponse.type](await(mockUkTaxReturnService.submitUKTR(validLiabilitySubmission)))
+        val result = intercept[UnexpectedResponse.type](await(mockUkTaxReturnService.submitUKTR(validLiabilitySubmission)))
+        result.code.toInt mustEqual INTERNAL_SERVER_ERROR
+        result.message mustEqual "Internal Server Error"
       }
     }
 


### PR DESCRIPTION
- A simple INTERNAL_SERVER_ERROR is now returned when response parsing fails in `CREATED` or `UNPROCESSABLE_ENTITY` statuses
- Logging was made more helpful

### Before
**Response**
```json
{
  "code": "500",
  "message": "Failed to parse success response: List(List(JsonValidationError(List(error.expected.jsnumber),List())), List(JsonValidationError(List(error.expected.jsnumber),List())))"
}
```

**Logger**
```
message=[Got an error while parsing {"processingDate":"2025-01-04T21:39:56.238242Z","formBundleNumber":"119000004320","chargeReference":"XTC01234123412"}] 
```

### After
**Response**
```json
{
  "code": "500",
  "message": "Internal Server Error"
}
```

**Logger**
```
message=[Error while parsing the backend response {"processingDate":"2025-01-04T21:44:09.660814Z","formBundleNumber":"119000004320","chargeReference":"XTC01234123412"} - (processingDate: error.expected.jsnumber; formBundleNumber: error.expected.jsnumber)] 
```