### PR TITLE
PIL-1638 Add Test Organisation Endpoints

### DIFF
--- a/API Testing/bruno.json
+++ b/API Testing/bruno.json
@@ -10,6 +10,10 @@
     {
       "name": "UKTR Submissions",
       "path": "uktr"
+    },
+    {
+      "name": "Test Organisation",
+      "path": "test-organisation"
     }
   ],
   "ignore": [

--- a/API Testing/test-organisation/create-test-organisation.bru
+++ b/API Testing/test-organisation/create-test-organisation.bru
@@ -1,0 +1,43 @@
+meta {
+  name: Create Test Organisation
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{submissionsApiBaseUrl}}/test-only/organisation
+  body: json
+  auth: none
+}
+
+headers {
+  Accept: application/vnd.hmrc.1.0+json
+  Authorization: {{bearerToken}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "orgDetails": {
+      "domesticOnly": true,
+      "organisationName": "Test Organisation Ltd",
+      "registrationDate": "2024-01-01"
+    },
+    "accountingPeriod": {
+      "startDate": "2024-01-01",
+      "endDate": "2024-12-31"
+    }
+  }
+}
+
+tests {
+  test("should return 201 Created", function() {
+    expect(res.getStatus()).to.equal(201);
+  });
+  
+  test("should contain all required fields", function() {
+    expect(res.body.pillar2Id).to.not.be.undefined;
+    expect(res.body.organisation).to.not.be.undefined;
+    expect(res.body.organisation.lastUpdated).to.not.be.undefined;
+  });
+} 

--- a/API Testing/test-organisation/delete-test-organisation.bru
+++ b/API Testing/test-organisation/delete-test-organisation.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Delete Test Organisation
+  type: http
+  seq: 4
+}
+
+delete {
+  url: {{submissionsApiBaseUrl}}/test-only/organisation
+  auth: none
+}
+
+headers {
+  Accept: application/vnd.hmrc.1.0+json
+  Authorization: {{bearerToken}}
+}
+
+tests {
+  test("should return 204 No Content", function() {
+    expect(res.getStatus()).to.equal(204);
+  });
+} 

--- a/API Testing/test-organisation/get-test-organisation.bru
+++ b/API Testing/test-organisation/get-test-organisation.bru
@@ -1,0 +1,26 @@
+meta {
+  name: Get Test Organisation
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{submissionsApiBaseUrl}}/test-only/organisation
+  auth: none
+}
+
+headers {
+  Accept: application/vnd.hmrc.1.0+json
+  Authorization: {{bearerToken}}
+}
+
+tests {
+  test("should return 200 OK", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+  
+  test("should contain all required fields", function() {
+    expect(res.body.organisation).to.not.be.undefined;
+    expect(res.body.organisation.lastUpdated).to.not.be.undefined;
+  });
+} 

--- a/API Testing/test-organisation/update-test-organisation.bru
+++ b/API Testing/test-organisation/update-test-organisation.bru
@@ -1,0 +1,42 @@
+meta {
+  name: Update Test Organisation
+  type: http
+  seq: 3
+}
+
+put {
+  url: {{submissionsApiBaseUrl}}/test-only/organisation
+  body: json
+  auth: none
+}
+
+headers {
+  Accept: application/vnd.hmrc.1.0+json
+  Authorization: {{bearerToken}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "orgDetails": {
+      "domesticOnly": false,
+      "organisationName": "Updated Test Organisation Ltd",
+      "registrationDate": "2024-01-01"
+    },
+    "accountingPeriod": {
+      "startDate": "2024-01-01",
+      "endDate": "2024-12-31"
+    }
+  }
+}
+
+tests {
+  test("should return 200 OK", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+  
+  test("should contain all required fields", function() {
+    expect(res.body.organisation.orgDetails.organisationName).to.equal("Updated Test Organisation Ltd");
+    expect(res.body.organisation.lastUpdated).to.not.be.undefined;
+  });
+} 

--- a/app/uk/gov/hmrc/pillar2submissionapi/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/config/AppConfig.scala
@@ -23,7 +23,10 @@ import javax.inject.{Inject, Singleton}
 case class AppConfig @Inject() (servicesConfig: ServicesConfig) {
 
   lazy val pillar2BaseUrl: String = servicesConfig.baseUrl("pillar2")
+  lazy val stubBaseUrl:    String = servicesConfig.baseUrl("stub")
 
   lazy val allowTestUsers: Boolean =
     servicesConfig.getBoolean("features.allow-test-users")
+
+  lazy val testOrganisationEnabled: Boolean = servicesConfig.getBoolean("features.testOrganisationEnabled")
 }

--- a/app/uk/gov/hmrc/pillar2submissionapi/connectors/TestOrganisationConnector.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/connectors/TestOrganisationConnector.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2submissionapi.connectors
+
+import play.api.Logging
+import play.api.libs.json.Json
+import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.http.client.HttpClientV2
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.pillar2submissionapi.config.AppConfig
+import uk.gov.hmrc.pillar2submissionapi.controllers.error._
+import uk.gov.hmrc.pillar2submissionapi.models.organisation.{TestOrganisation, TestOrganisationWithId}
+
+import java.net.URI
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class TestOrganisationConnector @Inject() (
+  val config:  AppConfig,
+  val http:    HttpClientV2
+)(implicit ec: ExecutionContext)
+    extends Logging {
+
+  def createTestOrganisation(pillar2Id: String, request: TestOrganisation)(implicit hc: HeaderCarrier): Future[TestOrganisationWithId] = {
+    val url = s"${config.stubBaseUrl}/pillar2/test/organisation/$pillar2Id"
+    logger.info(s"Calling $url to create test organisation")
+
+    http
+      .post(URI.create(url).toURL)
+      .withBody(Json.toJson(request))
+      .execute[HttpResponse]
+      .map { response =>
+        response.status match {
+          case 201 => Json.parse(response.body).as[TestOrganisationWithId]
+          case 409 => throw OrganisationAlreadyExists(pillar2Id)
+          case 500 => throw DatabaseError("create")
+          case _ =>
+            logger.warn(s"Unexpected response from create organisation with status: ${response.status}")
+            throw UnexpectedResponse
+        }
+      }
+  }
+
+  def getTestOrganisation(pillar2Id: String)(implicit hc: HeaderCarrier): Future[TestOrganisationWithId] = {
+    val url = s"${config.stubBaseUrl}/pillar2/test/organisation/$pillar2Id"
+    logger.info(s"Calling $url to get test organisation")
+
+    http
+      .get(URI.create(url).toURL)
+      .execute[HttpResponse]
+      .map { response =>
+        response.status match {
+          case 200 => Json.parse(response.body).as[TestOrganisationWithId]
+          case 404 => throw OrganisationNotFound(pillar2Id)
+          case _ =>
+            logger.warn(s"Unexpected response from get organisation with status: ${response.status}")
+            throw UnexpectedResponse
+        }
+      }
+  }
+
+  def updateTestOrganisation(pillar2Id: String, request: TestOrganisation)(implicit hc: HeaderCarrier): Future[TestOrganisationWithId] = {
+    val url = s"${config.stubBaseUrl}/pillar2/test/organisation/$pillar2Id"
+    logger.info(s"Calling $url to update test organisation")
+
+    http
+      .put(URI.create(url).toURL)
+      .withBody(Json.toJson(request))
+      .execute[HttpResponse]
+      .map { response =>
+        response.status match {
+          case 200 => Json.parse(response.body).as[TestOrganisationWithId]
+          case 404 => throw OrganisationNotFound(pillar2Id)
+          case 500 => throw DatabaseError("update")
+          case _ =>
+            logger.warn(s"Unexpected response from update organisation with status: ${response.status}")
+            throw UnexpectedResponse
+        }
+      }
+  }
+
+  def deleteTestOrganisation(pillar2Id: String)(implicit hc: HeaderCarrier): Future[Unit] = {
+    val url = s"${config.stubBaseUrl}/pillar2/test/organisation/$pillar2Id"
+    logger.info(s"Calling $url to delete test organisation")
+
+    http
+      .delete(URI.create(url).toURL)
+      .execute[HttpResponse]
+      .map { response =>
+        response.status match {
+          case 204 => ()
+          case 404 => throw OrganisationNotFound(pillar2Id)
+          case 500 => throw DatabaseError("delete")
+          case _ =>
+            logger.warn(s"Unexpected response from delete organisation with status: ${response.status}")
+            throw UnexpectedResponse
+        }
+      }
+  }
+}

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandler.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandler.scala
@@ -35,15 +35,19 @@ class Pillar2ErrorHandler extends HttpErrorHandler with Logging {
       case e if e.isInstanceOf[Pillar2Error] =>
         val pillar2Error: Pillar2Error = e.asInstanceOf[Pillar2Error]
         val ret = pillar2Error match {
-          case e @ InvalidJson               => Results.BadRequest(Pillar2ErrorResponse(e.code, e.message))
-          case e @ EmptyRequestBody          => Results.BadRequest(Pillar2ErrorResponse(e.code, e.message))
-          case e @ MissingHeader(_)          => Results.BadRequest(Pillar2ErrorResponse(e.code, e.message))
-          case e @ AuthenticationError       => Results.Unauthorized(Pillar2ErrorResponse(e.code, e.message))
-          case e @ ForbiddenError            => Results.Forbidden(Pillar2ErrorResponse(e.code, e.message))
-          case e @ NoSubscriptionData(_)     => Results.InternalServerError(Pillar2ErrorResponse(e.code, e.message))
-          case e @ UktrValidationError(_, _) => Results.UnprocessableEntity(Pillar2ErrorResponse(e.code, e.message))
-          case e @ BTNValidationError(_, _)  => Results.UnprocessableEntity(Pillar2ErrorResponse(e.code, e.message))
-          case e @ UnexpectedResponse        => Results.InternalServerError(Pillar2ErrorResponse(e.code, e.message))
+          case e @ InvalidJson                  => Results.BadRequest(Pillar2ErrorResponse(e.code, e.message))
+          case e @ EmptyRequestBody             => Results.BadRequest(Pillar2ErrorResponse(e.code, e.message))
+          case e @ MissingHeader(_)             => Results.BadRequest(Pillar2ErrorResponse(e.code, e.message))
+          case e @ AuthenticationError          => Results.Unauthorized(Pillar2ErrorResponse(e.code, e.message))
+          case e @ ForbiddenError               => Results.Forbidden(Pillar2ErrorResponse(e.code, e.message))
+          case e @ NoSubscriptionData(_)        => Results.InternalServerError(Pillar2ErrorResponse(e.code, e.message))
+          case e @ UktrValidationError(_, _)    => Results.UnprocessableEntity(Pillar2ErrorResponse(e.code, e.message))
+          case e @ BTNValidationError(_, _)     => Results.UnprocessableEntity(Pillar2ErrorResponse(e.code, e.message))
+          case e @ OrganisationAlreadyExists(_) => Results.Conflict(Pillar2ErrorResponse(e.code, e.message))
+          case e @ OrganisationNotFound(_)      => Results.NotFound(Pillar2ErrorResponse(e.code, e.message))
+          case e @ DatabaseError(_)             => Results.InternalServerError(Pillar2ErrorResponse(e.code, e.message))
+          case e @ UnexpectedResponse           => Results.InternalServerError(Pillar2ErrorResponse(e.code, e.message))
+          case e @ TestEndpointDisabled()       => Results.Forbidden(Pillar2ErrorResponse(e.code, e.message))
         }
         logger.warn(s"Caught Pillar2Error. Returning ${ret.header.status} statuscode", exception)
         Future.successful(ret)

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/error/Pillar2Error.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/error/Pillar2Error.scala
@@ -58,3 +58,23 @@ case object ForbiddenError extends Pillar2Error {
 case class UktrValidationError(code: String, message: String) extends Pillar2Error
 
 case class BTNValidationError(code: String, message: String) extends Pillar2Error
+
+case class OrganisationAlreadyExists(pillar2Id: String) extends Pillar2Error {
+  override val code:    String = "409"
+  override val message: String = s"Organisation with pillar2Id: $pillar2Id already exists"
+}
+
+case class OrganisationNotFound(pillar2Id: String) extends Pillar2Error {
+  override val code:    String = "404"
+  override val message: String = s"Organisation not found for pillar2Id: $pillar2Id"
+}
+
+case class DatabaseError(operation: String) extends Pillar2Error {
+  override val code:    String = "500"
+  override val message: String = s"Failed to $operation organisation due to database error"
+}
+
+case class TestEndpointDisabled() extends Pillar2Error {
+  override val code:    String = "403"
+  override val message: String = "Test endpoints are not available in this environment"
+}

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/submission/BTNSubmissionController.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/submission/BTNSubmissionController.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.pillar2submissionapi.controllers
+package uk.gov.hmrc.pillar2submissionapi.controllers.submission
 
 import play.api.libs.json.{JsError, JsSuccess, Json}
 import play.api.mvc.{Action, AnyContent, ControllerComponents}

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/submission/UKTaxReturnController.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/submission/UKTaxReturnController.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.pillar2submissionapi.controllers
+package uk.gov.hmrc.pillar2submissionapi.controllers.submission
 
 import play.api.libs.json.Format.GenericFormat
 import play.api.libs.json.OFormat.oFormatFromReadsAndOWrites

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/test/TestOrganisationController.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/test/TestOrganisationController.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2submissionapi.controllers.test
+
+import play.api.libs.json.{JsError, JsSuccess, Json}
+import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import uk.gov.hmrc.pillar2submissionapi.config.AppConfig
+import uk.gov.hmrc.pillar2submissionapi.controllers.actions.IdentifierAction
+import uk.gov.hmrc.pillar2submissionapi.controllers.error.{EmptyRequestBody, InvalidJson, TestEndpointDisabled}
+import uk.gov.hmrc.pillar2submissionapi.models.organisation.TestOrganisationRequest
+import uk.gov.hmrc.pillar2submissionapi.services.TestOrganisationService
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class TestOrganisationController @Inject() (
+  cc:                      ControllerComponents,
+  identify:                IdentifierAction,
+  testOrganisationService: TestOrganisationService,
+  config:                  AppConfig
+)(implicit ec:             ExecutionContext)
+    extends BackendController(cc) {
+
+  private def checkTestEndpointsEnabled[A](block: => Future[A]): Future[A] =
+    if (config.testOrganisationEnabled) {
+      block
+    } else {
+      Future.failed(TestEndpointDisabled())
+    }
+
+  def createTestOrganisation: Action[AnyContent] = identify.async { implicit request =>
+    checkTestEndpointsEnabled {
+      request.body.asJson match {
+        case Some(json) =>
+          json.validate[TestOrganisationRequest] match {
+            case JsSuccess(value, _) =>
+              testOrganisationService
+                .createTestOrganisation(request.clientPillar2Id, value)
+                .map(response => Created(Json.toJson(response)))
+            case JsError(_) => Future.failed(InvalidJson)
+          }
+        case None => Future.failed(EmptyRequestBody)
+      }
+    }
+  }
+
+  def getTestOrganisation: Action[AnyContent] = identify.async { implicit request =>
+    checkTestEndpointsEnabled {
+      testOrganisationService
+        .getTestOrganisation(request.clientPillar2Id)
+        .map(response => Ok(Json.toJson(response)))
+    }
+  }
+
+  def updateTestOrganisation: Action[AnyContent] = identify.async { implicit request =>
+    checkTestEndpointsEnabled {
+      request.body.asJson match {
+        case Some(json) =>
+          json.validate[TestOrganisationRequest] match {
+            case JsSuccess(value, _) =>
+              testOrganisationService
+                .updateTestOrganisation(request.clientPillar2Id, value)
+                .map(response => Ok(Json.toJson(response)))
+            case JsError(_) => Future.failed(InvalidJson)
+          }
+        case None => Future.failed(EmptyRequestBody)
+      }
+    }
+  }
+
+  def deleteTestOrganisation: Action[AnyContent] = identify.async { implicit request =>
+    checkTestEndpointsEnabled {
+      testOrganisationService
+        .deleteTestOrganisation(request.clientPillar2Id)
+        .map(_ => NoContent)
+    }
+  }
+}

--- a/app/uk/gov/hmrc/pillar2submissionapi/models/organisation/TestOrganisation.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/models/organisation/TestOrganisation.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2submissionapi.models.organisation
+
+import play.api.libs.json.{Format, Json}
+
+import java.time.{Instant, LocalDate}
+
+case class OrgDetails(
+  domesticOnly:     Boolean,
+  organisationName: String,
+  registrationDate: LocalDate
+)
+
+object OrgDetails {
+  implicit val format: Format[OrgDetails] = Json.format[OrgDetails]
+}
+
+case class AccountingPeriod(
+  startDate: LocalDate,
+  endDate:   LocalDate
+)
+
+object AccountingPeriod {
+  implicit val format: Format[AccountingPeriod] = Json.format[AccountingPeriod]
+}
+
+case class TestOrganisationRequest(
+  orgDetails:       OrgDetails,
+  accountingPeriod: AccountingPeriod
+)
+
+object TestOrganisationRequest {
+  implicit val format: Format[TestOrganisationRequest] = Json.format[TestOrganisationRequest]
+}
+
+case class TestOrganisation(
+  orgDetails:       OrgDetails,
+  accountingPeriod: AccountingPeriod,
+  lastUpdated:      Instant = Instant.now()
+)
+
+object TestOrganisation {
+  implicit val format: Format[TestOrganisation] = Json.format[TestOrganisation]
+}
+
+case class TestOrganisationWithId(
+  pillar2Id:    String,
+  organisation: TestOrganisation
+)
+
+object TestOrganisationWithId {
+  implicit val format: Format[TestOrganisationWithId] = Json.format[TestOrganisationWithId]
+}

--- a/app/uk/gov/hmrc/pillar2submissionapi/models/response/StubErrorResponse.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/models/response/StubErrorResponse.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2submissionapi.models.response
+
+import play.api.libs.json.{Json, OFormat}
+
+case class StubErrorResponse(message: String)
+
+object StubErrorResponse {
+  implicit val format: OFormat[StubErrorResponse] = Json.format[StubErrorResponse]
+}

--- a/app/uk/gov/hmrc/pillar2submissionapi/services/TestOrganisationService.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/services/TestOrganisationService.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2submissionapi.services
+
+import play.api.Logging
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.pillar2submissionapi.connectors.TestOrganisationConnector
+import uk.gov.hmrc.pillar2submissionapi.models.organisation.{TestOrganisation, TestOrganisationRequest, TestOrganisationWithId}
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.Future
+
+@Singleton
+class TestOrganisationService @Inject() (
+  testOrganisationConnector: TestOrganisationConnector
+) extends Logging {
+
+  def createTestOrganisation(pillar2Id: String, request: TestOrganisationRequest)(implicit
+    hc:                                 HeaderCarrier
+  ): Future[TestOrganisationWithId] = {
+    val organisationDetails = TestOrganisation(request.orgDetails, request.accountingPeriod)
+    testOrganisationConnector.createTestOrganisation(pillar2Id, organisationDetails)
+  }
+
+  def getTestOrganisation(pillar2Id: String)(implicit hc: HeaderCarrier): Future[TestOrganisationWithId] =
+    testOrganisationConnector.getTestOrganisation(pillar2Id)
+
+  def updateTestOrganisation(pillar2Id: String, request: TestOrganisationRequest)(implicit
+    hc:                                 HeaderCarrier
+  ): Future[TestOrganisationWithId] = {
+    val organisationDetails = TestOrganisation(request.orgDetails, request.accountingPeriod)
+    testOrganisationConnector.updateTestOrganisation(pillar2Id, organisationDetails)
+  }
+
+  def deleteTestOrganisation(pillar2Id: String)(implicit hc: HeaderCarrier): Future[Unit] =
+    testOrganisationConnector.deleteTestOrganisation(pillar2Id)
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -26,6 +26,12 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientV2Module"
 play.modules.enabled += "uk.gov.hmrc.pillar2submissionapi.config.Module"
 
 play.http.errorHandler = "uk.gov.hmrc.pillar2submissionapi.controllers.Pillar2ErrorHandler"
+
+# Feature flags
+features {
+  testOrganisationEnabled = true
+}
+
 # The application languages
 # ~~~~~
 play.i18n.langs = ["en"]
@@ -53,9 +59,15 @@ microservice {
 
     pillar2 {
           protocol = http
-          host = localhost
-          port = 10051
-        }
+      host = localhost
+      port = 10051
+    }
+
+    stub {
+      protocol = http
+      host = localhost
+      port = 10055
+    }
   }
 }
 

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -1,4 +1,4 @@
 # Add all the application routes to the submission.routes file
-->         /                          submission.Routes
 ->         /                          health.Routes
 ->         /                          definition.Routes
+->         /                          public.Routes

--- a/conf/public.routes
+++ b/conf/public.routes
@@ -1,0 +1,2 @@
+->         /                          test_only.Routes
+->         /                          submission.Routes

--- a/conf/submission.routes
+++ b/conf/submission.routes
@@ -51,7 +51,7 @@
 #         schema:
 #           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
 ###
-POST       /uk-tax-return              uk.gov.hmrc.pillar2submissionapi.controllers.UKTaxReturnController.submitUKTR
+POST       /uk-tax-return              uk.gov.hmrc.pillar2submissionapi.controllers.submission.UKTaxReturnController.submitUKTR
 
 ###
 # summary: Amend a Pillar2 UK Tax Return
@@ -106,7 +106,7 @@ POST       /uk-tax-return              uk.gov.hmrc.pillar2submissionapi.controll
 #         schema:
 #           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
 ###
-PUT        /uk-tax-return              uk.gov.hmrc.pillar2submissionapi.controllers.UKTaxReturnController.amendUKTR
+PUT        /uk-tax-return              uk.gov.hmrc.pillar2submissionapi.controllers.submission.UKTaxReturnController.amendUKTR
 
 ###
 # summary: Submit a Pillar2 Below-Threshold Notification
@@ -159,4 +159,4 @@ PUT        /uk-tax-return              uk.gov.hmrc.pillar2submissionapi.controll
 #         schema:
 #           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
 ###
-POST       /below-threshold-notification              uk.gov.hmrc.pillar2submissionapi.controllers.BTNSubmissionController.submitBTN
+POST       /below-threshold-notification              uk.gov.hmrc.pillar2submissionapi.controllers.submission.BTNSubmissionController.submitBTN

--- a/conf/swagger.yml
+++ b/conf/swagger.yml
@@ -118,6 +118,32 @@ paths:
         </table>
       security:
         - userRestricted: [write:pillar2]
+  /test-only/organisation:
+    post:
+      summary: Create Test Organisation
+      description: |
+        Creates a test organisation associated with your authed organisation.
+      security:
+        - userRestricted: [write:pillar2]
+    get:
+      summary: Get Test Organisation
+      description: |
+        Gets a test organisation associated with your authed organisation.
+      security:
+        - userRestricted: [read:pillar2]
+    put:
+      summary: Update Test Organisation
+      description: |
+        Updates a test organisation associated with your authed organisation.
+      security:
+        - userRestricted: [write:pillar2]
+    delete:
+      summary: Delete Test Organisation
+      description: |
+        Deletes a test organisation associated with your authed organisation.
+      security:
+        - userRestricted: [write:pillar2]
+   
 components:
   securitySchemes:
     userRestricted:

--- a/conf/test_only.routes
+++ b/conf/test_only.routes
@@ -1,0 +1,312 @@
+###
+# summary: Create a test organisation associated with your authorised organisation
+# parameters:
+#   - in: header
+#     name: Authorization
+#     required: true
+#     schema:
+#       type: string
+#     description: Bearer token for authentication
+#   - in: header
+#     name: X-Pillar2-Id
+#     required: false
+#     schema:
+#       type: string
+#     description: "Pillar 2 Id - Pattern: [A-Z0-9]{1,15}. Only requred if you are authorised as an agent to specify which client's Pillar 2 Id to associate the test organisation."
+# requestBody:
+#   content:
+#     application/json:
+#         schema:
+#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.organisation.TestOrganisation'
+# responses:
+#   201:
+#      description: Test Organisation Created
+#      content:
+#        application/json:
+#          schema:
+#            $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.organisation.TestOrganisationWithId'
+#          example:
+#            pillar2Id: "XAPLR1234567890"
+#            organisation:
+#              orgDetails:
+#                domesticOnly: true
+#                organisationName: "Test Organisation Ltd"
+#                registrationDate: "2024-01-01"
+#              accountingPeriod:
+#                startDate: "2024-01-01"
+#                endDate: "2024-12-31"
+#              lastUpdated: "2024-01-01T12:00:00Z"
+#   400:
+#     description: Invalid Request
+#     content:
+#       application/json:
+#         schema:
+#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
+#         examples:
+#           invalid_json:
+#             value:
+#               code: "001"
+#               message: "Invalid JSON Payload"
+#           empty_body:
+#             value:
+#               code: "002"
+#               message: "Empty body in request"
+#   401:
+#     description: Unauthorized
+#     content:
+#       application/json:
+#         schema:
+#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
+#         example:
+#           code: "003"
+#           message: "Not authorized"
+#   403:
+#     description: Forbidden
+#     content:
+#       application/json:
+#         schema:
+#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
+#         example:
+#           code: "403"
+#           message: "Test endpoints are not available in this environment"
+#   409:
+#     description: Organisation Already Exists
+#     content:
+#       application/json:
+#         schema:
+#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
+#         example:
+#           code: "409"
+#           message: "Organisation with pillar2Id: XAPLR1234567890 already exists"
+#   500:
+#     description: Internal Server Error
+#     content:
+#       application/json:
+#         schema:
+#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
+#         example:
+#           code: "500"
+#           message: "Failed to create organisation due to database error"
+###
+POST /test-only/organisation              uk.gov.hmrc.pillar2submissionapi.controllers.test.TestOrganisationController.createTestOrganisation()
+
+###
+# summary: Get a test organisation associated with your authed organisation
+# parameters:
+#   - in: header
+#     name: Authorization
+#     required: true
+#     schema:
+#       type: string
+#     description: Bearer token for authentication
+#   - in: header
+#     name: X-Pillar2-Id
+#     required: false
+#     schema:
+#       type: string
+#     description: "Pillar 2 Id - Pattern: [A-Z0-9]{1,15}. Only requred if you are authorised as an agent to specify which client's Pillar 2 Id to associate the test organisation."
+# responses:
+#   200:
+#      description: Test Organisation Found
+#      content:
+#        application/json:
+#          schema:
+#            $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.organisation.TestOrganisationWithId'
+#          example:
+#            pillar2Id: "XAPLR1234567890"
+#            organisation:
+#              orgDetails:
+#                domesticOnly: true
+#                organisationName: "Test Organisation Ltd"
+#                registrationDate: "2024-01-01"
+#              accountingPeriod:
+#                startDate: "2024-01-01"
+#                endDate: "2024-12-31"
+#              lastUpdated: "2024-01-01T12:00:00Z"
+#   401:
+#     description: Unauthorized
+#     content:
+#       application/json:
+#         schema:
+#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
+#         example:
+#           code: "003"
+#           message: "Not authorized"
+#   403:
+#     description: Forbidden
+#     content:
+#       application/json:
+#         schema:
+#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
+#         example:
+#           code: "403"
+#           message: "Test endpoints are not available in this environment"
+#   404:
+#     description: Organisation Not Found
+#     content:
+#       application/json:
+#         schema:
+#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
+#         example:
+#           code: "404"
+#           message: "Organisation not found for pillar2Id: XAPLR1234567890"
+#   500:
+#     description: Internal Server Error
+#     content:
+#       application/json:
+#         schema:
+#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
+#         example:
+#           code: "500"
+#           message: "Internal Server Error"
+###
+GET /test-only/organisation                 uk.gov.hmrc.pillar2submissionapi.controllers.test.TestOrganisationController.getTestOrganisation
+
+###
+# summary: Update the test organisation associated with your authed organisation
+# parameters:
+#   - in: header
+#     name: Authorization
+#     required: true
+#     schema:
+#       type: string
+#     description: Bearer token for authentication
+#   - in: header
+#     name: X-Pillar2-Id
+#     required: false
+#     schema:
+#       type: string
+#     description: "Pillar 2 Id - Pattern: [A-Z0-9]{1,15}. Only requred if you are authorised as an agent to specify which client's Pillar 2 Id to associate the test organisation."
+# requestBody:
+#   content:
+#     application/json:
+#         schema:
+#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.organisation.TestOrganisation'
+# responses:
+#   200:
+#      description: Test Organisation Updated
+#      content:
+#        application/json:
+#          schema:
+#            $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.organisation.TestOrganisationWithId'
+#          example:
+#            pillar2Id: "XAPLR1234567890"
+#            organisation:
+#              orgDetails:
+#                domesticOnly: true
+#                organisationName: "Test Organisation Ltd"
+#                registrationDate: "2024-01-01"
+#              accountingPeriod:
+#                startDate: "2024-01-01"
+#                endDate: "2024-12-31"
+#              lastUpdated: "2024-01-01T12:00:00Z"
+#   400:
+#     description: Invalid Request
+#     content:
+#       application/json:
+#         schema:
+#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
+#         examples:
+#           invalid_json:
+#             value:
+#               code: "001"
+#               message: "Invalid JSON Payload"
+#           empty_body:
+#             value:
+#               code: "002"
+#               message: "Empty body in request"
+#   401:
+#     description: Unauthorized
+#     content:
+#       application/json:
+#         schema:
+#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
+#         example:
+#           code: "003"
+#           message: "Not authorized"
+#   403:
+#     description: Forbidden
+#     content:
+#       application/json:
+#         schema:
+#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
+#         example:
+#           code: "403"
+#           message: "Test endpoints are not available in this environment"
+#   404:
+#     description: Organisation Not Found
+#     content:
+#       application/json:
+#         schema:
+#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
+#         example:
+#           code: "404"
+#           message: "Organisation not found for pillar2Id: XAPLR1234567890"
+#   500:
+#     description: Internal Server Error
+#     content:
+#       application/json:
+#         schema:
+#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
+#         example:
+#           code: "500"
+#           message: "Failed to update organisation due to database error"
+###
+PUT /test-only/organisation              uk.gov.hmrc.pillar2submissionapi.controllers.test.TestOrganisationController.updateTestOrganisation
+
+###
+# summary: Delete the test organisation associated with your authed organisation
+# parameters:
+#   - in: header
+#     name: Authorization
+#     required: true
+#     schema:
+#       type: string
+#     description: Bearer token for authentication
+#   - in: header
+#     name: X-Pillar2-Id
+#     required: false
+#     schema:
+#       type: string
+#     description: "Pillar 2 Id - Pattern: [A-Z0-9]{1,15}. Only requred if you are authorised as an agent to specify which client's Pillar 2 Id to associate the test organisation."
+# responses:
+#   204:
+#      description: Test Organisation Deleted Successfully
+#   401:
+#     description: Unauthorized
+#     content:
+#       application/json:
+#         schema:
+#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
+#         example:
+#           code: "003"
+#           message: "Not authorized"
+#   403:
+#     description: Forbidden
+#     content:
+#       application/json:
+#         schema:
+#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
+#         example:
+#           code: "403"
+#           message: "Test endpoints are not available in this environment"
+#   404:
+#     description: Organisation Not Found
+#     content:
+#       application/json:
+#         schema:
+#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
+#         example:
+#           code: "404"
+#           message: "Organisation not found for pillar2Id: XAPLR1234567890"
+#   500:
+#     description: Internal Server Error
+#     content:
+#       application/json:
+#         schema:
+#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
+#         example:
+#           code: "500"
+#           message: "Failed to delete organisation due to database error"
+###
+DELETE /test-only/organisation           uk.gov.hmrc.pillar2submissionapi.controllers.test.TestOrganisationController.deleteTestOrganisation

--- a/it/test/uk/gov/hmrc/pillar2submissionapi/BTNSubmissionISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2submissionapi/BTNSubmissionISpec.scala
@@ -32,7 +32,7 @@ import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2submissionapi.BTNSubmissionISpec._
 import uk.gov.hmrc.pillar2submissionapi.base.IntegrationSpecBase
 import uk.gov.hmrc.pillar2submissionapi.controllers.error.AuthenticationError
-import uk.gov.hmrc.pillar2submissionapi.controllers.routes
+import uk.gov.hmrc.pillar2submissionapi.controllers.submission.routes
 import uk.gov.hmrc.pillar2submissionapi.helpers.TestAuthRetrievals.Ops
 import uk.gov.hmrc.pillar2submissionapi.models.belowthresholdnotification.{SubmitBTNErrorResponse, SubmitBTNSuccessResponse}
 import uk.gov.hmrc.pillar2submissionapi.models.subscription.SubscriptionSuccess

--- a/it/test/uk/gov/hmrc/pillar2submissionapi/TestOrganisationISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2submissionapi/TestOrganisationISpec.scala
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2submissionapi
+
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatest.OptionValues
+import play.api.http.Status._
+import play.api.libs.json.{JsObject, JsValue, Json}
+import uk.gov.hmrc.auth.core.authorise.Predicate
+import uk.gov.hmrc.auth.core.retrieve.Retrieval
+import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.http.client.HttpClientV2
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.pillar2submissionapi.base.IntegrationSpecBase
+import uk.gov.hmrc.pillar2submissionapi.controllers.error.AuthenticationError
+import uk.gov.hmrc.pillar2submissionapi.models.organisation._
+import uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse
+import uk.gov.hmrc.play.bootstrap.http.HttpClientV2Provider
+
+import java.net.URI
+import java.time.{Instant, LocalDate}
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, ExecutionContext, Future}
+class TestOrganisationISpec extends IntegrationSpecBase with OptionValues {
+
+  lazy val provider: HttpClientV2Provider = app.injector.instanceOf[HttpClientV2Provider]
+  lazy val client:   HttpClientV2         = provider.get()
+  lazy val baseUrl = s"http://localhost:$port/test-only/organisation"
+
+  private val stubUrl = "/pillar2/test/organisation"
+
+  "TestOrganisationController" when {
+    "createTestOrganisation" must {
+      "return 201 CREATED for valid request" in {
+        stubRequest(
+          "POST",
+          s"$stubUrl/$plrReference",
+          CREATED,
+          Json.toJson(validOrganisationWithId)
+        )
+
+        val result = Await.result(
+          client
+            .post(URI.create(baseUrl).toURL)
+            .withBody(validRequestJson)
+            .execute[HttpResponse],
+          5.seconds
+        )
+
+        result.status mustEqual CREATED
+      }
+
+      "return 400 BAD_REQUEST for invalid request body" in {
+        val result = Await.result(
+          client
+            .post(URI.create(baseUrl).toURL)
+            .withBody(invalidRequestJson)
+            .execute[HttpResponse],
+          5.seconds
+        )
+
+        result.status mustEqual BAD_REQUEST
+      }
+
+      "return 409 CONFLICT when organisation already exists" in {
+        stubRequest(
+          "POST",
+          s"$stubUrl/$plrReference",
+          CONFLICT,
+          Json.toJson(Pillar2ErrorResponse("409", s"Organisation with pillar2Id: $plrReference already exists"))
+        )
+
+        val result = Await.result(
+          client
+            .post(URI.create(baseUrl).toURL)
+            .withBody(validRequestJson)
+            .execute[HttpResponse],
+          5.seconds
+        )
+
+        result.status mustEqual CONFLICT
+      }
+
+      "return 401 UNAUTHORIZED when user cannot be identified" in {
+        when(
+          mockAuthConnector
+            .authorise[RetrievalsType](any[Predicate](), any[Retrieval[RetrievalsType]]())(any[HeaderCarrier](), any[ExecutionContext]())
+        ).thenReturn(Future.failed(AuthenticationError))
+
+        val result = Await.result(
+          client
+            .post(URI.create(baseUrl).toURL)
+            .withBody(validRequestJson)
+            .execute[HttpResponse],
+          5.seconds
+        )
+
+        result.status mustEqual UNAUTHORIZED
+      }
+    }
+
+    "getTestOrganisation" must {
+
+      "return 200 OK with organisation details" in {
+        stubRequest(
+          "GET",
+          s"$stubUrl/$plrReference",
+          OK,
+          Json.toJson(validOrganisationWithId)
+        )
+
+        val result = Await.result(
+          client
+            .get(URI.create(baseUrl).toURL)
+            .execute[HttpResponse],
+          5.seconds
+        )
+
+        result.status mustEqual OK
+      }
+
+      "return 404 NOT_FOUND when organisation doesn't exist" in {
+        stubRequest(
+          "GET",
+          s"$stubUrl/$plrReference",
+          NOT_FOUND,
+          Json.toJson(Pillar2ErrorResponse("404", s"Organisation not found for pillar2Id: $plrReference"))
+        )
+
+        val result = Await.result(
+          client
+            .get(URI.create(baseUrl).toURL)
+            .execute[HttpResponse],
+          5.seconds
+        )
+
+        result.status mustEqual NOT_FOUND
+      }
+    }
+
+    "updateTestOrganisation" must {
+
+      "return 200 OK for valid update request" in {
+        stubRequest(
+          "PUT",
+          s"$stubUrl/$plrReference",
+          OK,
+          Json.toJson(validOrganisationWithId)
+        )
+
+        val result = Await.result(
+          client
+            .put(URI.create(baseUrl).toURL)
+            .withBody(validRequestJson)
+            .execute[HttpResponse],
+          5.seconds
+        )
+
+        result.status mustEqual OK
+      }
+
+      "return 404 NOT_FOUND when updating non-existent organisation" in {
+        stubRequest(
+          "PUT",
+          s"$stubUrl/$plrReference",
+          NOT_FOUND,
+          Json.toJson(Pillar2ErrorResponse("404", s"Organisation not found for pillar2Id: $plrReference"))
+        )
+
+        val result = Await.result(
+          client
+            .put(URI.create(baseUrl).toURL)
+            .withBody(validRequestJson)
+            .execute[HttpResponse],
+          5.seconds
+        )
+
+        result.status mustEqual NOT_FOUND
+      }
+    }
+
+    "deleteTestOrganisation" must {
+
+      "return 204 NO_CONTENT for successful deletion" in {
+        stubRequest(
+          "DELETE",
+          s"$stubUrl/$plrReference",
+          NO_CONTENT,
+          JsObject.empty
+        )
+
+        val result = Await.result(
+          client
+            .delete(URI.create(baseUrl).toURL)
+            .execute[HttpResponse],
+          5.seconds
+        )
+
+        result.status mustEqual NO_CONTENT
+      }
+
+      "return 404 NOT_FOUND when deleting non-existent organisation" in {
+        stubRequest(
+          "DELETE",
+          s"$stubUrl/$plrReference",
+          NOT_FOUND,
+          Json.toJson(Pillar2ErrorResponse("404", s"Organisation not found for pillar2Id: $plrReference"))
+        )
+
+        val result = Await.result(
+          client
+            .delete(URI.create(baseUrl).toURL)
+            .execute[HttpResponse],
+          5.seconds
+        )
+
+        result.status mustEqual NOT_FOUND
+      }
+    }
+  }
+
+  val validRequestJson: JsValue = Json.obj(
+    "orgDetails" -> Json.obj(
+      "domesticOnly"     -> true,
+      "organisationName" -> "Test Organisation Ltd",
+      "registrationDate" -> "2024-01-01"
+    ),
+    "accountingPeriod" -> Json.obj(
+      "startDate" -> "2024-01-01",
+      "endDate"   -> "2024-12-31"
+    )
+  )
+
+  val invalidRequestJson: JsValue = Json.obj(
+    "invalidField" -> "invalidValue"
+  )
+
+  val validOrganisation = TestOrganisation(
+    orgDetails = OrgDetails(
+      domesticOnly = true,
+      organisationName = "Test Organisation Ltd",
+      registrationDate = LocalDate.of(2024, 1, 1)
+    ),
+    accountingPeriod = AccountingPeriod(
+      startDate = LocalDate.of(2024, 1, 1),
+      endDate = LocalDate.of(2024, 12, 31)
+    ),
+    lastUpdated = Instant.parse("2024-01-01T12:00:00Z")
+  )
+
+  val validOrganisationWithId = TestOrganisationWithId(
+    pillar2Id = plrReference,
+    organisation = validOrganisation
+  )
+}

--- a/it/test/uk/gov/hmrc/pillar2submissionapi/UKTaxReturnISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2submissionapi/UKTaxReturnISpec.scala
@@ -33,7 +33,7 @@ import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2submissionapi.base.IntegrationSpecBase
 import uk.gov.hmrc.pillar2submissionapi.controllers.error.AuthenticationError
-import uk.gov.hmrc.pillar2submissionapi.controllers.routes
+import uk.gov.hmrc.pillar2submissionapi.controllers.submission.routes
 import uk.gov.hmrc.pillar2submissionapi.helpers.TestAuthRetrievals.Ops
 import uk.gov.hmrc.pillar2submissionapi.helpers.UKTRErrorCodes.INVALID_RETURN_093
 import uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse

--- a/it/test/uk/gov/hmrc/pillar2submissionapi/base/IntegrationSpecBase.scala
+++ b/it/test/uk/gov/hmrc/pillar2submissionapi/base/IntegrationSpecBase.scala
@@ -107,6 +107,8 @@ trait IntegrationSpecBase
 
   override lazy val app: Application = new GuiceApplicationBuilder()
     .configure("microservice.services.pillar2.port" -> wiremockPort)
+    .configure("microservice.services.stub.port" -> wiremockPort)
+    .configure("features.testOrganisationEnabled" -> true)
     .overrides(
       inject.bind[AuthConnector].toInstance(mockAuthConnector)
     )

--- a/project/PlaySwagger.scala
+++ b/project/PlaySwagger.scala
@@ -6,9 +6,11 @@ object PlaySwagger {
     swaggerDomainNameSpaces := Seq(
       "uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions",
       "uk.gov.hmrc.pillar2submissionapi.models.belowthresholdnotification",
-      "uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+      "uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse",
+      "uk.gov.hmrc.pillar2submissionapi.models.response.StubErrorResponse",
+      "uk.gov.hmrc.pillar2submissionapi.models.organisation"
     ),
-    swaggerRoutesFile := "submission.routes",
+    swaggerRoutesFile := "public.routes",
     swaggerV3 := true,
     swaggerPrettyJson := true
   )

--- a/resources/public/api/conf/1.0/application.yaml
+++ b/resources/public/api/conf/1.0/application.yaml
@@ -1,11 +1,353 @@
 openapi: 3.0.3
 info:
-  version: 0.72.0
+  version: 0.75.0
   title: Pillar 2 API
   description: An API for managing and retrieving data in accordance with Pillar 2
     tax rules.
 tags: []
 paths:
+  /organisations/pillar-two/test-only/organisation:
+    post:
+      security:
+      - userRestricted:
+        - write:pillar2
+      description: |
+        Creates a test organisation associated with your authed organisation.
+      tags:
+      - test_only
+      operationId: createTestOrganisation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TestOrganisation"
+      parameters:
+      - name: Authorization
+        in: header
+        description: Bearer token for authentication
+        schema:
+          type: string
+        required: true
+      - name: X-Pillar2-Id
+        in: header
+        description: "Pillar 2 Id - Pattern: [A-Z0-9]{1,15}. Only requred if you are\
+          \ authorised as an agent to specify which client's Pillar 2 Id to associate\
+          \ the test organisation."
+        schema:
+          type: string
+        required: false
+      summary: Create Test Organisation
+      responses:
+        "400":
+          description: Invalid Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              examples:
+                invalid_json:
+                  value:
+                    code: '001'
+                    message: Invalid JSON Payload
+                empty_body:
+                  value:
+                    code: '002'
+                    message: Empty body in request
+        "201":
+          description: Test Organisation Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TestOrganisationWithId"
+              example:
+                pillar2Id: XAPLR1234567890
+                organisation:
+                  orgDetails:
+                    domesticOnly: true
+                    organisationName: Test Organisation Ltd
+                    registrationDate: 2024-01-01
+                  accountingPeriod:
+                    startDate: 2024-01-01
+                    endDate: 2024-12-31
+                  lastUpdated: 2024-01-01T12:00:00Z
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              example:
+                code: 500
+                message: Failed to create organisation due to database error
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              example:
+                code: 403
+                message: Test endpoints are not available in this environment
+        "409":
+          description: Organisation Already Exists
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              example:
+                code: 409
+                message: "Organisation with pillar2Id: XAPLR1234567890 already exists"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              example:
+                code: '003'
+                message: Not authorized
+    get:
+      security:
+      - userRestricted:
+        - read:pillar2
+      description: |
+        Gets a test organisation associated with your authed organisation.
+      tags:
+      - test_only
+      operationId: getTestOrganisation
+      parameters:
+      - name: Authorization
+        in: header
+        description: Bearer token for authentication
+        schema:
+          type: string
+        required: true
+      - name: X-Pillar2-Id
+        in: header
+        description: "Pillar 2 Id - Pattern: [A-Z0-9]{1,15}. Only requred if you are\
+          \ authorised as an agent to specify which client's Pillar 2 Id to associate\
+          \ the test organisation."
+        schema:
+          type: string
+        required: false
+      summary: Get Test Organisation
+      responses:
+        "404":
+          description: Organisation Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              example:
+                code: 404
+                message: "Organisation not found for pillar2Id: XAPLR1234567890"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              example:
+                code: 500
+                message: Internal Server Error
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              example:
+                code: 403
+                message: Test endpoints are not available in this environment
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              example:
+                code: '003'
+                message: Not authorized
+        "200":
+          description: Test Organisation Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TestOrganisationWithId"
+              example:
+                pillar2Id: XAPLR1234567890
+                organisation:
+                  orgDetails:
+                    domesticOnly: true
+                    organisationName: Test Organisation Ltd
+                    registrationDate: 2024-01-01
+                  accountingPeriod:
+                    startDate: 2024-01-01
+                    endDate: 2024-12-31
+                  lastUpdated: 2024-01-01T12:00:00Z
+    put:
+      security:
+      - userRestricted:
+        - write:pillar2
+      description: |
+        Updates a test organisation associated with your authed organisation.
+      tags:
+      - test_only
+      operationId: updateTestOrganisation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TestOrganisation"
+      parameters:
+      - name: Authorization
+        in: header
+        description: Bearer token for authentication
+        schema:
+          type: string
+        required: true
+      - name: X-Pillar2-Id
+        in: header
+        description: "Pillar 2 Id - Pattern: [A-Z0-9]{1,15}. Only requred if you are\
+          \ authorised as an agent to specify which client's Pillar 2 Id to associate\
+          \ the test organisation."
+        schema:
+          type: string
+        required: false
+      summary: Update Test Organisation
+      responses:
+        "400":
+          description: Invalid Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              examples:
+                invalid_json:
+                  value:
+                    code: '001'
+                    message: Invalid JSON Payload
+                empty_body:
+                  value:
+                    code: '002'
+                    message: Empty body in request
+        "404":
+          description: Organisation Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              example:
+                code: 404
+                message: "Organisation not found for pillar2Id: XAPLR1234567890"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              example:
+                code: 500
+                message: Failed to update organisation due to database error
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              example:
+                code: 403
+                message: Test endpoints are not available in this environment
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              example:
+                code: '003'
+                message: Not authorized
+        "200":
+          description: Test Organisation Updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TestOrganisationWithId"
+              example:
+                pillar2Id: XAPLR1234567890
+                organisation:
+                  orgDetails:
+                    domesticOnly: true
+                    organisationName: Test Organisation Ltd
+                    registrationDate: 2024-01-01
+                  accountingPeriod:
+                    startDate: 2024-01-01
+                    endDate: 2024-12-31
+                  lastUpdated: 2024-01-01T12:00:00Z
+    delete:
+      security:
+      - userRestricted:
+        - write:pillar2
+      description: |
+        Deletes a test organisation associated with your authed organisation.
+      tags:
+      - test_only
+      operationId: deleteTestOrganisation
+      parameters:
+      - name: Authorization
+        in: header
+        description: Bearer token for authentication
+        schema:
+          type: string
+        required: true
+      - name: X-Pillar2-Id
+        in: header
+        description: "Pillar 2 Id - Pattern: [A-Z0-9]{1,15}. Only requred if you are\
+          \ authorised as an agent to specify which client's Pillar 2 Id to associate\
+          \ the test organisation."
+        schema:
+          type: string
+        required: false
+      summary: Delete Test Organisation
+      responses:
+        "404":
+          description: Organisation Not Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              example:
+                code: 404
+                message: "Organisation not found for pillar2Id: XAPLR1234567890"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              example:
+                code: 500
+                message: Failed to delete organisation due to database error
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              example:
+                code: 403
+                message: Test endpoints are not available in this environment
+        "204":
+          description: Test Organisation Deleted Successfully
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              example:
+                code: '003'
+                message: Not authorized
   /organisations/pillar-two/uk-tax-return:
     post:
       security:
@@ -261,6 +603,19 @@ paths:
                 message: Not authorized
 components:
   schemas:
+    TestOrganisation:
+      properties:
+        orgDetails:
+          $ref: "#/components/schemas/OrgDetails"
+        accountingPeriod:
+          $ref: "#/components/schemas/AccountingPeriod"
+        lastUpdated:
+          type: string
+          format: date-time
+      required:
+      - orgDetails
+      - accountingPeriod
+      - lastUpdated
     BTNSubmission:
       properties:
         accountingPeriodFrom:
@@ -322,6 +677,39 @@ components:
       - amountOwedDTT
       - amountOwedIIR
       - amountOwedUTPR
+    AccountingPeriod:
+      properties:
+        startDate:
+          type: string
+          format: date
+        endDate:
+          type: string
+          format: date
+      required:
+      - startDate
+      - endDate
+    TestOrganisationWithId:
+      properties:
+        pillar2Id:
+          type: string
+        organisation:
+          $ref: "#/components/schemas/TestOrganisation"
+      required:
+      - pillar2Id
+      - organisation
+    OrgDetails:
+      properties:
+        domesticOnly:
+          type: boolean
+        organisationName:
+          type: string
+        registrationDate:
+          type: string
+          format: date
+      required:
+      - domesticOnly
+      - organisationName
+      - registrationDate
     responses.UKTRSubmitSuccessResponse:
       properties:
         processingDate:

--- a/test/uk/gov/hmrc/pillar2submissionapi/base/ControllerBaseSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/base/ControllerBaseSpec.scala
@@ -32,6 +32,7 @@ import uk.gov.hmrc.pillar2submissionapi.connectors.SubscriptionConnector
 import uk.gov.hmrc.pillar2submissionapi.controllers.actions.{AuthenticatedIdentifierAction, SubscriptionDataRetrievalAction}
 import uk.gov.hmrc.pillar2submissionapi.helpers.{SubscriptionDataFixture, UKTaxReturnDataFixture}
 import uk.gov.hmrc.pillar2submissionapi.models.requests.{IdentifierRequest, SubscriptionDataRequest}
+import uk.gov.hmrc.pillar2submissionapi.services.TestOrganisationService
 import uk.gov.hmrc.pillar2submissionapi.services.{SubmitBTNService, UKTaxReturnService}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
@@ -47,9 +48,10 @@ trait ControllerBaseSpec extends PlaySpec with Results with Matchers with Mockit
   val mockAuthConnector:          AuthConnector         = mock[AuthConnector]
   val mockSubscriptionConnector:  SubscriptionConnector = mock[SubscriptionConnector]
 
-  val mockUkTaxReturnService: UKTaxReturnService = mock[UKTaxReturnService]
-  val mockSubmitBTNService:   SubmitBTNService   = mock[SubmitBTNService]
-  val appConfig:              AppConfig          = AppConfig(new ServicesConfig(Configuration.empty))
+  val mockUkTaxReturnService:      UKTaxReturnService      = mock[UKTaxReturnService]
+  val mockSubmitBTNService:        SubmitBTNService        = mock[SubmitBTNService]
+  val mockTestOrganisationService: TestOrganisationService = mock[TestOrganisationService]
+  val appConfig:                   AppConfig               = AppConfig(new ServicesConfig(Configuration.empty))
   implicit val identifierAction: AuthenticatedIdentifierAction = new AuthenticatedIdentifierAction(
     mockAuthConnector,
     new BodyParsers.Default,

--- a/test/uk/gov/hmrc/pillar2submissionapi/base/UnitTestBaseSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/base/UnitTestBaseSpec.scala
@@ -29,6 +29,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.test.HttpClientSupport
 import uk.gov.hmrc.pillar2submissionapi.connectors.SubmitBTNConnector
+import uk.gov.hmrc.pillar2submissionapi.connectors.TestOrganisationConnector
 import uk.gov.hmrc.pillar2submissionapi.connectors.UKTaxReturnConnector
 import uk.gov.hmrc.pillar2submissionapi.helpers.{UKTaxReturnDataFixture, WireMockServerHandler}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
@@ -51,10 +52,11 @@ trait UnitTestBaseSpec
   implicit lazy val system:       ActorSystem          = ActorSystem()
   implicit lazy val materializer: Materializer         = Materializer(system)
 
-  protected val mockConfiguration:        Configuration        = mock[Configuration]
-  protected val mockServicesConfig:       ServicesConfig       = mock[ServicesConfig]
-  protected val mockHttpClient:           HttpClientV2         = mock[HttpClientV2]
-  protected val mockPillar2Connector:     UKTaxReturnConnector = mock[UKTaxReturnConnector]
-  protected val mockUKTaxReturnConnector: UKTaxReturnConnector = mock[UKTaxReturnConnector]
-  protected val mockSubmitBTNConnector:   SubmitBTNConnector   = mock[SubmitBTNConnector]
+  protected val mockConfiguration:             Configuration             = mock[Configuration]
+  protected val mockServicesConfig:            ServicesConfig            = mock[ServicesConfig]
+  protected val mockHttpClient:                HttpClientV2              = mock[HttpClientV2]
+  protected val mockPillar2Connector:          UKTaxReturnConnector      = mock[UKTaxReturnConnector]
+  protected val mockUKTaxReturnConnector:      UKTaxReturnConnector      = mock[UKTaxReturnConnector]
+  protected val mockSubmitBTNConnector:        SubmitBTNConnector        = mock[SubmitBTNConnector]
+  protected val mockTestOrganisationConnector: TestOrganisationConnector = mock[TestOrganisationConnector]
 }

--- a/test/uk/gov/hmrc/pillar2submissionapi/connectors/TestOrganisationConnectorSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/connectors/TestOrganisationConnectorSpec.scala
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2submissionapi.connectors
+
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import play.api.http.Status._
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.{JsObject, Json}
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
+import play.api.{Application, Configuration}
+import uk.gov.hmrc.pillar2submissionapi.base.UnitTestBaseSpec
+import uk.gov.hmrc.pillar2submissionapi.controllers.error._
+import uk.gov.hmrc.pillar2submissionapi.models.organisation.{AccountingPeriod, OrgDetails, TestOrganisation}
+
+import java.time.{Instant, LocalDate}
+
+class TestOrganisationConnectorSpec extends UnitTestBaseSpec {
+
+  lazy val connector: TestOrganisationConnector = app.injector.instanceOf[TestOrganisationConnector]
+
+  override def fakeApplication(): Application = new GuiceApplicationBuilder()
+    .configure(Configuration("microservice.services.stub.port" -> server.port()))
+    .build()
+
+  private def url(pillar2Id: String) = s"/pillar2/test/organisation/$pillar2Id"
+
+  "TestOrganisationConnector" when {
+    "createTestOrganisation" must {
+      "return 201 CREATED for valid request" in {
+        stubRequest("POST", url(pillar2Id), CREATED, validResponseJson)
+
+        val result = await(connector.createTestOrganisation(pillar2Id, validOrganisationDetails)(hc))
+
+        result.pillar2Id                                shouldBe pillar2Id
+        result.organisation.orgDetails.organisationName shouldBe "Test Organisation Ltd"
+      }
+
+      "return 409 CONFLICT when organisation already exists" in {
+        val errorResponse = Json.obj(
+          "code"    -> "409",
+          "message" -> s"Organisation with pillar2Id: $pillar2Id already exists"
+        )
+        stubRequest("POST", url(pillar2Id), CONFLICT, errorResponse)
+
+        intercept[OrganisationAlreadyExists] {
+          await(connector.createTestOrganisation(pillar2Id, validOrganisationDetails)(hc))
+        }
+      }
+
+      "return DatabaseError when receiving 500 INTERNAL_SERVER_ERROR" in {
+        val errorResponse = Json.obj(
+          "code"    -> "500",
+          "message" -> "Database error"
+        )
+        stubRequest("POST", url(pillar2Id), INTERNAL_SERVER_ERROR, errorResponse)
+
+        intercept[DatabaseError] {
+          await(connector.createTestOrganisation(pillar2Id, validOrganisationDetails)(hc))
+        }.operation shouldBe "create"
+      }
+
+      "return UnexpectedResponse for any other status code" in {
+        stubRequest("POST", url(pillar2Id), BAD_REQUEST, Json.obj())
+
+        intercept[UnexpectedResponse.type] {
+          await(connector.createTestOrganisation(pillar2Id, validOrganisationDetails)(hc))
+        }
+      }
+    }
+
+    "getTestOrganisation" must {
+      "return organisation details for valid request" in {
+        stubRequest("GET", url(pillar2Id), OK, validResponseJson)
+
+        val result = await(connector.getTestOrganisation(pillar2Id)(hc))
+
+        result.pillar2Id                                shouldBe pillar2Id
+        result.organisation.orgDetails.organisationName shouldBe "Test Organisation Ltd"
+      }
+
+      "return 404 NOT_FOUND when organisation doesn't exist" in {
+        val errorResponse = Json.obj(
+          "code"    -> "404",
+          "message" -> s"Organisation not found for pillar2Id: $pillar2Id"
+        )
+        stubRequest("GET", url(pillar2Id), NOT_FOUND, errorResponse)
+
+        intercept[OrganisationNotFound] {
+          await(connector.getTestOrganisation(pillar2Id)(hc))
+        }
+      }
+
+      "return UnexpectedResponse for any other status code" in {
+        stubRequest("GET", url(pillar2Id), BAD_REQUEST, Json.obj())
+
+        intercept[UnexpectedResponse.type] {
+          await(connector.getTestOrganisation(pillar2Id)(hc))
+        }
+      }
+    }
+
+    "updateTestOrganisation" must {
+      "return updated organisation details for valid request" in {
+        stubRequest("PUT", url(pillar2Id), OK, validResponseJson)
+
+        val result = await(connector.updateTestOrganisation(pillar2Id, validOrganisationDetails)(hc))
+
+        result.pillar2Id                                shouldBe pillar2Id
+        result.organisation.orgDetails.organisationName shouldBe "Test Organisation Ltd"
+      }
+
+      "return 404 NOT_FOUND when organisation doesn't exist" in {
+        val errorResponse = Json.obj(
+          "code"    -> "404",
+          "message" -> s"Organisation not found for pillar2Id: $pillar2Id"
+        )
+        stubRequest("PUT", url(pillar2Id), NOT_FOUND, errorResponse)
+
+        intercept[OrganisationNotFound] {
+          await(connector.updateTestOrganisation(pillar2Id, validOrganisationDetails)(hc))
+        }
+      }
+
+      "return DatabaseError when receiving 500 INTERNAL_SERVER_ERROR" in {
+        val errorResponse = Json.obj(
+          "code"    -> "500",
+          "message" -> "Database error"
+        )
+        stubRequest("PUT", url(pillar2Id), INTERNAL_SERVER_ERROR, errorResponse)
+
+        intercept[DatabaseError] {
+          await(connector.updateTestOrganisation(pillar2Id, validOrganisationDetails)(hc))
+        }.operation shouldBe "update"
+      }
+
+      "return UnexpectedResponse for any other status code" in {
+        stubRequest("PUT", url(pillar2Id), BAD_REQUEST, Json.obj())
+
+        intercept[UnexpectedResponse.type] {
+          await(connector.updateTestOrganisation(pillar2Id, validOrganisationDetails)(hc))
+        }
+      }
+    }
+
+    "deleteTestOrganisation" must {
+      "return 204 NO_CONTENT for valid request" in {
+        stubRequest("DELETE", url(pillar2Id), NO_CONTENT, JsObject.empty)
+
+        val result = await(connector.deleteTestOrganisation(pillar2Id)(hc))
+
+        result shouldBe (())
+      }
+
+      "return 404 NOT_FOUND when organisation doesn't exist" in {
+        val errorResponse = Json.obj(
+          "code"    -> "404",
+          "message" -> s"Organisation not found for pillar2Id: $pillar2Id"
+        )
+        stubRequest("DELETE", url(pillar2Id), NOT_FOUND, errorResponse)
+
+        intercept[OrganisationNotFound] {
+          await(connector.deleteTestOrganisation(pillar2Id)(hc))
+        }
+      }
+
+      "return DatabaseError when receiving 500 INTERNAL_SERVER_ERROR" in {
+        val errorResponse = Json.obj(
+          "code"    -> "500",
+          "message" -> "Database error"
+        )
+        stubRequest("DELETE", url(pillar2Id), INTERNAL_SERVER_ERROR, errorResponse)
+
+        intercept[DatabaseError] {
+          await(connector.deleteTestOrganisation(pillar2Id)(hc))
+        }.operation shouldBe "delete"
+      }
+
+      "return UnexpectedResponse for any other status code" in {
+        stubRequest("DELETE", url(pillar2Id), BAD_REQUEST, Json.obj())
+
+        intercept[UnexpectedResponse.type] {
+          await(connector.deleteTestOrganisation(pillar2Id)(hc))
+        }
+      }
+    }
+  }
+
+  val validOrganisationDetails: TestOrganisation = TestOrganisation(
+    orgDetails = OrgDetails(
+      domesticOnly = true,
+      organisationName = "Test Organisation Ltd",
+      registrationDate = LocalDate.of(2024, 1, 1)
+    ),
+    accountingPeriod = AccountingPeriod(
+      startDate = LocalDate.of(2024, 1, 1),
+      endDate = LocalDate.of(2024, 12, 31)
+    ),
+    lastUpdated = Instant.parse("2024-01-01T12:00:00Z")
+  )
+
+  val validResponseJson: JsObject = Json.obj(
+    "pillar2Id" -> pillar2Id,
+    "organisation" -> Json.obj(
+      "orgDetails" -> Json.obj(
+        "domesticOnly"     -> true,
+        "organisationName" -> "Test Organisation Ltd",
+        "registrationDate" -> "2024-01-01"
+      ),
+      "accountingPeriod" -> Json.obj(
+        "startDate" -> "2024-01-01",
+        "endDate"   -> "2024-12-31"
+      ),
+      "lastUpdated" -> "2024-01-01T12:00:00Z"
+    )
+  )
+}

--- a/test/uk/gov/hmrc/pillar2submissionapi/controllers/BTNSubmissionControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/controllers/BTNSubmissionControllerSpec.scala
@@ -27,6 +27,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2submissionapi.base.ControllerBaseSpec
 import uk.gov.hmrc.pillar2submissionapi.controllers.BTNSubmissionControllerSpec._
 import uk.gov.hmrc.pillar2submissionapi.controllers.error.{EmptyRequestBody, InvalidJson}
+import uk.gov.hmrc.pillar2submissionapi.controllers.submission.BTNSubmissionController
 import uk.gov.hmrc.pillar2submissionapi.models.belowthresholdnotification.{BTNSubmission, SubmitBTNSuccessResponse}
 
 import scala.concurrent.Future

--- a/test/uk/gov/hmrc/pillar2submissionapi/controllers/TestOrganisationControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/controllers/TestOrganisationControllerSpec.scala
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2submissionapi.controllers
+
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
+import org.mockito.Mockito.when
+import play.api.http.Status._
+import play.api.libs.json.{JsValue, Json}
+import play.api.mvc.{BodyParsers, Request}
+import play.api.test.FakeRequest
+import play.api.test.Helpers.{contentAsJson, defaultAwaitTimeout, status}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.pillar2submissionapi.base.ControllerBaseSpec
+import uk.gov.hmrc.pillar2submissionapi.config.AppConfig
+import uk.gov.hmrc.pillar2submissionapi.controllers.actions.AuthenticatedIdentifierAction
+import uk.gov.hmrc.pillar2submissionapi.controllers.error.{EmptyRequestBody, InvalidJson, TestEndpointDisabled}
+import uk.gov.hmrc.pillar2submissionapi.controllers.test.TestOrganisationController
+import uk.gov.hmrc.pillar2submissionapi.models.organisation._
+import uk.gov.hmrc.pillar2submissionapi.models.requests.IdentifierRequest
+
+import java.time.{Instant, LocalDate}
+import scala.concurrent.Future
+
+class TestOrganisationControllerSpec extends ControllerBaseSpec {
+
+  val mockAppConfig: AppConfig = mock[AppConfig]
+
+  override val identifierAction: AuthenticatedIdentifierAction = new AuthenticatedIdentifierAction(
+    mockAuthConnector,
+    new BodyParsers.Default,
+    mockAppConfig
+  ) {
+    override def transform[A](request: Request[A]): Future[IdentifierRequest[A]] =
+      Future.successful(IdentifierRequest(request, "internalId", Some("groupID"), userIdForEnrolment = "userId", clientPillar2Id = pillar2Id))
+  }
+
+  def controller(testEndpointsEnabled: Boolean = true): TestOrganisationController = {
+    when(mockAppConfig.testOrganisationEnabled).thenReturn(testEndpointsEnabled)
+    new TestOrganisationController(cc, identifierAction, mockTestOrganisationService, mockAppConfig)
+  }
+
+  "TestOrganisationController" when {
+    "test endpoints are enabled" when {
+      "createTestOrganisation" must {
+        "return 201 CREATED for valid request" in {
+          when(mockTestOrganisationService.createTestOrganisation(eqTo(pillar2Id), any[TestOrganisationRequest])(any[HeaderCarrier]))
+            .thenReturn(Future.successful(validOrganisationDetailsWithId))
+
+          val result = controller().createTestOrganisation(FakeRequest().withJsonBody(validRequestJson))
+
+          status(result) mustBe CREATED
+          contentAsJson(result) mustBe validResponseJson
+        }
+
+        "return InvalidJson for invalid request" in {
+          val result = controller().createTestOrganisation(FakeRequest().withJsonBody(invalidRequestJson))
+
+          result shouldFailWith InvalidJson
+        }
+
+        "return EmptyRequestBody for missing body" in {
+          val result = controller().createTestOrganisation(FakeRequest())
+
+          result shouldFailWith EmptyRequestBody
+        }
+      }
+
+      "getTestOrganisation" must {
+        "return 200 OK with organisation details" in {
+          when(mockTestOrganisationService.getTestOrganisation(eqTo(pillar2Id))(any[HeaderCarrier]))
+            .thenReturn(Future.successful(validOrganisationDetailsWithId))
+
+          val result = controller().getTestOrganisation(FakeRequest())
+
+          status(result) mustBe OK
+          contentAsJson(result) mustBe validResponseJson
+        }
+      }
+
+      "updateTestOrganisation" must {
+        "return 200 OK for valid request" in {
+          when(mockTestOrganisationService.updateTestOrganisation(eqTo(pillar2Id), any[TestOrganisationRequest])(any[HeaderCarrier]))
+            .thenReturn(Future.successful(validOrganisationDetailsWithId))
+
+          val result = controller().updateTestOrganisation(FakeRequest().withJsonBody(validRequestJson))
+
+          status(result) mustBe OK
+          contentAsJson(result) mustBe validResponseJson
+        }
+
+        "return InvalidJson for invalid request" in {
+          val result = controller().updateTestOrganisation(FakeRequest().withJsonBody(invalidRequestJson))
+
+          result shouldFailWith InvalidJson
+        }
+
+        "return EmptyRequestBody for missing body" in {
+          val result = controller().updateTestOrganisation(FakeRequest())
+
+          result shouldFailWith EmptyRequestBody
+        }
+      }
+
+      "deleteTestOrganisation" must {
+        "return 204 NO_CONTENT for successful deletion" in {
+          when(mockTestOrganisationService.deleteTestOrganisation(eqTo(pillar2Id))(any[HeaderCarrier]))
+            .thenReturn(Future.successful(()))
+
+          val result = controller().deleteTestOrganisation(FakeRequest())
+
+          status(result) mustBe NO_CONTENT
+        }
+      }
+    }
+
+    "test endpoints are disabled" when {
+      "createTestOrganisation" must {
+        "return 403 FORBIDDEN" in {
+          val result = controller(testEndpointsEnabled = false).createTestOrganisation(FakeRequest().withJsonBody(validRequestJson))
+
+          result shouldFailWith TestEndpointDisabled()
+        }
+      }
+
+      "getTestOrganisation" must {
+        "return 403 FORBIDDEN" in {
+          val result = controller(testEndpointsEnabled = false).getTestOrganisation(FakeRequest())
+
+          result shouldFailWith TestEndpointDisabled()
+        }
+      }
+
+      "updateTestOrganisation" must {
+        "return 403 FORBIDDEN" in {
+          val result = controller(testEndpointsEnabled = false).updateTestOrganisation(FakeRequest().withJsonBody(validRequestJson))
+
+          result shouldFailWith TestEndpointDisabled()
+        }
+      }
+
+      "deleteTestOrganisation" must {
+        "return 403 FORBIDDEN" in {
+          val result = controller(testEndpointsEnabled = false).deleteTestOrganisation(FakeRequest())
+
+          result shouldFailWith TestEndpointDisabled()
+        }
+      }
+    }
+  }
+
+  val validRequestJson: JsValue = Json.obj(
+    "orgDetails" -> Json.obj(
+      "domesticOnly"     -> true,
+      "organisationName" -> "Test Organisation Ltd",
+      "registrationDate" -> "2024-01-01"
+    ),
+    "accountingPeriod" -> Json.obj(
+      "startDate" -> "2024-01-01",
+      "endDate"   -> "2024-12-31"
+    )
+  )
+
+  val invalidRequestJson: JsValue = Json.obj(
+    "invalidField" -> "invalidValue"
+  )
+
+  val validResponseJson: JsValue = Json.obj(
+    "pillar2Id" -> pillar2Id,
+    "organisation" -> Json.obj(
+      "orgDetails" -> Json.obj(
+        "domesticOnly"     -> true,
+        "organisationName" -> "Test Organisation Ltd",
+        "registrationDate" -> "2024-01-01"
+      ),
+      "accountingPeriod" -> Json.obj(
+        "startDate" -> "2024-01-01",
+        "endDate"   -> "2024-12-31"
+      ),
+      "lastUpdated" -> "2024-01-01T12:00:00Z"
+    )
+  )
+
+  val validOrganisationDetailsWithId: TestOrganisationWithId = TestOrganisationWithId(
+    pillar2Id = pillar2Id,
+    organisation = TestOrganisation(
+      orgDetails = OrgDetails(
+        domesticOnly = true,
+        organisationName = "Test Organisation Ltd",
+        registrationDate = LocalDate.of(2024, 1, 1)
+      ),
+      accountingPeriod = AccountingPeriod(
+        startDate = LocalDate.of(2024, 1, 1),
+        endDate = LocalDate.of(2024, 12, 31)
+      ),
+      lastUpdated = Instant.parse("2024-01-01T12:00:00Z")
+    )
+  )
+}

--- a/test/uk/gov/hmrc/pillar2submissionapi/controllers/UKTaxReturnControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/controllers/UKTaxReturnControllerSpec.scala
@@ -27,6 +27,7 @@ import play.api.test.Helpers.{OK, defaultAwaitTimeout, status}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2submissionapi.base.ControllerBaseSpec
 import uk.gov.hmrc.pillar2submissionapi.controllers.error.{EmptyRequestBody, InvalidJson}
+import uk.gov.hmrc.pillar2submissionapi.controllers.submission.UKTaxReturnController
 import uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.UKTRSubmissionData
 
 import scala.concurrent.Future

--- a/test/uk/gov/hmrc/pillar2submissionapi/helpers/SubscriptionDataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/helpers/SubscriptionDataFixture.scala
@@ -81,7 +81,7 @@ trait SubscriptionDataFixture {
       |      "accountingPeriod": {
       |          "startDate": "2024-01-06",
       |          "endDate": "2025-04-06",
-      |          "duetDate": "2024-04-06"
+      |          "dueDate": "2024-04-06"
       |      },
       |      "accountStatus": {
       |          "inactive": true

--- a/test/uk/gov/hmrc/pillar2submissionapi/services/TestOrganisationServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/services/TestOrganisationServiceSpec.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2submissionapi.services
+
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
+import org.mockito.Mockito.when
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.pillar2submissionapi.base.UnitTestBaseSpec
+import uk.gov.hmrc.pillar2submissionapi.models.organisation._
+
+import java.time.{Instant, LocalDate}
+import scala.concurrent.Future
+
+class TestOrganisationServiceSpec extends UnitTestBaseSpec {
+
+  val service = new TestOrganisationService(mockTestOrganisationConnector)
+
+  "TestOrganisationService" when {
+    "createTestOrganisation" must {
+      "return organisation details for valid request" in {
+        when(mockTestOrganisationConnector.createTestOrganisation(eqTo(pillar2Id), any[TestOrganisation])(any[HeaderCarrier]))
+          .thenReturn(Future.successful(validOrganisationDetailsWithId))
+
+        val result = await(service.createTestOrganisation(pillar2Id, validOrganisationDetailsRequest))
+
+        result mustBe validOrganisationDetailsWithId
+      }
+    }
+
+    "getTestOrganisation" must {
+      "return organisation details" in {
+        when(mockTestOrganisationConnector.getTestOrganisation(eqTo(pillar2Id))(any[HeaderCarrier]))
+          .thenReturn(Future.successful(validOrganisationDetailsWithId))
+
+        val result = await(service.getTestOrganisation(pillar2Id))
+
+        result mustBe validOrganisationDetailsWithId
+      }
+    }
+
+    "updateTestOrganisation" must {
+      "return updated organisation details" in {
+        when(mockTestOrganisationConnector.updateTestOrganisation(eqTo(pillar2Id), any[TestOrganisation])(any[HeaderCarrier]))
+          .thenReturn(Future.successful(validOrganisationDetailsWithId))
+
+        val result = await(service.updateTestOrganisation(pillar2Id, validOrganisationDetailsRequest))
+
+        result mustBe validOrganisationDetailsWithId
+      }
+    }
+
+    "deleteTestOrganisation" must {
+      "return unit when successful" in {
+        when(mockTestOrganisationConnector.deleteTestOrganisation(eqTo(pillar2Id))(any[HeaderCarrier]))
+          .thenReturn(Future.successful(()))
+
+        val result = await(service.deleteTestOrganisation(pillar2Id))
+
+        result mustBe (())
+      }
+    }
+  }
+
+  val validOrganisationDetailsRequest: TestOrganisationRequest = TestOrganisationRequest(
+    orgDetails = OrgDetails(
+      domesticOnly = true,
+      organisationName = "Test Organisation Ltd",
+      registrationDate = LocalDate.of(2024, 1, 1)
+    ),
+    accountingPeriod = AccountingPeriod(
+      startDate = LocalDate.of(2024, 1, 1),
+      endDate = LocalDate.of(2024, 12, 31)
+    )
+  )
+
+  val validOrganisationDetails: TestOrganisation = TestOrganisation(
+    orgDetails = validOrganisationDetailsRequest.orgDetails,
+    accountingPeriod = validOrganisationDetailsRequest.accountingPeriod,
+    lastUpdated = Instant.parse("2024-01-01T12:00:00Z")
+  )
+
+  val validOrganisationDetailsWithId: TestOrganisationWithId = TestOrganisationWithId(
+    pillar2Id = pillar2Id,
+    organisation = validOrganisationDetails
+  )
+}


### PR DESCRIPTION
Added new endpoints to create, read, update and delete test organisations for testing purposes:

- POST `/test-only/organisation` - Create a test organisation
- GET `/test-only/organisation` - Get a test organisation
- PUT `/test-only/organisation` - Update a test organisation  
- DELETE `/test-only/organisation` - Delete a test organisation

Changes include:
- New TestOrganisationController with CRUD operations
- TestOrganisationConnector to handle HTTP calls to stub service
- Error handling for common scenarios (404, 409, 500)
- Feature flag `features.testOrganisationEnabled` to restrict endpoints to test environments only
- Bruno scripts for manual testing for each endpoint
- Unit tests for controller, connector and service layers
- OpenAPI documentation for all endpoints

Authentication & Authorisation:
- Endpoints are secured behind auth and require a valid pillar2Id within the enrolments of the auth token
- For agent requests, a valid pillar2Id must be provided in the `X-Pillar2-ID` header
- When feature flag is disabled, endpoints return 403 Forbidden with message "Test endpoints are not available in this environment"

Co-authored-by: @MoDweik