### PR TITLE
PIL-1600 Add Error Response Examples to API Specifications

### DIFF
--- a/conf/submission.routes
+++ b/conf/submission.routes
@@ -14,6 +14,17 @@
 #        application/json:
 #          schema:
 #            $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.responses.UKTRSubmitSuccessResponse'
+#   401:
+#     description: Unauthorized
+#     content:
+#       application/json:
+#         schema:
+#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
+#         examples:
+#           AuthenticationError:
+#             value:
+#               code: "003"
+#               message: "Unauthorised"
 #   422:
 #     description: Business Validation Failure
 #     content:
@@ -26,30 +37,30 @@
 #       application/json:
 #         schema:
 #           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
-#   401:
-#     description: Unauthorized
-#     content:
-#       application/json:
-#         schema:
-#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
-#         example:
-#           code: "003"
-#           message: "Not authorized"
-#   403:
-#     description: Forbidden
-#     content:
-#       application/json:
-#         schema:
-#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
-#         example:
-#           code: "006"
-#           message: "Forbidden"
+#         examples:
+#           InvalidJson:
+#             value:
+#               code: "001"
+#               message: "Invalid JSON payload"
+#           EmptyRequestBody:
+#             value:
+#               code: "002"
+#               message: "Empty body in request"
 #   500:
 #     description: Internal Server Error
 #     content:
 #       application/json:
 #         schema:
 #           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
+#         examples:
+#           GenericServerError:
+#             value:
+#               code: "500"
+#               message: "Internal Server Error"
+#           NoSubscriptionData:
+#             value:
+#               code: "004"
+#               message: "No Pillar2 subscription found for [pillar2Id]"
 ###
 POST       /uk-tax-return              uk.gov.hmrc.pillar2submissionapi.controllers.UKTaxReturnController.submitUKTR
 
@@ -69,6 +80,15 @@ POST       /uk-tax-return              uk.gov.hmrc.pillar2submissionapi.controll
 #        application/json:
 #          schema:
 #            $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.responses.UKTRSubmitSuccessResponse'
+#   401:
+#     description: Unauthorized
+#     content:
+#       application/json:
+#         schema:
+#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
+#         example:
+#           code: "003"
+#           message: "Unauthorised"
 #   422:
 #     description: Business Validation Failure
 #     content:
@@ -81,15 +101,15 @@ POST       /uk-tax-return              uk.gov.hmrc.pillar2submissionapi.controll
 #       application/json:
 #         schema:
 #           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
-#   401:
-#     description: Unauthorized
-#     content:
-#       application/json:
-#         schema:
-#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
-#         example:
-#           code: "003"
-#           message: "Not authorized"
+#         examples:
+#           InvalidJson:
+#             value:
+#               code: "001"
+#               message: "Invalid JSON payload"
+#           EmptyRequestBody:
+#             value:
+#               code: "002"
+#               message: "Empty body in request"
 #   403:
 #     description: Forbidden
 #     content:
@@ -105,6 +125,15 @@ POST       /uk-tax-return              uk.gov.hmrc.pillar2submissionapi.controll
 #       application/json:
 #         schema:
 #           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
+#         examples:
+#           GenericServerError:
+#             value:
+#               code: "500"
+#               message: "Internal Server Error"
+#           NoSubscriptionData:
+#             value:
+#               code: "004"
+#               message: "No Pillar2 subscription found for [pillar2Id]"
 ###
 PUT        /uk-tax-return              uk.gov.hmrc.pillar2submissionapi.controllers.UKTaxReturnController.amendUKTR
 
@@ -122,6 +151,15 @@ PUT        /uk-tax-return              uk.gov.hmrc.pillar2submissionapi.controll
 #        application/json:
 #          schema:
 #            $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.belowthresholdnotification.SubmitBTNSuccessResponse'
+#   401:
+#     description: Unauthorized
+#     content:
+#       application/json:
+#         schema:
+#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
+#         example:
+#           code: "003"
+#           message: "Unauthorised"
 #   422:
 #     description: Business Validation Failure
 #     content:
@@ -134,15 +172,15 @@ PUT        /uk-tax-return              uk.gov.hmrc.pillar2submissionapi.controll
 #       application/json:
 #         schema:
 #           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
-#   401:
-#     description: Unauthorized
-#     content:
-#       application/json:
-#         schema:
-#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
-#         example:
-#           code: "003"
-#           message: "Not authorized"
+#         examples:
+#           InvalidJson:
+#             value:
+#               code: "001"
+#               message: "Invalid JSON payload"
+#           EmptyRequestBody:
+#             value:
+#               code: "002"
+#               message: "Empty body in request"
 #   403:
 #     description: Forbidden
 #     content:
@@ -158,5 +196,14 @@ PUT        /uk-tax-return              uk.gov.hmrc.pillar2submissionapi.controll
 #       application/json:
 #         schema:
 #           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
+#         examples:
+#           GenericServerError:
+#             value:
+#               code: "500"
+#               message: "Internal Server Error"
+#           NoSubscriptionData:
+#             value:
+#               code: "004"
+#               message: "No Pillar2 subscription found for [pillar2Id]"
 ###
 POST       /below-threshold-notification              uk.gov.hmrc.pillar2submissionapi.controllers.BTNSubmissionController.submitBTN

--- a/conf/submission.routes
+++ b/conf/submission.routes
@@ -3,49 +3,109 @@
 # requestBody:
 #   content:
 #     application/json:
-#         schema:
-#           oneOf:
-#               - $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.UKTRSubmissionData'
-#               - $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.UKTRSubmissionNilReturn'
+#       schema:
+#         oneOf:
+#           - $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.UKTRSubmissionData'
+#           - $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.UKTRSubmissionNilReturn'
 # responses:
 #   201:
-#      description: UK Tax Return Submission Created
-#      content:
-#        application/json:
-#          schema:
-#            $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.responses.UKTRSubmitSuccessResponse'
+#     description: UK Tax Return Submission Created
+#     content:
+#       application/json:
+#         schema:
+#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.responses.UKTRSubmitSuccessResponse'
 #   401:
 #     description: Unauthorized
 #     content:
 #       application/json:
 #         schema:
 #           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
-#         examples:
-#           AuthenticationError:
-#             value:
-#               code: "003"
-#               message: "Unauthorised"
+#         example:
+#           code: '003'
+#           message: Not authorized
 #   422:
 #     description: Business Validation Failure
 #     content:
 #       application/json:
 #         schema:
 #           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
+#         examples:
+#           Invalid Pillar2ID:
+#             value:
+#               code: '002'
+#               message: Pillar 2 ID missing or invalid
+#           Invalid Request:
+#             value:
+#               code: '003'
+#               message: Request could not be processed
+#           Duplicate Submission:
+#             value:
+#               code: '004'
+#               message: Duplicate submission acknowledgment reference
+#           No Active Submission:
+#             value:
+#               code: '007'
+#               message: Business Partner does not have an active subscription
+#           Tax Obligation Fulfilled:
+#             value:
+#               code: '044'
+#               message: Tax Obligation already fulfilled
+#           Invalid Return:
+#             value:
+#               code: '093'
+#               message: Invalid Return
+#           Invalid DTT Election:
+#             value:
+#               code: '094'
+#               message: Invalid DTT Election
+#           Invalid UTPR Election:
+#             value:
+#               code: '095'
+#               message: Invalid UTPR Election
+#           Invalid Total Liability:
+#             value:
+#               code: '096'
+#               message: Invalid Total Liability
+#           Invalid Total Liability IIR:
+#             value:
+#               code: '097'
+#               message: Invalid Total Liability IIR
+#           Invalid Total Liability DTT:
+#             value:
+#               code: '098'
+#               message: Invalid Total Liability DTT
+#           Invalid Total Liability UTPR:
+#             value:
+#               code: '099'
+#               message: Invalid Total Liability UTPR
 #   400:
-#     description: Invalid Submission
+#     description: Bad Request
 #     content:
 #       application/json:
 #         schema:
 #           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
 #         examples:
-#           InvalidJson:
+#           Invalid Json:
 #             value:
 #               code: "001"
 #               message: "Invalid JSON payload"
-#           EmptyRequestBody:
+#           Empty Request Body:
 #             value:
 #               code: "002"
 #               message: "Empty body in request"
+#           Missing Header:
+#             value:
+#               code: "005"
+#               message: "Missing Header in request"
+#   403:
+#     description: Forbidden
+#     content:
+#       application/json:
+#         schema:
+#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
+#         example:
+#           code: "006"
+#           message: "Forbidden"
 #   500:
 #     description: Internal Server Error
 #     content:
@@ -53,11 +113,11 @@
 #         schema:
 #           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
 #         examples:
-#           GenericServerError:
+#           Generic Server Error:
 #             value:
 #               code: "500"
 #               message: "Internal Server Error"
-#           NoSubscriptionData:
+#           No Subscription Data:
 #             value:
 #               code: "004"
 #               message: "No Pillar2 subscription found for [pillar2Id]"
@@ -69,17 +129,17 @@ POST       /uk-tax-return              uk.gov.hmrc.pillar2submissionapi.controll
 # requestBody:
 #   content:
 #     application/json:
-#         schema:
-#           oneOf:
-#               - $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.UKTRSubmissionData'
-#               - $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.UKTRSubmissionNilReturn'
+#       schema:
+#         oneOf:
+#           - $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.UKTRSubmissionData'
+#           - $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.UKTRSubmissionNilReturn'
 # responses:
 #   200:
-#      description: UK Tax Return Submission Amended
-#      content:
-#        application/json:
-#          schema:
-#            $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.responses.UKTRSubmitSuccessResponse'
+#     description: UK Tax Return Submission Amended
+#     content:
+#       application/json:
+#         schema:
+#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.responses.UKTRSubmitSuccessResponse'
 #   401:
 #     description: Unauthorized
 #     content:
@@ -87,29 +147,78 @@ POST       /uk-tax-return              uk.gov.hmrc.pillar2submissionapi.controll
 #         schema:
 #           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
 #         example:
-#           code: "003"
-#           message: "Unauthorised"
+#           code: '003'
+#           message: Not authorized
 #   422:
 #     description: Business Validation Failure
 #     content:
 #       application/json:
 #         schema:
 #           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
+#         examples:
+#           Invalid Pillar2ID:
+#             value:
+#               code: '002'
+#               message: Pillar 2 ID missing or invalid
+#           Invalid Request:
+#             value:
+#               code: '003'
+#               message: Request could not be processed
+#           Duplicate Submission:
+#             value:
+#               code: '004'
+#               message: Duplicate submission acknowledgment reference
+#           No Active Submission:
+#             value:
+#               code: '007'
+#               message: Business Partner does not have an active subscription
+#           Invalid Return:
+#             value:
+#               code: '093'
+#               message: Invalid Return
+#           Invalid DTT Election:
+#             value:
+#               code: '094'
+#               message: Invalid DTT Election
+#           Invalid UTPR Election:
+#             value:
+#               code: '095'
+#               message: Invalid UTPR Election
+#           Invalid Total Liability:
+#             value:
+#               code: '096'
+#               message: Invalid Total Liability
+#           Invalid Total Liability IIR:
+#             value:
+#               code: '097'
+#               message: Invalid Total Liability IIR
+#           Invalid Total Liability DTT:
+#             value:
+#               code: '098'
+#               message: Invalid Total Liability DTT
+#           Invalid Total Liability UTPR:
+#             value:
+#               code: '099'
+#               message: Invalid Total Liability UTPR
 #   400:
-#     description: Invalid Submission
+#     description: Bad Request
 #     content:
 #       application/json:
 #         schema:
 #           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
 #         examples:
-#           InvalidJson:
+#           Invalid Json:
 #             value:
 #               code: "001"
 #               message: "Invalid JSON payload"
-#           EmptyRequestBody:
+#           Empty Request Body:
 #             value:
 #               code: "002"
 #               message: "Empty body in request"
+#           Missing Header:
+#             value:
+#               code: "005"
+#               message: "Missing Header in request"
 #   403:
 #     description: Forbidden
 #     content:
@@ -126,11 +235,11 @@ POST       /uk-tax-return              uk.gov.hmrc.pillar2submissionapi.controll
 #         schema:
 #           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
 #         examples:
-#           GenericServerError:
+#           Generic Server Error:
 #             value:
 #               code: "500"
 #               message: "Internal Server Error"
-#           NoSubscriptionData:
+#           No Subscription Data:
 #             value:
 #               code: "004"
 #               message: "No Pillar2 subscription found for [pillar2Id]"
@@ -142,15 +251,15 @@ PUT        /uk-tax-return              uk.gov.hmrc.pillar2submissionapi.controll
 # requestBody:
 #   content:
 #     application/json:
-#         schema:
-#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.belowthresholdnotification.BTNSubmission'
+#       schema:
+#         $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.belowthresholdnotification.BTNSubmission'
 # responses:
 #   201:
-#      description: Below-Threshold Notification Submission Created
-#      content:
-#        application/json:
-#          schema:
-#            $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.belowthresholdnotification.SubmitBTNSuccessResponse'
+#     description: Below-Threshold Notification Submission Created
+#     content:
+#       application/json:
+#         schema:
+#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.belowthresholdnotification.SubmitBTNSuccessResponse'
 #   401:
 #     description: Unauthorized
 #     content:
@@ -158,29 +267,54 @@ PUT        /uk-tax-return              uk.gov.hmrc.pillar2submissionapi.controll
 #         schema:
 #           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
 #         example:
-#           code: "003"
-#           message: "Unauthorised"
+#           code: '003'
+#           message: Not authorized
 #   422:
 #     description: Business Validation Failure
 #     content:
 #       application/json:
 #         schema:
 #           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
+#         examples:
+#           Invalid Pillar2ID:
+#             value:
+#               code: '002'
+#               message: Pillar 2 ID missing or invalid
+#           Invalid Request:
+#             value:
+#               code: '003'
+#               message: Request could not be processed
+#           Duplicate Acknowledgment:
+#             value:
+#               code: '004'
+#               message: Duplicate acknowledgment reference
+#           No Active Submission:
+#             value:
+#               code: '007'
+#               message: Business Partner does not have an Active Pillar 2 registration
+#           Tax Obligation Fulfilled:
+#             value:
+#               code: '044'
+#               message: Tax Obligation already fulfilled
 #   400:
-#     description: Invalid Submission
+#     description: Bad Request
 #     content:
 #       application/json:
 #         schema:
 #           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
 #         examples:
-#           InvalidJson:
+#           Invalid Json:
 #             value:
 #               code: "001"
 #               message: "Invalid JSON payload"
-#           EmptyRequestBody:
+#           Empty Request Body:
 #             value:
 #               code: "002"
 #               message: "Empty body in request"
+#           Missing Header:
+#             value:
+#               code: "005"
+#               message: "Missing Header in request"
 #   403:
 #     description: Forbidden
 #     content:
@@ -197,11 +331,11 @@ PUT        /uk-tax-return              uk.gov.hmrc.pillar2submissionapi.controll
 #         schema:
 #           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
 #         examples:
-#           GenericServerError:
+#           Generic Server Error:
 #             value:
 #               code: "500"
 #               message: "Internal Server Error"
-#           NoSubscriptionData:
+#           No Subscription Data:
 #             value:
 #               code: "004"
 #               message: "No Pillar2 subscription found for [pillar2Id]"

--- a/resources/public/api/conf/1.0/application.yaml
+++ b/resources/public/api/conf/1.0/application.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.69.0
+  version: 0.72.0
   title: Pillar 2 API
   description: An API for managing and retrieving data in accordance with Pillar 2
     tax rules.
@@ -70,6 +70,15 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              examples:
+                InvalidJson:
+                  value:
+                    code: '001'
+                    message: Invalid JSON payload
+                EmptyRequestBody:
+                  value:
+                    code: '002'
+                    message: Empty body in request
         "201":
           description: UK Tax Return Submission Created
           content:
@@ -82,15 +91,15 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
-              example:
-                code: '006'
-                message: Forbidden
+              examples:
+                GenericServerError:
+                  value:
+                    code: 500
+                    message: Internal Server Error
+                NoSubscriptionData:
+                  value:
+                    code: '004'
+                    message: No Pillar2 subscription found for -pillar2Id
         "422":
           description: Business Validation Failure
           content:
@@ -103,9 +112,11 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
-              example:
-                code: '003'
-                message: Not authorized
+              examples:
+                AuthenticationError:
+                  value:
+                    code: '003'
+                    message: Unauthorised
     put:
       security:
       - userRestricted:
@@ -132,12 +143,30 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              examples:
+                InvalidJson:
+                  value:
+                    code: '001'
+                    message: Invalid JSON payload
+                EmptyRequestBody:
+                  value:
+                    code: '002'
+                    message: Empty body in request
         "500":
           description: Internal Server Error
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              examples:
+                GenericServerError:
+                  value:
+                    code: 500
+                    message: Internal Server Error
+                NoSubscriptionData:
+                  value:
+                    code: '004'
+                    message: No Pillar2 subscription found for -pillar2Id
         "403":
           description: Forbidden
           content:
@@ -161,7 +190,7 @@ paths:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
               example:
                 code: '003'
-                message: Not authorized
+                message: Unauthorised
         "200":
           description: UK Tax Return Submission Amended
           content:
@@ -223,6 +252,15 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              examples:
+                InvalidJson:
+                  value:
+                    code: '001'
+                    message: Invalid JSON payload
+                EmptyRequestBody:
+                  value:
+                    code: '002'
+                    message: Empty body in request
         "201":
           description: Below-Threshold Notification Submission Created
           content:
@@ -235,6 +273,15 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              examples:
+                GenericServerError:
+                  value:
+                    code: 500
+                    message: Internal Server Error
+                NoSubscriptionData:
+                  value:
+                    code: '004'
+                    message: No Pillar2 subscription found for -pillar2Id
         "403":
           description: Forbidden
           content:
@@ -258,7 +305,7 @@ paths:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
               example:
                 code: '003'
-                message: Not authorized
+                message: Unauthorised
 components:
   schemas:
     BTNSubmission:

--- a/resources/public/api/conf/1.0/application.yaml
+++ b/resources/public/api/conf/1.0/application.yaml
@@ -65,20 +65,24 @@ paths:
       summary: SubmitUKTR
       responses:
         "400":
-          description: Invalid Submission
+          description: Bad Request
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
               examples:
-                InvalidJson:
+                Invalid Json:
                   value:
                     code: '001'
                     message: Invalid JSON payload
-                EmptyRequestBody:
+                Empty Request Body:
                   value:
                     code: '002'
                     message: Empty body in request
+                Missing Header:
+                  value:
+                    code: '005'
+                    message: Missing Header in request
         "201":
           description: UK Tax Return Submission Created
           content:
@@ -92,31 +96,87 @@ paths:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
               examples:
-                GenericServerError:
+                Generic Server Error:
                   value:
                     code: 500
                     message: Internal Server Error
-                NoSubscriptionData:
+                No Subscription Data:
                   value:
                     code: '004'
                     message: No Pillar2 subscription found for -pillar2Id
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              example:
+                code: '006'
+                message: Forbidden
         "422":
           description: Business Validation Failure
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              examples:
+                Invalid UTPR Election:
+                  value:
+                    code: '095'
+                    message: Invalid UTPR Election
+                Invalid Pillar2ID:
+                  value:
+                    code: '002'
+                    message: Pillar 2 ID missing or invalid
+                Invalid Total Liability IIR:
+                  value:
+                    code: '097'
+                    message: Invalid Total Liability IIR
+                Invalid DTT Election:
+                  value:
+                    code: '094'
+                    message: Invalid DTT Election
+                Invalid Return:
+                  value:
+                    code: '093'
+                    message: Invalid Return
+                Invalid Request:
+                  value:
+                    code: '003'
+                    message: Request could not be processed
+                Duplicate Submission:
+                  value:
+                    code: '004'
+                    message: Duplicate submission acknowledgment reference
+                Invalid Total Liability UTPR:
+                  value:
+                    code: '099'
+                    message: Invalid Total Liability UTPR
+                Invalid Total Liability:
+                  value:
+                    code: '096'
+                    message: Invalid Total Liability
+                Tax Obligation Fulfilled:
+                  value:
+                    code: '044'
+                    message: Tax Obligation already fulfilled
+                No Active Submission:
+                  value:
+                    code: '007'
+                    message: Business Partner does not have an active subscription
+                Invalid Total Liability DTT:
+                  value:
+                    code: '098'
+                    message: Invalid Total Liability DTT
         "401":
           description: Unauthorized
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
-              examples:
-                AuthenticationError:
-                  value:
-                    code: '003'
-                    message: Unauthorised
+              example:
+                code: '003'
+                message: Not authorized
     put:
       security:
       - userRestricted:
@@ -138,20 +198,24 @@ paths:
       summary: AmendUKTR
       responses:
         "400":
-          description: Invalid Submission
+          description: Bad Request
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
               examples:
-                InvalidJson:
+                Invalid Json:
                   value:
                     code: '001'
                     message: Invalid JSON payload
-                EmptyRequestBody:
+                Empty Request Body:
                   value:
                     code: '002'
                     message: Empty body in request
+                Missing Header:
+                  value:
+                    code: '005'
+                    message: Missing Header in request
         "500":
           description: Internal Server Error
           content:
@@ -159,11 +223,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
               examples:
-                GenericServerError:
+                Generic Server Error:
                   value:
                     code: 500
                     message: Internal Server Error
-                NoSubscriptionData:
+                No Subscription Data:
                   value:
                     code: '004'
                     message: No Pillar2 subscription found for -pillar2Id
@@ -182,6 +246,51 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              examples:
+                Invalid UTPR Election:
+                  value:
+                    code: '095'
+                    message: Invalid UTPR Election
+                Invalid Pillar2ID:
+                  value:
+                    code: '002'
+                    message: Pillar 2 ID missing or invalid
+                Invalid Total Liability IIR:
+                  value:
+                    code: '097'
+                    message: Invalid Total Liability IIR
+                Invalid DTT Election:
+                  value:
+                    code: '094'
+                    message: Invalid DTT Election
+                Invalid Return:
+                  value:
+                    code: '093'
+                    message: Invalid Return
+                Invalid Request:
+                  value:
+                    code: '003'
+                    message: Request could not be processed
+                Duplicate Submission:
+                  value:
+                    code: '004'
+                    message: Duplicate submission acknowledgment reference
+                Invalid Total Liability UTPR:
+                  value:
+                    code: '099'
+                    message: Invalid Total Liability UTPR
+                Invalid Total Liability:
+                  value:
+                    code: '096'
+                    message: Invalid Total Liability
+                No Active Submission:
+                  value:
+                    code: '007'
+                    message: Business Partner does not have an active subscription
+                Invalid Total Liability DTT:
+                  value:
+                    code: '098'
+                    message: Invalid Total Liability DTT
         "401":
           description: Unauthorized
           content:
@@ -190,7 +299,7 @@ paths:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
               example:
                 code: '003'
-                message: Unauthorised
+                message: Not authorized
         "200":
           description: UK Tax Return Submission Amended
           content:
@@ -247,20 +356,24 @@ paths:
       summary: SubmitBTN
       responses:
         "400":
-          description: Invalid Submission
+          description: Bad Request
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
               examples:
-                InvalidJson:
+                Invalid Json:
                   value:
                     code: '001'
                     message: Invalid JSON payload
-                EmptyRequestBody:
+                Empty Request Body:
                   value:
                     code: '002'
                     message: Empty body in request
+                Missing Header:
+                  value:
+                    code: '005'
+                    message: Missing Header in request
         "201":
           description: Below-Threshold Notification Submission Created
           content:
@@ -274,11 +387,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
               examples:
-                GenericServerError:
+                Generic Server Error:
                   value:
                     code: 500
                     message: Internal Server Error
-                NoSubscriptionData:
+                No Subscription Data:
                   value:
                     code: '004'
                     message: No Pillar2 subscription found for -pillar2Id
@@ -297,6 +410,27 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              examples:
+                Invalid Pillar2ID:
+                  value:
+                    code: '002'
+                    message: Pillar 2 ID missing or invalid
+                Invalid Request:
+                  value:
+                    code: '003'
+                    message: Request could not be processed
+                Tax Obligation Fulfilled:
+                  value:
+                    code: '044'
+                    message: Tax Obligation already fulfilled
+                Duplicate Acknowledgment:
+                  value:
+                    code: '004'
+                    message: Duplicate acknowledgment reference
+                No Active Submission:
+                  value:
+                    code: '007'
+                    message: Business Partner does not have an Active Pillar 2 registration
         "401":
           description: Unauthorized
           content:
@@ -305,7 +439,7 @@ paths:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
               example:
                 code: '003'
-                message: Unauthorised
+                message: Not authorized
 components:
   schemas:
     BTNSubmission:


### PR DESCRIPTION
This PR updates the API specifications by adding standardized error response examples to `app.routes` and generated a new `application.yaml` from it.

**Note:** During these updates, some inconsistencies in our API error handling were identified but not addressed in this PR. Additionally, each endpoint may require specific `422 Unprocessable Entity` error examples as they are a different set per endpoint.

## Changes

- **`conf/app.routes`:**
  - Added `401 Unauthorized` error responses with a generic message.
  - Provided examples for `InvalidJson`, `EmptyRequestBody`, `GenericServerError`, and `NoSubscriptionData`.
  - Generated a new `application.yaml` from this
  
## Inconsistencies Found

- **Malformed Response Handling:**
  - BTN endpoints return detailed JSON errors (`UnparsableResponse`) to the client, while UKTR endpoints use a generic "Internal Server Error" (`UnexpectedResponse`).
  
- **AuthenticationError Usage:**
  - All authentication errors currently map to `401 Unauthorized`, though some might be more appropriate as `403 Forbidden` or `400 Bad Request`.

These inconsistencies should probably be addressed in future PRs to ensure uniform error responses across the API.
