### PR TITLE
[PIL-1514-allow-test-users] Add a featureflag to allow test users in all environments except production

### DIFF
--- a/API Testing/development/Exchange Auth Token.bru
+++ b/API Testing/development/Exchange Auth Token.bru
@@ -16,7 +16,7 @@ headers {
 }
 
 body:form-urlencoded {
-  code: 4dc6433206104d49b6b528b685abf9ee
+  code: d8698cda2b0c4642a81ddc5a9fef3979
   client_id: 3P091N0H49jKqMfDky9pNz3aczpF
   client_secret: cd82cb89-174b-47e1-9e22-4bf6ca1e3180
   redirect_uri: urn:ietf:wg:oauth:2.0:oob

--- a/API Testing/development/Exchange Auth Token.bru
+++ b/API Testing/development/Exchange Auth Token.bru
@@ -16,9 +16,13 @@ headers {
 }
 
 body:form-urlencoded {
-  code: d8698cda2b0c4642a81ddc5a9fef3979
+  code: 611789cbd6e84dd0ba4d3324175c3f17
   client_id: 3P091N0H49jKqMfDky9pNz3aczpF
   client_secret: cd82cb89-174b-47e1-9e22-4bf6ca1e3180
   redirect_uri: urn:ietf:wg:oauth:2.0:oob
   grant_type: authorization_code
+}
+
+script:post-response {
+  bru.setEnvVar("access_token",res.body.access_token)
 }

--- a/API Testing/development/Submit UKTR.bru
+++ b/API Testing/development/Submit UKTR.bru
@@ -12,7 +12,7 @@ post {
 
 headers {
   Accept: application/vnd.hmrc.1.0+json
-  Authorization: Bearer 32a5a7e8d880c99a9b2fe2a49e597622
+  Authorization: Bearer db23a63bcf45d4c0836c0197ef0feeb3
   Content-Type: application/json
   content-type: application/json
 }

--- a/API Testing/development/Submit UKTR.bru
+++ b/API Testing/development/Submit UKTR.bru
@@ -12,7 +12,7 @@ post {
 
 headers {
   Accept: application/vnd.hmrc.1.0+json
-  Authorization: Bearer db23a63bcf45d4c0836c0197ef0feeb3
+  Authorization: Bearer {{access_token}}
   Content-Type: application/json
   content-type: application/json
 }

--- a/app/uk/gov/hmrc/pillar2submissionapi/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/config/AppConfig.scala
@@ -15,15 +15,15 @@
  */
 
 package uk.gov.hmrc.pillar2submissionapi.config
-
-import play.api.Configuration
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import javax.inject.{Inject, Singleton}
 
 @Singleton
-class AppConfig @Inject() (config: Configuration, servicesConfig: ServicesConfig) {
+case class AppConfig @Inject() (servicesConfig: ServicesConfig) {
 
-  val appName:        String = config.get[String]("appName")
-  val pillar2BaseUrl: String = servicesConfig.baseUrl("pillar2")
+  lazy val pillar2BaseUrl: String = servicesConfig.baseUrl("pillar2")
+
+  lazy val allowTestUsers: Boolean =
+    servicesConfig.getBoolean("features.allow-test-users")
 }

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/actions/AuthenticatedIdentifierAction.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/actions/AuthenticatedIdentifierAction.scala
@@ -25,6 +25,7 @@ import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
 import uk.gov.hmrc.auth.core.retrieve.~
 import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.pillar2submissionapi.config.AppConfig
 import uk.gov.hmrc.pillar2submissionapi.controllers.error.{AuthenticationError, ForbiddenError, MissingHeader}
 import uk.gov.hmrc.pillar2submissionapi.models.requests.IdentifierRequest
 import uk.gov.hmrc.play.http.HeaderCarrierConverter
@@ -34,7 +35,8 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class AuthenticatedIdentifierAction @Inject() (
   override val authConnector:    AuthConnector,
-  val parser:                    BodyParsers.Default
+  val parser:                    BodyParsers.Default,
+  val config:                    AppConfig
 )(implicit val executionContext: ExecutionContext)
     extends IdentifierAction
     with AuthorisedFunctions
@@ -47,6 +49,30 @@ class AuthenticatedIdentifierAction @Inject() (
       identifier       <- pillar2Enrolment.getIdentifier(ENROLMENT_IDENTIFIER)
     } yield identifier.value
 
+  def processPillar2Enrolment[A](
+    request:    Request[A],
+    enrolments: Enrolments,
+    internalId: String,
+    groupId:    String,
+    providerId: String
+  ): Future[IdentifierRequest[A]] = getPillar2Id(
+    enrolments
+  ) match {
+    case Some(pillar2Id) =>
+      Future.successful(
+        IdentifierRequest(
+          request = request,
+          userId = internalId,
+          groupId = Some(groupId),
+          clientPillar2Id = pillar2Id,
+          userIdForEnrolment = providerId
+        )
+      )
+    case None =>
+      logger.warn(s"Pillar2 ID not found in enrolments for user $internalId")
+      Future.failed(ForbiddenError)
+  }
+
   override protected def transform[A](request: Request[A]): Future[IdentifierRequest[A]] = {
     implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequest(request)
 
@@ -56,23 +82,13 @@ class AuthenticatedIdentifierAction @Inject() (
 
     authorised(AuthProviders(GovernmentGateway) and ConfidenceLevel.L50)
       .retrieve(retrievals) {
+        case Some(internalId) ~ Some(groupId) ~ enrolments ~ Some(Organisation) ~ None ~ Some(credentials) if config.allowTestUsers =>
+          processPillar2Enrolment(request = request, enrolments = enrolments, internalId = internalId, groupId = groupId, credentials.providerId)
         case Some(internalId) ~ Some(groupId) ~ enrolments ~ Some(Organisation) ~ Some(User) ~ Some(credentials) =>
-          getPillar2Id(enrolments) match {
-            case Some(pillar2Id) =>
-              Future.successful(
-                IdentifierRequest(
-                  request = request,
-                  userId = internalId,
-                  groupId = Some(groupId),
-                  clientPillar2Id = pillar2Id,
-                  userIdForEnrolment = credentials.providerId
-                )
-              )
-            case None =>
-              logger.warn(s"Pillar2 ID not found in enrolments for user $internalId")
-              Future.failed(ForbiddenError)
-          }
+          processPillar2Enrolment(request = request, enrolments = enrolments, internalId = internalId, groupId = groupId, credentials.providerId)
         case Some(_) ~ Some(_) ~ _ ~ Some(Agent) ~ Some(User) ~ Some(_) =>
+          agentAuth[A](request, request.headers.get("X-Pillar2-Id"))
+        case Some(_) ~ Some(_) ~ _ ~ Some(Agent) ~ None ~ Some(_) if config.allowTestUsers =>
           agentAuth[A](request, request.headers.get("X-Pillar2-Id"))
         case c =>
           logger.warn(s"pattern: affinityGroup: ${c.a.a.b} - credentialRole: ${c.a.b} ")

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/actions/AuthenticatedIdentifierAction.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/actions/AuthenticatedIdentifierAction.scala
@@ -49,7 +49,7 @@ class AuthenticatedIdentifierAction @Inject() (
       identifier       <- pillar2Enrolment.getIdentifier(ENROLMENT_IDENTIFIER)
     } yield identifier.value
 
-  def processPillar2Enrolment[A](
+  private def processPillar2Enrolment[A](
     request:    Request[A],
     enrolments: Enrolments,
     internalId: String,
@@ -90,9 +90,7 @@ class AuthenticatedIdentifierAction @Inject() (
           agentAuth[A](request, request.headers.get("X-Pillar2-Id"))
         case Some(_) ~ Some(_) ~ _ ~ Some(Agent) ~ None ~ Some(_) if config.allowTestUsers =>
           agentAuth[A](request, request.headers.get("X-Pillar2-Id"))
-        case c =>
-          logger.warn(s"pattern: affinityGroup: ${c.a.a.b} - credentialRole: ${c.a.b} ")
-          logger.warn(s"internalId: ${c.a.a.a.a.a} - groupId: ${c.a.a.a.a.b}")
+        case _ =>
           logger.warn("User is not valid for this API")
           Future.failed(ForbiddenError)
       } recoverWith { case e: AuthorisationException =>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -59,3 +59,7 @@ microservice {
   }
 }
 
+features {
+  allow-test-users = true
+}
+

--- a/it/test/uk/gov/hmrc/pillar2submissionapi/base/IntegrationSpecBase.scala
+++ b/it/test/uk/gov/hmrc/pillar2submissionapi/base/IntegrationSpecBase.scala
@@ -38,7 +38,6 @@ import uk.gov.hmrc.auth.core.retrieve.{Credentials, Retrieval, ~}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.test.HttpClientSupport
 import uk.gov.hmrc.pillar2submissionapi.base.TestAuthRetrievals.Ops
-import uk.gov.hmrc.pillar2submissionapi.controllers.actions.{AuthenticatedIdentifierAction, IdentifierAction}
 import uk.gov.hmrc.pillar2submissionapi.helpers.{SubscriptionDataFixture, UKTaxReturnDataFixture, WireMockServerHandler}
 
 import java.util.UUID
@@ -109,7 +108,7 @@ trait IntegrationSpecBase
   override lazy val app: Application = new GuiceApplicationBuilder()
     .configure("microservice.services.pillar2.port" -> wiremockPort)
     .overrides(
-      inject.bind[IdentifierAction].toInstance(new AuthenticatedIdentifierAction(mockAuthConnector, new BodyParsers.Default()))
+      inject.bind[AuthConnector].toInstance(mockAuthConnector)
     )
     .build()
 

--- a/test/uk/gov/hmrc/pillar2submissionapi/base/ControllerBaseSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/base/ControllerBaseSpec.scala
@@ -23,14 +23,17 @@ import org.scalatest.matchers.must.Matchers
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
+import play.api.Configuration
 import play.api.mvc._
 import play.api.test.Helpers.stubControllerComponents
 import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.pillar2submissionapi.config.AppConfig
 import uk.gov.hmrc.pillar2submissionapi.connectors.SubscriptionConnector
 import uk.gov.hmrc.pillar2submissionapi.controllers.actions.{AuthenticatedIdentifierAction, SubscriptionDataRetrievalAction}
 import uk.gov.hmrc.pillar2submissionapi.helpers.{SubscriptionDataFixture, UKTaxReturnDataFixture}
 import uk.gov.hmrc.pillar2submissionapi.models.requests.{IdentifierRequest, SubscriptionDataRequest}
 import uk.gov.hmrc.pillar2submissionapi.services.{SubmitBTNService, UKTaxReturnService}
+import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, ExecutionContext, Future}
@@ -46,10 +49,11 @@ trait ControllerBaseSpec extends PlaySpec with Results with Matchers with Mockit
 
   val mockUkTaxReturnService: UKTaxReturnService = mock[UKTaxReturnService]
   val mockSubmitBTNService:   SubmitBTNService   = mock[SubmitBTNService]
-
+  val appConfig:              AppConfig          = AppConfig(new ServicesConfig(Configuration.empty))
   implicit val identifierAction: AuthenticatedIdentifierAction = new AuthenticatedIdentifierAction(
     mockAuthConnector,
-    new BodyParsers.Default
+    new BodyParsers.Default,
+    appConfig
   ) {
     override def transform[A](request: Request[A]): Future[IdentifierRequest[A]] =
       Future.successful(IdentifierRequest(request, "internalId", Some("groupID"), userIdForEnrolment = "userId", clientPillar2Id = ""))

--- a/test/uk/gov/hmrc/pillar2submissionapi/controllers/actions/AuthenticatedIdentifierActionSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/controllers/actions/AuthenticatedIdentifierActionSpec.scala
@@ -20,6 +20,7 @@ import com.google.inject.Inject
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
+import play.api.Configuration
 import play.api.mvc._
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
@@ -31,22 +32,24 @@ import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
 import uk.gov.hmrc.auth.core.retrieve.{Credentials, Retrieval, ~}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2submissionapi.base.ActionBaseSpec
+import uk.gov.hmrc.pillar2submissionapi.config.AppConfig
+import uk.gov.hmrc.pillar2submissionapi.controllers.actions.AuthenticatedIdentifierAction._
 import uk.gov.hmrc.pillar2submissionapi.controllers.actions.AuthenticatedIdentifierActionSpec._
-import uk.gov.hmrc.pillar2submissionapi.controllers.error.AuthenticationError
-import uk.gov.hmrc.pillar2submissionapi.controllers.error.ForbiddenError
-import uk.gov.hmrc.pillar2submissionapi.controllers.error.MissingHeader
+import uk.gov.hmrc.pillar2submissionapi.controllers.error.{AuthenticationError, ForbiddenError, MissingHeader}
 import uk.gov.hmrc.pillar2submissionapi.helpers.TestAuthRetrievals._
+import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 
-import AuthenticatedIdentifierAction._
-
 class AuthenticatedIdentifierActionSpec extends ActionBaseSpec {
+
+  val emptyAppConfig: AppConfig = AppConfig(new ServicesConfig(Configuration.empty))
 
   val identifierAction: AuthenticatedIdentifierAction = new AuthenticatedIdentifierAction(
     mockAuthConnector,
-    new BodyParsers.Default
+    new BodyParsers.Default,
+    emptyAppConfig
   )(ec)
 
   "IdentifierAction - different types of user" when {
@@ -247,7 +250,42 @@ class AuthenticatedIdentifierActionSpec extends ActionBaseSpec {
     }
 
     "user missing" should {
-      "user is unauthorized" in {
+      "test user is authorised if featureflag is enabled" in {
+        val allowTestUsers = AppConfig(new ServicesConfig(Configuration.from(Map("features.allow-test-users" -> true))))
+
+        val identifierAction: AuthenticatedIdentifierAction = new AuthenticatedIdentifierAction(
+          mockAuthConnector,
+          new BodyParsers.Default,
+          allowTestUsers
+        )(ec)
+        when(
+          mockAuthConnector.authorise[RetrievalsType](ArgumentMatchers.eq(requiredOrgPredicate), ArgumentMatchers.eq(requiredRetrievals))(
+            any[HeaderCarrier](),
+            any[ExecutionContext]()
+          )
+        )
+          .thenReturn(
+            Future.successful(Some(id) ~ Some(groupId) ~ pillar2Enrolments ~ Some(Organisation) ~ None ~ Some(Credentials(providerId, providerType)))
+          )
+
+        val result = await(identifierAction.refine(fakeRequest))
+
+        result.map { identifierRequest =>
+          identifierRequest.userId             must be(id)
+          identifierRequest.groupId            must be(Some(groupId))
+          identifierRequest.clientPillar2Id    must be(identifierValue)
+          identifierRequest.userIdForEnrolment must be(providerId)
+        }
+      }
+
+      "test user is unauthorized if featureflag is disabled" in {
+        val disallowTestUsers = AppConfig(new ServicesConfig(Configuration.from(Map("features.allow-test-users" -> false))))
+
+        val identifierAction: AuthenticatedIdentifierAction = new AuthenticatedIdentifierAction(
+          mockAuthConnector,
+          new BodyParsers.Default,
+          disallowTestUsers
+        )(ec)
         when(
           mockAuthConnector.authorise[RetrievalsType](ArgumentMatchers.eq(requiredOrgPredicate), ArgumentMatchers.eq(requiredRetrievals))(
             any[HeaderCarrier](),
@@ -300,7 +338,8 @@ class AuthenticatedIdentifierActionSpec extends ActionBaseSpec {
       "user is unauthorized" in {
         val identifierAction: AuthenticatedIdentifierAction = new AuthenticatedIdentifierAction(
           new FakeFailingAuthConnector,
-          new BodyParsers.Default
+          new BodyParsers.Default,
+          emptyAppConfig
         )(ec)
 
         val result = intercept[AuthenticationError.type](


### PR DESCRIPTION
We have found that test users created via API Platform do not have a credential role. We rely on the credential role to ensure  a user is a User (instead of Assistant), therefore this has posed a problem.

The solution we have chosen is to add a featureflag to allow test users, which can be turned off in production