### PR TITLE
[PIL-1725-enable-api] Move API to Beta for testing

### DIFF
--- a/app/uk/gov/hmrc/pillar2submissionapi/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/config/AppConfig.scala
@@ -22,10 +22,10 @@ import javax.inject.{Inject, Singleton}
 @Singleton
 case class AppConfig @Inject() (servicesConfig: ServicesConfig) {
 
-  lazy val pillar2BaseUrl: String = servicesConfig.baseUrl("pillar2")
-  lazy val stubBaseUrl:    String = servicesConfig.baseUrl("stub")
-  lazy val apiPlatformStatus:String = servicesConfig.getString("features.api-platform.status")
-  lazy val apiPlatformEndpointsEnabled:Boolean = servicesConfig.getBoolean("features.api-platform.endpoints-enabled")
+  lazy val pillar2BaseUrl:              String  = servicesConfig.baseUrl("pillar2")
+  lazy val stubBaseUrl:                 String  = servicesConfig.baseUrl("stub")
+  lazy val apiPlatformStatus:           String  = servicesConfig.getString("features.api-platform.status")
+  lazy val apiPlatformEndpointsEnabled: Boolean = servicesConfig.getBoolean("features.api-platform.endpoints-enabled")
 
   lazy val allowTestUsers: Boolean =
     servicesConfig.getBoolean("features.allow-test-users")

--- a/app/uk/gov/hmrc/pillar2submissionapi/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/config/AppConfig.scala
@@ -24,6 +24,8 @@ case class AppConfig @Inject() (servicesConfig: ServicesConfig) {
 
   lazy val pillar2BaseUrl: String = servicesConfig.baseUrl("pillar2")
   lazy val stubBaseUrl:    String = servicesConfig.baseUrl("stub")
+  lazy val apiPlatformStatus:String = servicesConfig.getString("features.api-platform.status")
+  lazy val apiPlatformEndpointsEnabled:Boolean = servicesConfig.getBoolean("features.api-platform.endpoints-enabled")
 
   lazy val allowTestUsers: Boolean =
     servicesConfig.getBoolean("features.allow-test-users")

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/platform/DocumentationController.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/platform/DocumentationController.scala
@@ -17,16 +17,31 @@
 package uk.gov.hmrc.pillar2submissionapi.controllers.platform
 
 import controllers.Assets
+import play.api.libs.json._
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import uk.gov.hmrc.pillar2submissionapi.config.AppConfig
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import javax.inject.{Inject, Singleton}
+import scala.io.Source
 
 @Singleton
-class DocumentationController @Inject() (assets: Assets, cc: ControllerComponents) extends BackendController(cc) {
+class DocumentationController @Inject() (assets: Assets, cc: ControllerComponents, appConfig: AppConfig) extends BackendController(cc) {
 
-  def definition(): Action[AnyContent] =
-    assets.at("/public/api", "definition.json")
+  def definition(): Action[AnyContent] = Action {
+    val json = Json.parse(Source.fromResource("public/api/definition.json").mkString)
+    val optimus = (__ \ "api" \ "versions").json.update(
+      Reads
+        .list(
+          (__ \ "status").json.update(Reads.of[JsString].map(_ => JsString(appConfig.apiPlatformStatus)))
+            andThen
+              (__ \ "endpointsEnabled").json
+                .update(Reads.of[JsBoolean].map(_ => JsBoolean(appConfig.apiPlatformEndpointsEnabled)))
+        )
+        .map(JsArray(_))
+    )
+    json.transform(optimus).map(Ok(_)).getOrElse(throw new RuntimeException("Failed to create definition.json"))
+  }
 
   def specification(version: String, file: String): Action[AnyContent] =
     assets.at(s"/public/api/conf/$version", file)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -73,5 +73,9 @@ microservice {
 
 features {
   allow-test-users = true
+  api-platform {
+    endpoints-enabled = false
+    status = ALPHA
+  }
 }
 

--- a/it/test/uk/gov/hmrc/pillar2submissionapi/base/IntegrationSpecBase.scala
+++ b/it/test/uk/gov/hmrc/pillar2submissionapi/base/IntegrationSpecBase.scala
@@ -109,6 +109,8 @@ trait IntegrationSpecBase
     .configure("microservice.services.pillar2.port" -> wiremockPort)
     .configure("microservice.services.stub.port" -> wiremockPort)
     .configure("features.testOrganisationEnabled" -> true)
+    .configure("features.api-platform.status" -> "BETA")
+    .configure("features.api-platform.endpoints-enabled" -> true)
     .overrides(
       inject.bind[AuthConnector].toInstance(mockAuthConnector)
     )

--- a/it/test/uk/gov/hmrc/pillar2submissionapi/controllers/platform/DocumentationControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2submissionapi/controllers/platform/DocumentationControllerISpec.scala
@@ -35,9 +35,9 @@ class DocumentationControllerISpec extends IntegrationSpecBase {
 
   "DocumentationController" should {
     "return definition" in {
-      val url                = s"$baseUrl${routes.DocumentationController.definition().url}"
-      val definition         = Await.result(client.get(URI.create(url).toURL).execute[HttpResponse], 5.seconds)
-      val json      = definition.json
+      val url        = s"$baseUrl${routes.DocumentationController.definition().url}"
+      val definition = Await.result(client.get(URI.create(url).toURL).execute[HttpResponse], 5.seconds)
+      val json       = definition.json
       (json \ "api" \ "name").as[String] mustEqual "Pillar 2"
       (json \ "api" \ "description").as[String] mustEqual "An API for managing and retrieving Pillar 2 data"
       (json \ "api" \ "context").as[String] mustEqual "organisations/pillar-two"

--- a/resources/public/api/definition.json
+++ b/resources/public/api/definition.json
@@ -7,8 +7,8 @@
     "versions": [
       {
         "version": "1.0",
-        "status": "ALPHA",
-        "endpointsEnabled": false,
+        "status": "BETA",
+        "endpointsEnabled": true,
         "access": {
           "type": "PRIVATE",
           "isTrial": true

--- a/resources/public/api/definition.json
+++ b/resources/public/api/definition.json
@@ -7,8 +7,8 @@
     "versions": [
       {
         "version": "1.0",
-        "status": "BETA",
-        "endpointsEnabled": true,
+        "status": "ALPHA",
+        "endpointsEnabled": false,
         "access": {
           "type": "PRIVATE",
           "isTrial": true


### PR DESCRIPTION
This change allows a configuration `definition.json`. The ultimate goal here is to enable endpoints in QA but not enable them in externaltest (until we are ready). 