### PR TITLE
PIL-1606 : Update BTN endpoint to return generic 500 error message

### DIFF
--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandler.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandler.scala
@@ -43,7 +43,6 @@ class Pillar2ErrorHandler extends HttpErrorHandler with Logging {
           case e @ NoSubscriptionData(_)     => Results.InternalServerError(Pillar2ErrorResponse(e.code, e.message))
           case e @ UktrValidationError(_, _) => Results.UnprocessableEntity(Pillar2ErrorResponse(e.code, e.message))
           case e @ BTNValidationError(_, _)  => Results.UnprocessableEntity(Pillar2ErrorResponse(e.code, e.message))
-          case e @ UnparsableResponse(_)     => Results.InternalServerError(Pillar2ErrorResponse(e.code, e.message))
           case e @ UnexpectedResponse        => Results.InternalServerError(Pillar2ErrorResponse(e.code, e.message))
         }
         logger.warn(s"Caught Pillar2Error. Returning ${ret.header.status} statuscode", exception)

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/error/Pillar2Error.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/error/Pillar2Error.scala
@@ -57,9 +57,5 @@ case object ForbiddenError extends Pillar2Error {
 
 case class UktrValidationError(code: String, message: String) extends Pillar2Error
 
-case class UnparsableResponse(errors: String) extends Pillar2Error {
-  val code:    String = "500"
-  val message: String = errors
-}
 
 case class BTNValidationError(code: String, message: String) extends Pillar2Error

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/error/Pillar2Error.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/error/Pillar2Error.scala
@@ -57,5 +57,4 @@ case object ForbiddenError extends Pillar2Error {
 
 case class UktrValidationError(code: String, message: String) extends Pillar2Error
 
-
 case class BTNValidationError(code: String, message: String) extends Pillar2Error

--- a/test/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandlerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandlerSpec.scala
@@ -99,15 +99,6 @@ class Pillar2ErrorHandlerSpec extends AnyFunSuite with ScalaCheckDrivenPropertyC
     result.message mustEqual "Invalid Return"
   }
 
-  test("UnparsableResponse error response") {
-    val response =
-      classUnderTest.onServerError(dummyRequest, UnparsableResponse("Failed to parse success response: One of many errors!, Another error!"))
-    status(response) mustEqual 500
-    val result = contentAsJson(response).as[Pillar2ErrorResponse]
-    result.code mustEqual "500"
-    result.message mustEqual "Failed to parse success response: One of many errors!, Another error!"
-  }
-
   test("UnexpectedResponse error response") {
     val response = classUnderTest.onServerError(dummyRequest, UnexpectedResponse)
     status(response) mustEqual 500

--- a/test/uk/gov/hmrc/pillar2submissionapi/services/SubmitBTNServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/services/SubmitBTNServiceSpec.scala
@@ -49,18 +49,18 @@ class SubmitBTNServiceSpec extends UnitTestBaseSpec {
     }
   }
 
-  "submitBTN() unparsable 201 response back" should {
+  "submitBTN() unexpected 201 response back" should {
     "Runtime exception thrown" in {
 
       when(mockSubmitBTNConnector.submitBTN(any[BTNSubmission])(any[HeaderCarrier]))
-        .thenReturn(Future.successful(HttpResponse.apply(201, Json.toJson("unparsable success response"), Map.empty)))
+        .thenReturn(Future.successful(HttpResponse.apply(201, Json.toJson("unexpected success response"), Map.empty)))
 
-      intercept[UnparsableResponse](await(submitBTNService.submitBTN(validBTNSubmission)))
+      intercept[UnexpectedResponse.type](await(submitBTNService.submitBTN(validBTNSubmission)))
     }
   }
 
   "submitBTN() valid 422 response back" should {
-    "Runtime exception thrown (To be updated to the appropriate exception)" in {
+    "Runtime exception thrown" in {
 
       when(mockSubmitBTNConnector.submitBTN(any[BTNSubmission])(any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse.apply(422, Json.toJson(SubmitBTNErrorResponse("093", "Invalid Return")), Map.empty)))
@@ -69,13 +69,13 @@ class SubmitBTNServiceSpec extends UnitTestBaseSpec {
     }
   }
 
-  "submitBTN() unparsable 422 response back" should {
-    "Runtime exception thrown (To be updated to 500 Internal server error exception)" in {
+  "submitBTN() unexpected 422 response back" should {
+    "Runtime exception thrown" in {
 
       when(mockSubmitBTNConnector.submitBTN(any[BTNSubmission])(any[HeaderCarrier]))
-        .thenReturn(Future.successful(HttpResponse.apply(422, Json.toJson("unparsable error response"), Map.empty)))
+        .thenReturn(Future.successful(HttpResponse.apply(422, Json.toJson("unexpected error response"), Map.empty)))
 
-      intercept[UnparsableResponse](await(submitBTNService.submitBTN(validBTNSubmission)))
+      intercept[UnexpectedResponse.type](await(submitBTNService.submitBTN(validBTNSubmission)))
     }
   }
 


### PR DESCRIPTION
For malformed responses the BTN endpoint returns UnparsableResponse with a 500 status code and a detailed JSON validation errors, which are now removed and UnexpectedResponse will be returned with 500 status code and a generic error message.