### PR TITLE
PIL-1501 Add UKTR Amend Endpoint

### DIFF
--- a/API Testing/uktr/amend/amend-uktr-empty.bru
+++ b/API Testing/uktr/amend/amend-uktr-empty.bru
@@ -1,0 +1,31 @@
+meta {
+  name: Amend Empty UKTR
+  type: http
+  seq: 2
+}
+
+put {
+  url: {{submissionsApiBaseUrl}}/uk-tax-return
+  body: json
+}
+
+headers {
+  Accept: application/vnd.hmrc.1.0+json
+  Authorization: {{bearerToken}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+  }
+}
+
+tests {
+  test("should return 400 Bad Request", function() {
+    expect(res.getStatus()).to.equal(400);
+  });
+  
+  test("should contain correct error message", function() {
+    expect(res.body.message).to.equal("Invalid JSON Payload");
+  });
+} 

--- a/API Testing/uktr/amend/amend-uktr-invalid.bru
+++ b/API Testing/uktr/amend/amend-uktr-invalid.bru
@@ -1,0 +1,32 @@
+meta {
+  name: Amend Invalid UKTR
+  type: http
+  seq: 3
+}
+
+put {
+  url: {{submissionsApiBaseUrl}}/uk-tax-return
+  body: json
+}
+
+headers {
+  Accept: application/vnd.hmrc.1.0+json
+  Authorization: {{bearerToken}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "badRequest": ""
+  }
+}
+
+tests {
+  test("should return 400 Bad Request", function() {
+    expect(res.getStatus()).to.equal(400);
+  });
+  
+  test("should contain correct error message", function() {
+    expect(res.body.message).to.equal("Invalid JSON Payload");
+  });
+} 

--- a/API Testing/uktr/amend/amend-uktr-unauthorized.bru
+++ b/API Testing/uktr/amend/amend-uktr-unauthorized.bru
@@ -1,20 +1,18 @@
 meta {
-  name: Submit UKTR
+  name: Amend UKTR Unauthorized
   type: http
-  seq: 1
+  seq: 4
 }
 
-post {
+put {
   url: {{submissionsApiBaseUrl}}/uk-tax-return
   body: json
-  auth: none
 }
 
 headers {
   Accept: application/vnd.hmrc.1.0+json
-  Authorization: {{bearerToken}}
+  Authorization: "Bearer invalid-token"
   Content-Type: application/json
-  content-type: application/json
 }
 
 body:json {
@@ -47,13 +45,11 @@ body:json {
 }
 
 tests {
-  test("should return 201 Created", function() {
-    expect(res.getStatus()).to.equal(201);
+  test("should return 401 Unauthorized", function() {
+    expect(res.getStatus()).to.equal(401);
   });
   
-  test("should contain all required fields", function() {
-    expect(res.body.processingDate).to.not.be.undefined;
-    expect(res.body.formBundleNumber).to.not.be.undefined;
-    expect(res.body.chargeReference).to.not.be.undefined;
+  test("should contain correct error message", function() {
+    expect(res.body.message).to.equal("Not authorized");
   });
-}
+} 

--- a/API Testing/uktr/amend/amend-uktr.bru
+++ b/API Testing/uktr/amend/amend-uktr.bru
@@ -1,0 +1,58 @@
+meta {
+  name: Amend UKTR Success
+  type: http
+  seq: 1
+}
+
+put {
+  url: {{submissionsApiBaseUrl}}/uk-tax-return
+  body: json
+  auth: none
+}
+
+headers {
+  Accept: application/vnd.hmrc.1.0+json
+  Authorization: {{bearerToken}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "accountingPeriodFrom": "2024-08-14",
+    "accountingPeriodTo": "2024-12-14",
+    "obligationMTT": true,
+    "electionUKGAAP": true,
+    "liabilities": {
+      "electionDTTSingleMember": false,
+      "electionUTPRSingleMember": false,
+      "numberSubGroupDTT": 1,
+      "numberSubGroupUTPR": 1,
+      "totalLiability": 10000.99,
+      "totalLiabilityDTT": 5000.99,
+      "totalLiabilityIIR": 4000,
+      "totalLiabilityUTPR": 10000.99,
+      "liableEntities": [
+        {
+          "ukChargeableEntityName": "Newco PLC",
+          "idType": "CRN",
+          "idValue": "12345678",
+          "amountOwedDTT": 5000,
+          "amountOwedIIR": 3400,
+          "amountOwedUTPR": 6000.5
+        }
+      ]
+    }
+  }
+}
+
+tests {
+  test("should return 200 OK", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+  
+  test("should contain all required fields", function() {
+    expect(res.body.processingDate).to.not.be.undefined;
+    expect(res.body.formBundleNumber).to.not.be.undefined;
+    expect(res.body.chargeReference).to.not.be.undefined;
+  });
+} 

--- a/API Testing/uktr/submit/submit-uktr-empty.bru
+++ b/API Testing/uktr/submit/submit-uktr-empty.bru
@@ -1,0 +1,31 @@
+meta {
+  name: Submit Empty UKTR
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{submissionsApiBaseUrl}}/uk-tax-return
+  body: json
+}
+
+headers {
+  Accept: application/vnd.hmrc.1.0+json
+  Authorization: {{bearerToken}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+  }
+}
+
+tests {
+  test("should return 400 Bad Request", function() {
+    expect(res.getStatus()).to.equal(400);
+  });
+  
+  test("should contain correct error message", function() {
+    expect(res.body.message).to.equal("Invalid JSON Payload");
+  });
+} 

--- a/API Testing/uktr/submit/submit-uktr-invalid.bru
+++ b/API Testing/uktr/submit/submit-uktr-invalid.bru
@@ -1,0 +1,32 @@
+meta {
+  name: Submit Invalid UKTR
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{submissionsApiBaseUrl}}/uk-tax-return
+  body: json
+}
+
+headers {
+  Accept: application/vnd.hmrc.1.0+json
+  Authorization: {{bearerToken}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "badRequest": ""
+  }
+}
+
+tests {
+  test("should return 400 Bad Request", function() {
+    expect(res.getStatus()).to.equal(400);
+  });
+  
+  test("should contain correct error message", function() {
+    expect(res.body.message).to.equal("Invalid JSON Payload");
+  });
+} 

--- a/API Testing/uktr/submit/submit-uktr-unauthorized.bru
+++ b/API Testing/uktr/submit/submit-uktr-unauthorized.bru
@@ -1,0 +1,55 @@
+meta {
+  name: Submit UKTR Unauthorized
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{submissionsApiBaseUrl}}/uk-tax-return
+  body: json
+}
+
+headers {
+  Accept: application/vnd.hmrc.1.0+json
+  Authorization: "Bearer invalid-token"
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "accountingPeriodFrom": "2024-08-14",
+    "accountingPeriodTo": "2024-12-14",
+    "obligationMTT": true,
+    "electionUKGAAP": true,
+    "liabilities": {
+      "electionDTTSingleMember": false,
+      "electionUTPRSingleMember": false,
+      "numberSubGroupDTT": 1,
+      "numberSubGroupUTPR": 1,
+      "totalLiability": 10000.99,
+      "totalLiabilityDTT": 5000.99,
+      "totalLiabilityIIR": 4000,
+      "totalLiabilityUTPR": 10000.99,
+      "liableEntities": [
+        {
+          "ukChargeableEntityName": "Newco PLC",
+          "idType": "CRN",
+          "idValue": "12345678",
+          "amountOwedDTT": 5000,
+          "amountOwedIIR": 3400,
+          "amountOwedUTPR": 6000.5
+        }
+      ]
+    }
+  }
+}
+
+tests {
+  test("should return 401 Unauthorized", function() {
+    expect(res.getStatus()).to.equal(401);
+  });
+  
+  test("should contain correct error message", function() {
+    expect(res.body.message).to.equal("Not authorized");
+  });
+} 

--- a/API Testing/uktr/submit/submit-uktr.bru
+++ b/API Testing/uktr/submit/submit-uktr.bru
@@ -1,0 +1,58 @@
+meta {
+  name: Submit UKTR Success
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{submissionsApiBaseUrl}}/uk-tax-return
+  body: json
+  auth: none
+}
+
+headers {
+  Accept: application/vnd.hmrc.1.0+json
+  Authorization: {{bearerToken}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "accountingPeriodFrom": "2024-08-14",
+    "accountingPeriodTo": "2024-12-14",
+    "obligationMTT": true,
+    "electionUKGAAP": true,
+    "liabilities": {
+      "electionDTTSingleMember": false,
+      "electionUTPRSingleMember": false,
+      "numberSubGroupDTT": 1,
+      "numberSubGroupUTPR": 1,
+      "totalLiability": 10000.99,
+      "totalLiabilityDTT": 5000.99,
+      "totalLiabilityIIR": 4000,
+      "totalLiabilityUTPR": 10000.99,
+      "liableEntities": [
+        {
+          "ukChargeableEntityName": "Newco PLC",
+          "idType": "CRN",
+          "idValue": "12345678",
+          "amountOwedDTT": 5000,
+          "amountOwedIIR": 3400,
+          "amountOwedUTPR": 6000.5
+        }
+      ]
+    }
+  }
+}
+
+tests {
+  test("should return 201 Created", function() {
+    expect(res.getStatus()).to.equal(201);
+  });
+  
+  test("should contain all required fields", function() {
+    expect(res.body.processingDate).to.not.be.undefined;
+    expect(res.body.formBundleNumber).to.not.be.undefined;
+    expect(res.body.chargeReference).to.not.be.undefined;
+  });
+} 

--- a/app/uk/gov/hmrc/pillar2submissionapi/connectors/UKTaxReturnConnector.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/connectors/UKTaxReturnConnector.scala
@@ -33,10 +33,17 @@ import scala.concurrent.{ExecutionContext, Future}
 class UKTaxReturnConnector @Inject() (val config: AppConfig, val http: HttpClientV2)(implicit ec: ExecutionContext) extends Logging {
 
   private val uktrSubmissionUrl: String = s"${config.pillar2BaseUrl}/report-pillar2-top-up-taxes/submit-uk-tax-return"
+  private val uktrAmendmentUrl:  String = s"${config.pillar2BaseUrl}/report-pillar2-top-up-taxes/amend-uk-tax-return"
 
   def submitUKTR(uktrSubmission: UKTRSubmission)(implicit hc: HeaderCarrier): Future[HttpResponse] = {
     logger.info(s"Calling pillar2 backend: $uktrSubmissionUrl")
     val request = http.post(URI.create(uktrSubmissionUrl).toURL()).withBody(Json.toJson(uktrSubmission))
+    request.execute[HttpResponse]
+  }
+
+  def amendUKTR(uktrSubmission: UKTRSubmission)(implicit hc: HeaderCarrier): Future[HttpResponse] = {
+    logger.info(s"Calling pillar2 backend: $uktrAmendmentUrl")
+    val request = http.put(URI.create(uktrAmendmentUrl).toURL()).withBody(Json.toJson(uktrSubmission))
     request.execute[HttpResponse]
   }
 }

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/UKTaxReturnController.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/UKTaxReturnController.scala
@@ -57,4 +57,22 @@ class UKTaxReturnController @Inject() (
       case None => Future.failed(EmptyRequestBody)
     }
   }
+
+  def amendUKTR: Action[AnyContent] = (identify andThen verifySubscriptionExists).async { request =>
+    implicit val hc: HeaderCarrier =
+      HeaderCarrierConverter
+        .fromRequest(request)
+        .withExtraHeaders("X-Pillar2-Id" -> request.clientPillar2Id)
+    request.body.asJson match {
+      case Some(request) =>
+        request.validate[UKTRSubmission] match {
+          case JsSuccess(value, _) =>
+            ukTaxReturnService
+              .amendUKTR(value)
+              .map(response => Ok(Json.toJson(response)))
+          case JsError(_) => Future.failed(InvalidJson)
+        }
+      case None => Future.failed(EmptyRequestBody)
+    }
+  }
 }

--- a/app/uk/gov/hmrc/pillar2submissionapi/services/UKTaxReturnService.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/services/UKTaxReturnService.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.pillar2submissionapi.services
 
 import com.google.inject.{Inject, Singleton}
 import play.api.Logging
-import play.api.http.Status.{CREATED, UNPROCESSABLE_ENTITY}
+import play.api.http.Status.{CREATED, OK, UNPROCESSABLE_ENTITY}
 import play.api.libs.json._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2submissionapi.connectors.UKTaxReturnConnector
@@ -34,6 +34,9 @@ class UKTaxReturnService @Inject() (ukTaxReturnConnector: UKTaxReturnConnector)(
   def submitUKTR(request: UKTRSubmission)(implicit hc: HeaderCarrier): Future[UKTRSubmitSuccessResponse] =
     ukTaxReturnConnector.submitUKTR(request).map(convertToResult)
 
+  def amendUKTR(request: UKTRSubmission)(implicit hc: HeaderCarrier): Future[UKTRSubmitSuccessResponse] =
+    ukTaxReturnConnector.amendUKTR(request).map(convertToResult)
+
   private def convertToResult(response: HttpResponse): UKTRSubmitSuccessResponse = {
     def logAndThrow(errors: Seq[(JsPath, Seq[JsonValidationError])]): UKTRSubmitSuccessResponse = {
       val errorPath    = errors.map(_._1.path.headOption.fold("error.path.missing")(_.asInstanceOf[KeyPathNode].key))
@@ -48,7 +51,7 @@ class UKTaxReturnService @Inject() (ukTaxReturnConnector: UKTaxReturnConnector)(
     }
 
     response.status match {
-      case CREATED =>
+      case CREATED | OK =>
         response.json.validate[UKTRSubmitSuccessResponse] match {
           case JsSuccess(success, _) => success
           case JsError(errors)       => logAndThrow(errors.asInstanceOf[Seq[(JsPath, Seq[JsonValidationError])]])

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -14,6 +14,21 @@
 POST       /uk-tax-return              uk.gov.hmrc.pillar2submissionapi.controllers.UKTaxReturnController.submitUKTR
 
 ###
+# summary: Amend a Pillar2 UKTR
+# requestBody:
+#   content:
+#     application/json:
+#         schema:
+#           oneOf:
+#               - $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.UKTRSubmissionData'
+#               - $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.UKTRSubmissionNilReturn'
+# responses:
+#   200:
+#     description: success
+###
+PUT        /uk-tax-return              uk.gov.hmrc.pillar2submissionapi.controllers.UKTaxReturnController.amendUKTR
+
+###
 # summary: Submit a Pillar2 BTN
 # requestBody:
 #   content:

--- a/it/test/uk/gov/hmrc/pillar2submissionapi/BTNSubmissionISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2submissionapi/BTNSubmissionISpec.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.pillar2submissionapi
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatest.OptionValues
-import play.api.http.Status.{CREATED, INTERNAL_SERVER_ERROR, OK, UNAUTHORIZED, UNPROCESSABLE_ENTITY}
+import play.api.http.Status.{BAD_REQUEST, CREATED, INTERNAL_SERVER_ERROR, OK, UNAUTHORIZED, UNPROCESSABLE_ENTITY}
 import play.api.libs.json.{JsObject, JsValue, Json}
 import uk.gov.hmrc.auth.core.authorise.Predicate
 import uk.gov.hmrc.auth.core.retrieve.Retrieval
@@ -45,168 +45,166 @@ class BTNSubmissionISpec extends IntegrationSpecBase with OptionValues {
   lazy val str = s"http://localhost:$port${routes.BTNSubmissionController.submitBTN.url}"
   lazy val baseRequest: RequestBuilder = client.post(URI.create(str).toURL)
 
-  "Create a new BTN submission (POST)" should {
-    "create submission when given valid submission data" in {
-      stubGet(
-        "/report-pillar2-top-up-taxes/subscription/read-subscription/XCCVRUGFJG788",
-        OK,
-        Json.toJson(SubscriptionSuccess(subscriptionData)).toString()
-      )
-      stubResponse(
-        "/report-pillar2-top-up-taxes/below-threshold-notification/submit",
-        CREATED,
-        Json.toJson(SubmitBTNSuccessResponse("2022-01-31T09:26:17Z", "119000004320", Some("XTC01234123412")))
-      )
-      val request = baseRequest.withBody(validRequestJson)
-      val result  = Await.result(request.execute[SubmitBTNSuccessResponse], 5.seconds)
-      result.chargeReference.value mustEqual "XTC01234123412"
-      result.formBundleNumber mustEqual "119000004320"
-    }
-  }
+  private val submitUrl = "/report-pillar2-top-up-taxes/below-threshold-notification/submit"
 
-  "has an invalid request body" should {
-    "return a 400 BAD_REQUEST response" in {
-      stubGet(
-        "/report-pillar2-top-up-taxes/subscription/read-subscription/XCCVRUGFJG788",
-        OK,
-        Json.toJson(SubscriptionSuccess(subscriptionData)).toString()
-      )
-      val request = baseRequest.withBody(invalidRequestJson)
-      val result  = Await.result(request.execute[HttpResponse], 5.seconds)
-      println(result.body)
-      result.status mustEqual 400
-    }
-  }
-
-  "has an empty request body" should {
-    "return a 400 BAD_REQUEST response " in {
-      stubGet(
-        "/report-pillar2-top-up-taxes/subscription/read-subscription/XCCVRUGFJG788",
-        OK,
-        Json.toJson(SubscriptionSuccess(subscriptionData)).toString()
-      )
-      val request = baseRequest.withBody(JsObject.empty)
-      val result  = Await.result(request.execute[HttpResponse], 5.seconds)
-      result.status mustEqual 400
-    }
-  }
-
-  "has no request body" should {
-    "return a 400 BAD_REQUEST response " in {
-      stubGet(
-        "/report-pillar2-top-up-taxes/subscription/read-subscription/XCCVRUGFJG788",
-        OK,
-        Json.toJson(SubscriptionSuccess(subscriptionData)).toString()
-      )
-      val request = baseRequest
-      val result  = Await.result(request.execute[HttpResponse], 5.seconds)
-      result.status mustEqual 400
-    }
-  }
-
-  "has a valid request body containing duplicates fields and additional fields" should {
-    "return a 201 CREATED response" in {
-      stubGet(
-        "/report-pillar2-top-up-taxes/subscription/read-subscription/XCCVRUGFJG788",
-        OK,
-        Json.toJson(SubscriptionSuccess(subscriptionData)).toString()
-      )
-      stubResponse(
-        "/report-pillar2-top-up-taxes/below-threshold-notification/submit",
-        CREATED,
-        Json.toJson(SubmitBTNSuccessResponse("2022-01-31T09:26:17Z", "119000004320", Some("XTC01234123412")))
-      )
-      val request = baseRequest.withBody(validRequestJson_duplicateFieldsAndAdditionalFields)
-      val result  = Await.result(request.execute[SubmitBTNSuccessResponse], 5.seconds)
-      result.chargeReference.value mustEqual "XTC01234123412"
-      result.formBundleNumber mustEqual "119000004320"
-    }
-  }
-
-  "User unable to be identified" should {
-    "return a InternalServerError resulting in a RuntimeException being thrown" in {
-      when(
-        mockAuthConnector.authorise[RetrievalsType](any[Predicate](), any[Retrieval[RetrievalsType]]())(any[HeaderCarrier](), any[ExecutionContext]())
-      )
-        .thenReturn(
-          Future.failed(AuthenticationError("Invalid credentials"))
+  "BTNSubmissionController" when {
+    "submitBTN" must {
+      "return 201 CREATED when given valid submission data" in {
+        stubGet(
+          "/report-pillar2-top-up-taxes/subscription/read-subscription/XCCVRUGFJG788",
+          OK,
+          Json.toJson(SubscriptionSuccess(subscriptionData)).toString()
         )
-      val request = baseRequest.withBody(validRequestJson)
+        stubRequest(
+          "POST",
+          submitUrl,
+          CREATED,
+          Json.toJson(SubmitBTNSuccessResponse("2022-01-31T09:26:17Z", "119000004320", Some("XTC01234123412")))
+        )
 
-      val result = Await.result(request.execute[HttpResponse], 5.seconds)
-      result.status mustEqual 401
-      val errorResponse = result.json.as[Pillar2ErrorResponse]
-      errorResponse.code mustEqual "003"
-      errorResponse.message mustEqual "Invalid credentials"
-    }
-  }
+        val result = Await.result(baseRequest.withBody(validRequestJson).execute[SubmitBTNSuccessResponse], 5.seconds)
 
-  "'Invalid Return' response from ETMP returned" should {
-    "return a 422 UNPROCESSABLE_ENTITY response" in {
-      stubGet(
-        "/report-pillar2-top-up-taxes/subscription/read-subscription/XCCVRUGFJG788",
-        OK,
-        Json.toJson(SubscriptionSuccess(subscriptionData)).toString()
-      )
-      stubResponse(
-        "/report-pillar2-top-up-taxes/below-threshold-notification/submit",
-        UNPROCESSABLE_ENTITY,
-        Json.toJson(SubmitBTNErrorResponse("093", "Invalid Return"))
-      )
-      val request = baseRequest.withBody(validRequestJson)
-      val result  = Await.result(request.execute[HttpResponse], 5.seconds)
-      result.status mustEqual 422
-      val errorResponse = result.json.as[Pillar2ErrorResponse]
-      errorResponse.code mustEqual "093"
-      errorResponse.message mustEqual "Invalid Return"
-    }
-  }
+        result.chargeReference.value mustEqual "XTC01234123412"
+        result.formBundleNumber mustEqual "119000004320"
+      }
 
-  "'Unauthorized' response from ETMP returned" should {
-    "return a 500 INTERNAL_SERVER_ERROR response" in {
-      stubGet(
-        "/report-pillar2-top-up-taxes/subscription/read-subscription/XCCVRUGFJG788",
-        OK,
-        Json.toJson(SubscriptionSuccess(subscriptionData)).toString()
-      )
-      stubResponse(
-        "/report-pillar2-top-up-taxes/below-threshold-notification/submit",
-        UNAUTHORIZED,
-        Json.toJson(SubmitBTNErrorResponse("001", "Unauthorized"))
-      )
-      val request = baseRequest.withBody(validRequestJson)
-      val result  = Await.result(request.execute[HttpResponse], 5.seconds)
-      result.status mustEqual 500
-      val errorResponse = result.json.as[Pillar2ErrorResponse]
-      errorResponse.code mustEqual "500"
-      errorResponse.message mustEqual "Internal Server Error"
-    }
-  }
+      "return 400 BAD_REQUEST for invalid request body" in {
+        stubGet(
+          "/report-pillar2-top-up-taxes/subscription/read-subscription/XCCVRUGFJG788",
+          OK,
+          Json.toJson(SubscriptionSuccess(subscriptionData)).toString()
+        )
 
-  "'internal server error' response from ETMP returned" should {
-    "return a 500 INTERNAL_SERVER_ERROR response" in {
-      stubGet(
-        "/report-pillar2-top-up-taxes/subscription/read-subscription/XCCVRUGFJG788",
-        OK,
-        Json.toJson(SubscriptionSuccess(subscriptionData)).toString()
-      )
-      stubResponse(
-        "/report-pillar2-top-up-taxes/below-threshold-notification/submit",
-        INTERNAL_SERVER_ERROR,
-        Json.toJson(SubmitBTNErrorResponse("999", "internal_server_error"))
-      )
-      val request = baseRequest.withBody(validRequestJson)
-      val result  = Await.result(request.execute[HttpResponse], 5.seconds)
-      result.status mustEqual 500
-      val errorResponse = result.json.as[Pillar2ErrorResponse]
-      errorResponse.code mustEqual "500"
-      errorResponse.message mustEqual "Internal Server Error"
+        val result = Await.result(baseRequest.withBody(invalidRequestJson).execute[HttpResponse], 5.seconds)
+
+        result.status mustEqual BAD_REQUEST
+      }
+
+      "return 400 BAD_REQUEST for empty request body" in {
+        stubGet(
+          "/report-pillar2-top-up-taxes/subscription/read-subscription/XCCVRUGFJG788",
+          OK,
+          Json.toJson(SubscriptionSuccess(subscriptionData)).toString()
+        )
+
+        val result = Await.result(baseRequest.withBody(JsObject.empty).execute[HttpResponse], 5.seconds)
+
+        result.status mustEqual BAD_REQUEST
+      }
+
+      "return 400 BAD_REQUEST for missing request body" in {
+        stubGet(
+          "/report-pillar2-top-up-taxes/subscription/read-subscription/XCCVRUGFJG788",
+          OK,
+          Json.toJson(SubscriptionSuccess(subscriptionData)).toString()
+        )
+
+        val result = Await.result(baseRequest.execute[HttpResponse], 5.seconds)
+
+        result.status mustEqual BAD_REQUEST
+      }
+
+      "return 201 CREATED for request with duplicate fields and additional fields" in {
+        stubGet(
+          "/report-pillar2-top-up-taxes/subscription/read-subscription/XCCVRUGFJG788",
+          OK,
+          Json.toJson(SubscriptionSuccess(subscriptionData)).toString()
+        )
+        stubRequest(
+          "POST",
+          submitUrl,
+          CREATED,
+          Json.toJson(SubmitBTNSuccessResponse("2022-01-31T09:26:17Z", "119000004320", Some("XTC01234123412")))
+        )
+
+        val result =
+          Await.result(baseRequest.withBody(validRequestJson_duplicateFieldsAndAdditionalFields).execute[SubmitBTNSuccessResponse], 5.seconds)
+
+        result.chargeReference.value mustEqual "XTC01234123412"
+        result.formBundleNumber mustEqual "119000004320"
+      }
+
+      "return 401 UNAUTHORIZED when user cannot be identified" in {
+        when(
+          mockAuthConnector
+            .authorise[RetrievalsType](any[Predicate](), any[Retrieval[RetrievalsType]]())(any[HeaderCarrier](), any[ExecutionContext]())
+        ).thenReturn(Future.failed(AuthenticationError("Invalid credentials")))
+
+        val result = Await.result(baseRequest.withBody(validRequestJson).execute[HttpResponse], 5.seconds)
+
+        result.status mustEqual UNAUTHORIZED
+        val errorResponse = result.json.as[Pillar2ErrorResponse]
+        errorResponse.code mustEqual "003"
+        errorResponse.message mustEqual "Invalid credentials"
+      }
+
+      "return 422 UNPROCESSABLE_ENTITY for invalid return from ETMP" in {
+        stubGet(
+          "/report-pillar2-top-up-taxes/subscription/read-subscription/XCCVRUGFJG788",
+          OK,
+          Json.toJson(SubscriptionSuccess(subscriptionData)).toString()
+        )
+        stubRequest(
+          "POST",
+          submitUrl,
+          UNPROCESSABLE_ENTITY,
+          Json.toJson(SubmitBTNErrorResponse("093", "Invalid Return"))
+        )
+
+        val result = Await.result(baseRequest.withBody(validRequestJson).execute[HttpResponse], 5.seconds)
+
+        result.status mustEqual UNPROCESSABLE_ENTITY
+        val errorResponse = result.json.as[Pillar2ErrorResponse]
+        errorResponse.code mustEqual "093"
+        errorResponse.message mustEqual "Invalid Return"
+      }
+
+      "return 500 INTERNAL_SERVER_ERROR for unauthorized response from ETMP" in {
+        stubGet(
+          "/report-pillar2-top-up-taxes/subscription/read-subscription/XCCVRUGFJG788",
+          OK,
+          Json.toJson(SubscriptionSuccess(subscriptionData)).toString()
+        )
+        stubRequest(
+          "POST",
+          submitUrl,
+          UNAUTHORIZED,
+          Json.toJson(SubmitBTNErrorResponse("001", "Unauthorized"))
+        )
+
+        val result = Await.result(baseRequest.withBody(validRequestJson).execute[HttpResponse], 5.seconds)
+
+        result.status mustEqual INTERNAL_SERVER_ERROR
+        val errorResponse = result.json.as[Pillar2ErrorResponse]
+        errorResponse.code mustEqual "500"
+        errorResponse.message mustEqual "Internal Server Error"
+      }
+
+      "return 500 INTERNAL_SERVER_ERROR for internal server error from ETMP" in {
+        stubGet(
+          "/report-pillar2-top-up-taxes/subscription/read-subscription/XCCVRUGFJG788",
+          OK,
+          Json.toJson(SubscriptionSuccess(subscriptionData)).toString()
+        )
+        stubRequest(
+          "POST",
+          submitUrl,
+          INTERNAL_SERVER_ERROR,
+          Json.toJson(SubmitBTNErrorResponse("999", "internal_server_error"))
+        )
+
+        val result = Await.result(baseRequest.withBody(validRequestJson).execute[HttpResponse], 5.seconds)
+
+        result.status mustEqual INTERNAL_SERVER_ERROR
+        val errorResponse = result.json.as[Pillar2ErrorResponse]
+        errorResponse.code mustEqual "500"
+        errorResponse.message mustEqual "Internal Server Error"
+      }
     }
   }
 }
 
 object BTNSubmissionISpec {
-
   val validRequestJson: JsValue =
     Json.parse("""{
                  |  "accountingPeriodFrom": "2023-01-01",
@@ -227,5 +225,4 @@ object BTNSubmissionISpec {
                  |  "extraField1": "value1",
                  |  "extraField1": "value2"
                  |}""".stripMargin)
-
 }

--- a/it/test/uk/gov/hmrc/pillar2submissionapi/UKTaxReturnISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2submissionapi/UKTaxReturnISpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.pillar2submissionapi
 
-import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, postRequestedFor, urlEqualTo}
+import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, postRequestedFor, putRequestedFor, urlEqualTo}
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
@@ -47,154 +47,324 @@ class UKTaxReturnISpec extends IntegrationSpecBase with OptionValues {
   def requestWithBody(body: JsValue = validLiabilityReturn): RequestBuilder = client.post(URI.create(str).toURL).withBody(body)
   def getSubscriptionStub: StubMapping = stubGet(s"$readSubscriptionPath/$plrReference", OK, subscriptionSuccess.toString)
 
-  "Create a new UKTR submission (POST)" should {
-    "forward the X-Pillar2-Id header" in {
-      getSubscriptionStub
-      implicit val hc: HeaderCarrier = HeaderCarrier().withExtraHeaders("X-Pillar2-Id" -> plrReference)
-      stubResponseWithExtraHeader("/report-pillar2-top-up-taxes/submit-uk-tax-return", CREATED, Json.toJson(uktrSubmissionSuccessResponse))
+  private val submitUrl = "/report-pillar2-top-up-taxes/submit-uk-tax-return"
+  private val amendUrl  = "/report-pillar2-top-up-taxes/amend-uk-tax-return"
 
-      val result = Await.result(requestWithBody().execute[UKTRSubmitSuccessResponse], 5.seconds)
+  "UKTaxReturnController" when {
+    "submitUKTR" must {
+      "forward the X-Pillar2-Id header" in {
+        getSubscriptionStub
+        //implicit val hc: HeaderCarrier = HeaderCarrier().withExtraHeaders("X-Pillar2-Id" -> plrReference)
+        stubRequest(
+          "POST",
+          submitUrl,
+          CREATED,
+          Json.toJson(uktrSubmissionSuccessResponse),
+          Map("X-Pillar2-Id" -> plrReference)
+        )
 
-      result.chargeReference.value mustEqual pillar2Id
-      result.formBundleNumber mustEqual formBundleNumber
-      server.verify(
-        postRequestedFor(urlEqualTo("/report-pillar2-top-up-taxes/submit-uk-tax-return")).withHeader("X-Pillar2-Id", equalTo(plrReference))
-      )
+        val result = Await.result(requestWithBody().execute[UKTRSubmitSuccessResponse], 5.seconds)
+
+        result.chargeReference.value mustEqual pillar2Id
+        result.formBundleNumber mustEqual formBundleNumber
+        server.verify(
+          postRequestedFor(urlEqualTo(submitUrl)).withHeader("X-Pillar2-Id", equalTo(plrReference))
+        )
+      }
+
+      "return 201 CREATED for valid submission data" in {
+        getSubscriptionStub
+        stubRequest(
+          "POST",
+          submitUrl,
+          CREATED,
+          Json.toJson(uktrSubmissionSuccessResponse)
+        )
+
+        val result = Await.result(requestWithBody().execute[UKTRSubmitSuccessResponse], 5.seconds)
+
+        result.chargeReference.value mustEqual pillar2Id
+        result.formBundleNumber mustEqual formBundleNumber
+      }
+
+      "return 201 CREATED for valid nil-return submission" in {
+        getSubscriptionStub
+        stubRequest(
+          "POST",
+          submitUrl,
+          CREATED,
+          Json.toJson(uktrSubmissionSuccessResponse)
+        )
+
+        val result = Await.result(requestWithBody(validNilReturn).execute[UKTRSubmitSuccessResponse], 5.seconds)
+
+        result.chargeReference.value mustEqual pillar2Id
+        result.formBundleNumber mustEqual formBundleNumber
+      }
+
+      "return 400 BAD_REQUEST for invalid request body" in {
+        getSubscriptionStub
+
+        val result = Await.result(requestWithBody(invalidBody).execute[HttpResponse], 5.seconds)
+
+        result.status mustEqual BAD_REQUEST
+      }
+
+      "return 400 BAD_REQUEST for empty request body" in {
+        getSubscriptionStub
+
+        val result = Await.result(requestWithBody(JsObject.empty).execute[HttpResponse], 5.seconds)
+
+        result.status mustEqual BAD_REQUEST
+      }
+
+      "return 201 CREATED for request with duplicate fields" in {
+        getSubscriptionStub
+        stubRequest(
+          "POST",
+          submitUrl,
+          CREATED,
+          Json.toJson(uktrSubmissionSuccessResponse)
+        )
+
+        val result = Await.result(requestWithBody(liabilityReturnDuplicateFields).execute[UKTRSubmitSuccessResponse], 5.seconds)
+
+        result.chargeReference.value mustEqual pillar2Id
+        result.formBundleNumber mustEqual formBundleNumber
+      }
+
+      "return 500 INTERNAL_SERVER_ERROR when subscription data does not exist" in {
+        val result = Await.result(requestWithBody().execute[HttpResponse], 5.seconds)
+
+        result.status mustEqual INTERNAL_SERVER_ERROR
+        val errorResponse = result.json.as[Pillar2ErrorResponse]
+        errorResponse.code mustEqual "004"
+        errorResponse.message mustEqual "No Pillar2 subscription found for XCCVRUGFJG788"
+      }
+
+      "return 401 UNAUTHORIZED when user cannot be identified" in {
+        when(
+          mockAuthConnector
+            .authorise[RetrievalsType](any[Predicate](), any[Retrieval[RetrievalsType]]())(any[HeaderCarrier](), any[ExecutionContext]())
+        ).thenReturn(Future.failed(AuthenticationError("Invalid credentials")))
+
+        val result = Await.result(requestWithBody().execute[HttpResponse], 5.seconds)
+
+        result.status mustEqual UNAUTHORIZED
+        val errorResponse = result.json.as[Pillar2ErrorResponse]
+        errorResponse.code mustEqual "003"
+        errorResponse.message mustEqual "Invalid credentials"
+      }
+
+      "return 422 UNPROCESSABLE_ENTITY for invalid return from ETMP" in {
+        getSubscriptionStub
+        stubRequest(
+          "POST",
+          submitUrl,
+          UNPROCESSABLE_ENTITY,
+          Json.toJson(UKTRSubmitErrorResponse(INVALID_RETURN_093, "Invalid Return"))
+        )
+
+        val result = Await.result(requestWithBody().execute[HttpResponse], 5.seconds)
+
+        result.status mustEqual UNPROCESSABLE_ENTITY
+        val errorResponse = result.json.as[Pillar2ErrorResponse]
+        errorResponse.code mustEqual INVALID_RETURN_093
+        errorResponse.message mustEqual "Invalid Return"
+      }
+
+      "return 500 INTERNAL_SERVER_ERROR for unauthorized response from ETMP" in {
+        getSubscriptionStub
+        stubRequest(
+          "POST",
+          submitUrl,
+          UNAUTHORIZED,
+          Json.toJson(UKTRSubmitErrorResponse("001", "Unauthorized"))
+        )
+
+        val result = Await.result(requestWithBody().execute[HttpResponse], 5.seconds)
+
+        result.status mustEqual INTERNAL_SERVER_ERROR
+        val errorResponse = result.json.as[Pillar2ErrorResponse]
+        errorResponse.code mustEqual "500"
+        errorResponse.message mustEqual "Internal Server Error"
+      }
+
+      "return 500 INTERNAL_SERVER_ERROR for internal server error from ETMP" in {
+        getSubscriptionStub
+        stubRequest(
+          "POST",
+          submitUrl,
+          INTERNAL_SERVER_ERROR,
+          Json.toJson(UKTRSubmitErrorResponse("999", "internal_server_error"))
+        )
+
+        val result = Await.result(requestWithBody().execute[HttpResponse], 5.seconds)
+
+        result.status mustEqual INTERNAL_SERVER_ERROR
+        val errorResponse = result.json.as[Pillar2ErrorResponse]
+        errorResponse.code mustEqual "500"
+        errorResponse.message mustEqual "Internal Server Error"
+      }
     }
 
-    "create submission when given valid submission data" in {
-      getSubscriptionStub
-      stubResponse("/report-pillar2-top-up-taxes/submit-uk-tax-return", CREATED, Json.toJson(uktrSubmissionSuccessResponse))
+    "amendUKTR" must {
+      val amendRequest = (body: JsValue) => client.put(URI.create(str).toURL).withBody(body)
 
-      val result = Await.result(requestWithBody().execute[UKTRSubmitSuccessResponse], 5.seconds)
+      "forward the X-Pillar2-Id header" in {
+        getSubscriptionStub
+        //implicit val hc: HeaderCarrier = HeaderCarrier().withExtraHeaders("X-Pillar2-Id" -> plrReference)
+        stubRequest(
+          "PUT",
+          amendUrl,
+          OK,
+          Json.toJson(uktrSubmissionSuccessResponse),
+          Map("X-Pillar2-Id" -> plrReference)
+        )
 
-      result.chargeReference.value mustEqual pillar2Id
-      result.formBundleNumber mustEqual formBundleNumber
-    }
-  }
+        val result = Await.result(amendRequest(validLiabilityReturn).execute[UKTRSubmitSuccessResponse], 5.seconds)
 
-  "has valid nil-return submission data" should {
-    "return a 201 CREATED response" in {
-      getSubscriptionStub
-      stubResponse("/report-pillar2-top-up-taxes/submit-uk-tax-return", CREATED, Json.toJson(uktrSubmissionSuccessResponse))
+        result.chargeReference.value mustEqual pillar2Id
+        result.formBundleNumber mustEqual formBundleNumber
+        server.verify(
+          putRequestedFor(urlEqualTo(amendUrl)).withHeader("X-Pillar2-Id", equalTo(plrReference))
+        )
+      }
 
-      val result = Await.result(requestWithBody(validNilReturn).execute[UKTRSubmitSuccessResponse], 5.seconds)
+      "return 200 OK for valid submission data" in {
+        getSubscriptionStub
+        stubRequest(
+          "PUT",
+          amendUrl,
+          OK,
+          Json.toJson(uktrSubmissionSuccessResponse)
+        )
 
-      result.chargeReference.value mustEqual pillar2Id
-      result.formBundleNumber mustEqual formBundleNumber
-    }
-  }
+        val result = Await.result(amendRequest(validLiabilityReturn).execute[UKTRSubmitSuccessResponse], 5.seconds)
 
-  "has an invalid request body" should {
-    "return a 400 BAD_REQUEST response" in {
-      getSubscriptionStub
+        result.chargeReference.value mustEqual pillar2Id
+        result.formBundleNumber mustEqual formBundleNumber
+      }
 
-      val result = Await.result(requestWithBody(invalidBody).execute[HttpResponse], 5.seconds)
+      "return 200 OK for valid nil-return submission" in {
+        getSubscriptionStub
+        stubRequest(
+          "PUT",
+          amendUrl,
+          OK,
+          Json.toJson(uktrSubmissionSuccessResponse)
+        )
 
-      result.status mustEqual BAD_REQUEST
-    }
-  }
+        val result = Await.result(amendRequest(validNilReturn).execute[UKTRSubmitSuccessResponse], 5.seconds)
 
-  "has an empty request body" should {
-    "return a 400 BAD_REQUEST response " in {
-      getSubscriptionStub
+        result.chargeReference.value mustEqual pillar2Id
+        result.formBundleNumber mustEqual formBundleNumber
+      }
 
-      val result = Await.result(requestWithBody(JsObject.empty).execute[HttpResponse], 5.seconds)
+      "return 400 BAD_REQUEST for invalid request body" in {
+        getSubscriptionStub
 
-      result.status mustEqual BAD_REQUEST
-    }
-  }
+        val result = Await.result(amendRequest(invalidBody).execute[HttpResponse], 5.seconds)
 
-  "has a valid request body containing duplicates fields and additional fields" should {
-    "return a 201 CREATED response" in {
-      getSubscriptionStub
-      stubResponse("/report-pillar2-top-up-taxes/submit-uk-tax-return", CREATED, Json.toJson(uktrSubmissionSuccessResponse))
+        result.status mustEqual BAD_REQUEST
+      }
 
-      val result = Await.result(requestWithBody(liabilityReturnDuplicateFields).execute[UKTRSubmitSuccessResponse], 5.seconds)
+      "return 400 BAD_REQUEST for empty request body" in {
+        getSubscriptionStub
 
-      result.chargeReference.value mustEqual pillar2Id
-      result.formBundleNumber mustEqual formBundleNumber
-    }
-  }
+        val result = Await.result(amendRequest(JsObject.empty).execute[HttpResponse], 5.seconds)
 
-  "Subscription data does not exist" should {
-    "return a InternalServerError resulting in a RuntimeException being thrown" in {
-      val result = Await.result(requestWithBody().execute[HttpResponse], 5.seconds)
-      result.status mustEqual INTERNAL_SERVER_ERROR
+        result.status mustEqual BAD_REQUEST
+      }
 
-      val errorResponse = result.json.as[Pillar2ErrorResponse]
-      errorResponse.code mustEqual "004"
-      errorResponse.message mustEqual "No Pillar2 subscription found for XCCVRUGFJG788"
-    }
-  }
+      "return 200 OK for request with duplicate fields" in {
+        getSubscriptionStub
+        stubRequest(
+          "PUT",
+          amendUrl,
+          OK,
+          Json.toJson(uktrSubmissionSuccessResponse)
+        )
 
-  "User unable to be identified" should {
-    "return a InternalServerError resulting in a RuntimeException being thrown" in {
-      when(
-        mockAuthConnector.authorise[RetrievalsType](any[Predicate](), any[Retrieval[RetrievalsType]]())(any[HeaderCarrier](), any[ExecutionContext]())
-      )
-        .thenReturn(Future.failed(AuthenticationError("Invalid credentials")))
+        val result = Await.result(amendRequest(liabilityReturnDuplicateFields).execute[UKTRSubmitSuccessResponse], 5.seconds)
 
-      val result = Await.result(requestWithBody().execute[HttpResponse], 5.seconds)
+        result.chargeReference.value mustEqual pillar2Id
+        result.formBundleNumber mustEqual formBundleNumber
+      }
 
-      result.status mustEqual UNAUTHORIZED
-      val errorResponse = result.json.as[Pillar2ErrorResponse]
-      errorResponse.code mustEqual "003"
-      errorResponse.message mustEqual "Invalid credentials"
-    }
-  }
+      "return 500 INTERNAL_SERVER_ERROR when subscription data does not exist" in {
+        val result = Await.result(amendRequest(validLiabilityReturn).execute[HttpResponse], 5.seconds)
 
-  "'Invalid Return' response from ETMP returned" should {
-    "return a 422 UNPROCESSABLE_ENTITY response" in {
-      getSubscriptionStub
-      stubResponse(
-        "/report-pillar2-top-up-taxes/submit-uk-tax-return",
-        UNPROCESSABLE_ENTITY,
-        Json.toJson(UKTRSubmitErrorResponse(INVALID_RETURN_093, "Invalid Return"))
-      )
+        result.status mustEqual INTERNAL_SERVER_ERROR
+        val errorResponse = result.json.as[Pillar2ErrorResponse]
+        errorResponse.code mustEqual "004"
+        errorResponse.message mustEqual "No Pillar2 subscription found for XCCVRUGFJG788"
+      }
 
-      val result = Await.result(requestWithBody().execute[HttpResponse], 5.seconds)
+      "return 401 UNAUTHORIZED when user cannot be identified" in {
+        when(
+          mockAuthConnector
+            .authorise[RetrievalsType](any[Predicate](), any[Retrieval[RetrievalsType]]())(any[HeaderCarrier](), any[ExecutionContext]())
+        ).thenReturn(Future.failed(AuthenticationError("Invalid credentials")))
 
-      result.status mustEqual UNPROCESSABLE_ENTITY
-      val errorResponse = result.json.as[Pillar2ErrorResponse]
-      errorResponse.code mustEqual INVALID_RETURN_093
-      errorResponse.message mustEqual "Invalid Return"
-    }
-  }
+        val result = Await.result(amendRequest(validLiabilityReturn).execute[HttpResponse], 5.seconds)
 
-  "'Unauthorized' response from ETMP returned" should {
-    "return a 500 INTERNAL_SERVER_ERROR response" in {
-      getSubscriptionStub
-      stubResponse(
-        "/report-pillar2-top-up-taxes/submit-uk-tax-return",
-        UNAUTHORIZED,
-        Json.toJson(UKTRSubmitErrorResponse("001", "Unauthorized"))
-      )
+        result.status mustEqual UNAUTHORIZED
+        val errorResponse = result.json.as[Pillar2ErrorResponse]
+        errorResponse.code mustEqual "003"
+        errorResponse.message mustEqual "Invalid credentials"
+      }
 
-      val result = Await.result(requestWithBody().execute[HttpResponse], 5.seconds)
+      "return 422 UNPROCESSABLE_ENTITY for invalid return from ETMP" in {
+        getSubscriptionStub
+        stubRequest(
+          "PUT",
+          amendUrl,
+          UNPROCESSABLE_ENTITY,
+          Json.toJson(UKTRSubmitErrorResponse(INVALID_RETURN_093, "Invalid Return"))
+        )
 
-      result.status mustEqual INTERNAL_SERVER_ERROR
-      val errorResponse = result.json.as[Pillar2ErrorResponse]
-      errorResponse.code mustEqual "500"
-      errorResponse.message mustEqual "Internal Server Error"
-    }
-  }
+        val result = Await.result(amendRequest(validLiabilityReturn).execute[HttpResponse], 5.seconds)
 
-  "'internal server error' response from ETMP returned" should {
-    "return a 500 INTERNAL_SERVER_ERROR response" in {
-      getSubscriptionStub
-      stubResponse(
-        "/report-pillar2-top-up-taxes/submit-uk-tax-return",
-        INTERNAL_SERVER_ERROR,
-        Json.toJson(UKTRSubmitErrorResponse("999", "internal_server_error"))
-      )
+        result.status mustEqual UNPROCESSABLE_ENTITY
+        val errorResponse = result.json.as[Pillar2ErrorResponse]
+        errorResponse.code mustEqual INVALID_RETURN_093
+        errorResponse.message mustEqual "Invalid Return"
+      }
 
-      val result = Await.result(requestWithBody().execute[HttpResponse], 5.seconds)
+      "return 500 INTERNAL_SERVER_ERROR for unauthorized response from ETMP" in {
+        getSubscriptionStub
+        stubRequest(
+          "PUT",
+          amendUrl,
+          UNAUTHORIZED,
+          Json.toJson(UKTRSubmitErrorResponse("001", "Unauthorized"))
+        )
 
-      result.status mustEqual INTERNAL_SERVER_ERROR
-      val errorResponse = result.json.as[Pillar2ErrorResponse]
-      errorResponse.code mustEqual "500"
-      errorResponse.message mustEqual "Internal Server Error"
+        val result = Await.result(amendRequest(validLiabilityReturn).execute[HttpResponse], 5.seconds)
+
+        result.status mustEqual INTERNAL_SERVER_ERROR
+        val errorResponse = result.json.as[Pillar2ErrorResponse]
+        errorResponse.code mustEqual "500"
+        errorResponse.message mustEqual "Internal Server Error"
+      }
+
+      "return 500 INTERNAL_SERVER_ERROR for internal server error from ETMP" in {
+        getSubscriptionStub
+        stubRequest(
+          "PUT",
+          amendUrl,
+          INTERNAL_SERVER_ERROR,
+          Json.toJson(UKTRSubmitErrorResponse("999", "internal_server_error"))
+        )
+
+        val result = Await.result(amendRequest(validLiabilityReturn).execute[HttpResponse], 5.seconds)
+
+        result.status mustEqual INTERNAL_SERVER_ERROR
+        val errorResponse = result.json.as[Pillar2ErrorResponse]
+        errorResponse.code mustEqual "500"
+        errorResponse.message mustEqual "Internal Server Error"
+      }
     }
   }
 }

--- a/test/uk/gov/hmrc/pillar2submissionapi/base/UnitTestBaseSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/base/UnitTestBaseSpec.scala
@@ -57,5 +57,4 @@ trait UnitTestBaseSpec
   protected val mockPillar2Connector:     UKTaxReturnConnector = mock[UKTaxReturnConnector]
   protected val mockUKTaxReturnConnector: UKTaxReturnConnector = mock[UKTaxReturnConnector]
   protected val mockSubmitBTNConnector:   SubmitBTNConnector   = mock[SubmitBTNConnector]
-
 }

--- a/test/uk/gov/hmrc/pillar2submissionapi/connectors/SubmitBTNConnectorSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/connectors/SubmitBTNConnectorSpec.scala
@@ -16,12 +16,14 @@
 
 package uk.gov.hmrc.pillar2submissionapi.connectors
 
+import com.github.tomakehurst.wiremock.client.WireMock._
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
-import play.api.http.Status.{BAD_REQUEST, CREATED}
+import play.api.http.Status._
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.JsObject
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import play.api.{Application, Configuration}
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2submissionapi.base.UnitTestBaseSpec
 import uk.gov.hmrc.pillar2submissionapi.connectors.SubmitBTNConnectorSpec.validBTNSubmission
 import uk.gov.hmrc.pillar2submissionapi.models.btnsubmissions.BTNSubmission
@@ -33,40 +35,47 @@ class SubmitBTNConnectorSpec extends UnitTestBaseSpec {
 
   lazy val submitBTNConnector: SubmitBTNConnector = app.injector.instanceOf[SubmitBTNConnector]
   override def fakeApplication(): Application = new GuiceApplicationBuilder()
-    .configure(
-      Configuration(
-        "microservice.services.pillar2.port" -> server.port()
-      )
-    )
+    .configure(Configuration("microservice.services.pillar2.port" -> server.port()))
     .build()
 
+  private val submitUrl = "/report-pillar2-top-up-taxes/below-threshold-notification/submit"
+
   "SubmitBTNConnector" when {
-    "submitBTN() called with a valid request" must {
-      "return 201 CREATED response" in {
-        stubResponse("/report-pillar2-top-up-taxes/below-threshold-notification/submit", CREATED, JsObject.empty)
+    "submitBTN" must {
+      "forward the X-Pillar2-Id header" in {
+        implicit val hc: HeaderCarrier = HeaderCarrier().withExtraHeaders("X-Pillar2-Id" -> pillar2Id)
+        stubRequestWithPillar2Id("POST", submitUrl, CREATED, JsObject.empty)
 
-        val result = await(submitBTNConnector.submitBTN(validBTNSubmission)(hc))
+        val result = await(submitBTNConnector.submitBTN(validBTNSubmission))
 
-        result.status should be(201)
+        result.status should be(CREATED)
+        server.verify(
+          postRequestedFor(urlEqualTo(submitUrl)).withHeader("X-Pillar2-Id", equalTo(pillar2Id))
+        )
       }
-    }
 
-    "submitBTN() called with an invalid request" must {
-      "return 400 BAD_REQUEST response" in {
-        stubResponse("/report-pillar2-top-up-taxes/below-threshold-notification/submit", BAD_REQUEST, JsObject.empty)
+      "return 201 CREATED for valid request" in {
+        stubRequest("POST", submitUrl, CREATED, JsObject.empty)
 
         val result = await(submitBTNConnector.submitBTN(validBTNSubmission)(hc))
 
-        result.status should be(400)
+        result.status should be(CREATED)
       }
-    }
 
-    "submitBTN() called with an invalid url configured" must {
-      "return 404 NOT_FOUND response" in {
+      "return 400 BAD_REQUEST for invalid request" in {
+        stubRequest("POST", submitUrl, BAD_REQUEST, JsObject.empty)
 
         val result = await(submitBTNConnector.submitBTN(validBTNSubmission)(hc))
 
-        result.status should be(404)
+        result.status should be(BAD_REQUEST)
+      }
+
+      "return 404 NOT_FOUND for incorrect URL" in {
+        stubRequest("POST", "/INCORRECT_URL", NOT_FOUND, JsObject.empty)
+
+        val result = await(submitBTNConnector.submitBTN(validBTNSubmission)(hc))
+
+        result.status should be(NOT_FOUND)
       }
     }
   }
@@ -74,5 +83,4 @@ class SubmitBTNConnectorSpec extends UnitTestBaseSpec {
 
 object SubmitBTNConnectorSpec {
   val validBTNSubmission: BTNSubmission = new BTNSubmission(LocalDate.now(), LocalDate.now().plus(365, ChronoUnit.DAYS))
-
 }

--- a/test/uk/gov/hmrc/pillar2submissionapi/services/UKTaxReturnServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/services/UKTaxReturnServiceSpec.scala
@@ -119,5 +119,88 @@ class UKTaxReturnServiceSpec extends UnitTestBaseSpec {
         intercept[UnexpectedResponse.type](await(mockUkTaxReturnService.submitUKTR(validLiabilitySubmission)))
       }
     }
+
+    "amendUKTR() is called with a UKTRSubmission" should {
+      "forward the X-Pillar2-Id header" in {
+        val captor = ArgumentCaptor.forClass(classOf[HeaderCarrier])
+        when(mockUKTaxReturnConnector.amendUKTR(any[UKTRSubmission])(captor.capture()))
+          .thenReturn(Future.successful(HttpResponse.apply(OK, Json.toJson(uktrSubmissionSuccessResponse), Map.empty)))
+
+        val result =
+          await(mockUkTaxReturnService.amendUKTR(validLiabilitySubmission)(hc = hc.withExtraHeaders("X-Pillar2-Id" -> pillar2Id)))
+
+        assertEquals(uktrSubmissionSuccessResponse, result)
+        captor.getValue.extraHeaders.map(_._1) must contain("X-Pillar2-Id")
+        captor.getValue.extraHeaders.map(_._2).head mustEqual pillar2Id
+      }
+    }
+
+    "amendUKTR() called with a valid tax return" should {
+      "return 200 OK response" in {
+        when(mockUKTaxReturnConnector.amendUKTR(any[UKTRSubmissionData])(any[HeaderCarrier]))
+          .thenReturn(Future.successful(HttpResponse.apply(OK, Json.toJson(uktrSubmissionSuccessResponse), Map.empty)))
+
+        val result = await(mockUkTaxReturnService.amendUKTR(validNilSubmission))
+
+        assertEquals(uktrSubmissionSuccessResponse, result)
+      }
+    }
+
+    "amendUKTR() called with a valid nil return" should {
+      "return 200 OK response" in {
+        when(mockUKTaxReturnConnector.amendUKTR(any[UKTRSubmissionNilReturn])(any[HeaderCarrier]))
+          .thenReturn(Future.successful(HttpResponse.apply(OK, Json.toJson(uktrSubmissionSuccessResponse), Map.empty)))
+
+        val result = await(mockUkTaxReturnService.amendUKTR(validNilSubmission))
+
+        assertEquals(uktrSubmissionSuccessResponse, result)
+      }
+    }
+
+    "amendUKTR() unparsable 200 response back" should {
+      "Runtime exception thrown" in {
+        when(mockUKTaxReturnConnector.amendUKTR(any[UKTRSubmissionData])(any[HeaderCarrier]))
+          .thenReturn(Future.successful(HttpResponse.apply(OK, Json.toJson("unparsable success response"), Map.empty)))
+
+        intercept[UnexpectedResponse.type](await(mockUkTaxReturnService.amendUKTR(validNilSubmission)))
+        val result = intercept[UnexpectedResponse.type](await(mockUkTaxReturnService.amendUKTR(validLiabilitySubmission)))
+        result.code.toInt mustEqual INTERNAL_SERVER_ERROR
+        result.message mustEqual "Internal Server Error"
+      }
+    }
+
+    "amendUKTR() valid 422 response back" should {
+      "Runtime exception thrown (To be updated to the appropriate exception)" in {
+        when(mockUKTaxReturnConnector.amendUKTR(any[UKTRSubmissionData])(any[HeaderCarrier]))
+          .thenReturn(
+            Future.successful(
+              HttpResponse.apply(UNPROCESSABLE_ENTITY, Json.toJson(UKTRSubmitErrorResponse(INVALID_RETURN_093, "Invalid Return")), Map.empty)
+            )
+          )
+
+        intercept[UktrValidationError](await(mockUkTaxReturnService.amendUKTR(validNilSubmission)))
+      }
+    }
+
+    "amendUKTR() unparsable 422 response back" should {
+      "Runtime exception thrown" in {
+        when(mockUKTaxReturnConnector.amendUKTR(any[UKTRSubmissionData])(any[HeaderCarrier]))
+          .thenReturn(Future.successful(HttpResponse.apply(UNPROCESSABLE_ENTITY, Json.toJson("unparsable error response"), Map.empty)))
+
+        intercept[UnexpectedResponse.type](await(mockUkTaxReturnService.amendUKTR(validLiabilitySubmission)))
+        val result = intercept[UnexpectedResponse.type](await(mockUkTaxReturnService.amendUKTR(validLiabilitySubmission)))
+        result.code.toInt mustEqual INTERNAL_SERVER_ERROR
+        result.message mustEqual "Internal Server Error"
+      }
+    }
+
+    "amendUKTR() 500 response back" should {
+      "Runtime exception thrown " in {
+        when(mockUKTaxReturnConnector.amendUKTR(any[UKTRSubmissionData])(any[HeaderCarrier]))
+          .thenReturn(Future.successful(HttpResponse.apply(INTERNAL_SERVER_ERROR, Json.toJson(InternalServerError.toString()), Map.empty)))
+
+        intercept[UnexpectedResponse.type](await(mockUkTaxReturnService.amendUKTR(validLiabilitySubmission)))
+      }
+    }
   }
 }


### PR DESCRIPTION
Adds ability to amend UK Tax Returns via a PUT endpoint that accepts the same payload as the submission endpoint.

Changes:
- Added new PUT endpoint `/uk-tax-return` for amendments
- Added `amendUKTR` method to controller, service, and connector layers
- Added integration and unit tests for amendment functionality
- Refactored test helpers to use a single `stubRequest` method instead of separate methods for each HTTP verb
- Reorganized Bruno API tests into submit/amend subdirectories with comprehensive test cases for success and error scenarios

The amendment endpoint returns 200 OK on success (vs 201 CREATED for submissions) but otherwise behaves identically to the submission endpoint.