### PR TITLE
[PIL-1706-rename-path-prefix] Rename path prefix

### DIFF
--- a/API Testing/test-organisation/create-test-organisation.bru
+++ b/API Testing/test-organisation/create-test-organisation.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 post {
-  url: {{submissionsApiBaseUrl}}/test-only/organisation
+  url: {{submissionsApiBaseUrl}}/setup/organisation
   body: json
   auth: none
 }

--- a/API Testing/test-organisation/delete-test-organisation.bru
+++ b/API Testing/test-organisation/delete-test-organisation.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 delete {
-  url: {{submissionsApiBaseUrl}}/test-only/organisation
+  url: {{submissionsApiBaseUrl}}/setup/organisation
   auth: none
 }
 

--- a/API Testing/test-organisation/get-test-organisation.bru
+++ b/API Testing/test-organisation/get-test-organisation.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{submissionsApiBaseUrl}}/test-only/organisation
+  url: {{submissionsApiBaseUrl}}/setup/organisation
   auth: none
 }
 

--- a/API Testing/test-organisation/update-test-organisation.bru
+++ b/API Testing/test-organisation/update-test-organisation.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 put {
-  url: {{submissionsApiBaseUrl}}/test-only/organisation
+  url: {{submissionsApiBaseUrl}}/setup/organisation
   body: json
   auth: none
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -58,7 +58,7 @@ microservice {
     }
 
     pillar2 {
-          protocol = http
+      protocol = http
       host = localhost
       port = 10051
     }

--- a/conf/public.routes
+++ b/conf/public.routes
@@ -1,2 +1,2 @@
-->         /                          test_only.Routes
+->         /                          setup.Routes
 ->         /                          submission.Routes

--- a/conf/setup.routes
+++ b/conf/setup.routes
@@ -88,7 +88,7 @@
 #           code: "500"
 #           message: "Failed to create organisation due to database error"
 ###
-POST /test-only/organisation              uk.gov.hmrc.pillar2submissionapi.controllers.test.TestOrganisationController.createTestOrganisation()
+POST /setup/organisation              uk.gov.hmrc.pillar2submissionapi.controllers.test.TestOrganisationController.createTestOrganisation()
 
 ###
 # summary: Get a test organisation associated with your authed organisation
@@ -160,7 +160,7 @@ POST /test-only/organisation              uk.gov.hmrc.pillar2submissionapi.contr
 #           code: "500"
 #           message: "Internal Server Error"
 ###
-GET /test-only/organisation                 uk.gov.hmrc.pillar2submissionapi.controllers.test.TestOrganisationController.getTestOrganisation
+GET /setup/organisation                 uk.gov.hmrc.pillar2submissionapi.controllers.test.TestOrganisationController.getTestOrganisation
 
 ###
 # summary: Update the test organisation associated with your authed organisation
@@ -252,7 +252,7 @@ GET /test-only/organisation                 uk.gov.hmrc.pillar2submissionapi.con
 #           code: "500"
 #           message: "Failed to update organisation due to database error"
 ###
-PUT /test-only/organisation              uk.gov.hmrc.pillar2submissionapi.controllers.test.TestOrganisationController.updateTestOrganisation
+PUT /setup/organisation              uk.gov.hmrc.pillar2submissionapi.controllers.test.TestOrganisationController.updateTestOrganisation
 
 ###
 # summary: Delete the test organisation associated with your authed organisation
@@ -309,4 +309,4 @@ PUT /test-only/organisation              uk.gov.hmrc.pillar2submissionapi.contro
 #           code: "500"
 #           message: "Failed to delete organisation due to database error"
 ###
-DELETE /test-only/organisation           uk.gov.hmrc.pillar2submissionapi.controllers.test.TestOrganisationController.deleteTestOrganisation
+DELETE /setup/organisation           uk.gov.hmrc.pillar2submissionapi.controllers.test.TestOrganisationController.deleteTestOrganisation

--- a/conf/swagger.yml
+++ b/conf/swagger.yml
@@ -118,7 +118,7 @@ paths:
         </table>
       security:
         - userRestricted: [write:pillar2]
-  /test-only/organisation:
+  /setup/organisation:
     post:
       summary: Create Test Organisation
       description: |

--- a/it/test/uk/gov/hmrc/pillar2submissionapi/TestOrganisationISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2submissionapi/TestOrganisationISpec.scala
@@ -40,7 +40,7 @@ class TestOrganisationISpec extends IntegrationSpecBase with OptionValues {
 
   lazy val provider: HttpClientV2Provider = app.injector.instanceOf[HttpClientV2Provider]
   lazy val client:   HttpClientV2         = provider.get()
-  lazy val baseUrl = s"http://localhost:$port/test-only/organisation"
+  lazy val baseUrl = s"http://localhost:$port/setup/organisation"
 
   private val stubUrl = "/pillar2/test/organisation"
 

--- a/resources/public/api/conf/1.0/application.yaml
+++ b/resources/public/api/conf/1.0/application.yaml
@@ -1,12 +1,12 @@
 openapi: 3.0.3
 info:
-  version: 0.76.0
+  version: 0.78.0
   title: Pillar 2 API
   description: An API for managing and retrieving data in accordance with Pillar 2
     tax rules.
 tags: []
 paths:
-  /organisations/pillar-two/test-only/organisation:
+  /organisations/pillar-two/setup/organisation:
     post:
       security:
       - userRestricted:
@@ -14,7 +14,7 @@ paths:
       description: |
         Creates a test organisation associated with your authed organisation.
       tags:
-      - test_only
+      - setup
       operationId: createTestOrganisation
       requestBody:
         content:
@@ -113,7 +113,7 @@ paths:
       description: |
         Gets a test organisation associated with your authed organisation.
       tags:
-      - test_only
+      - setup
       operationId: getTestOrganisation
       parameters:
       - name: Authorization
@@ -192,7 +192,7 @@ paths:
       description: |
         Updates a test organisation associated with your authed organisation.
       tags:
-      - test_only
+      - setup
       operationId: updateTestOrganisation
       requestBody:
         content:
@@ -291,7 +291,7 @@ paths:
       description: |
         Deletes a test organisation associated with your authed organisation.
       tags:
-      - test_only
+      - setup
       operationId: deleteTestOrganisation
       parameters:
       - name: Authorization


### PR DESCRIPTION
rename the `test-only` path prefix to `setup` to avoid any alarms/alerts once we deploy