### PR TITLE
PIL - 1831 : Headers added to open api spec

### DIFF
--- a/conf/setup.routes
+++ b/conf/setup.routes
@@ -13,6 +13,13 @@
 #     schema:
 #       type: string
 #     description: "Pillar 2 Id - Pattern: [A-Z0-9]{1,15}. Only requred if you are authorised as an agent to specify which client's Pillar 2 Id to associate the test organisation."
+#   - in: header
+#     name: Accept
+#     required: false
+#     schema:
+#       type: string
+#       example: application/vnd.hmrc.1.0+json
+#     description: Specifies the expected response format as versioned JSON from the HMRC API (v1.0). If not provided, it will default to application/vnd.hmrc.1.0+json.
 # requestBody:
 #   content:
 #     application/json:
@@ -105,6 +112,13 @@ POST /setup/organisation              uk.gov.hmrc.pillar2submissionapi.controlle
 #     schema:
 #       type: string
 #     description: "Pillar 2 Id - Pattern: [A-Z0-9]{1,15}. Only requred if you are authorised as an agent to specify which client's Pillar 2 Id to associate the test organisation."
+#   - in: header
+#     name: Accept
+#     required: false
+#     schema:
+#       type: string
+#       example: application/vnd.hmrc.1.0+json
+#     description: Specifies the expected response format as versioned JSON from the HMRC API (v1.0). If not provided, it will default to application/vnd.hmrc.1.0+json.
 # responses:
 #   200:
 #      description: Test Organisation Found
@@ -177,6 +191,13 @@ GET /setup/organisation                 uk.gov.hmrc.pillar2submissionapi.control
 #     schema:
 #       type: string
 #     description: "Pillar 2 Id - Pattern: [A-Z0-9]{1,15}. Only requred if you are authorised as an agent to specify which client's Pillar 2 Id to associate the test organisation."
+#   - in: header
+#     name: Accept
+#     required: false
+#     schema:
+#       type: string
+#       example: application/vnd.hmrc.1.0+json
+#     description: Specifies the expected response format as versioned JSON from the HMRC API (v1.0). If not provided, it will default to application/vnd.hmrc.1.0+json.
 # requestBody:
 #   content:
 #     application/json:
@@ -269,6 +290,13 @@ PUT /setup/organisation              uk.gov.hmrc.pillar2submissionapi.controller
 #     schema:
 #       type: string
 #     description: "Pillar 2 Id - Pattern: [A-Z0-9]{1,15}. Only requred if you are authorised as an agent to specify which client's Pillar 2 Id to associate the test organisation."
+#   - in: header
+#     name: Accept
+#     required: false
+#     schema:
+#       type: string
+#       example: application/vnd.hmrc.1.0+json
+#     description: Specifies the expected response format as versioned JSON from the HMRC API (v1.0). If not provided, it will default to application/vnd.hmrc.1.0+json.
 # responses:
 #   204:
 #      description: Test Organisation and Submission Data Deleted Successfully

--- a/conf/submission.routes
+++ b/conf/submission.routes
@@ -2,10 +2,23 @@
 # summary: Submit a Pillar2 UK Tax Return
 # parameters:
 #  - in: header
+#    name: Authorization
+#    required: true
+#    schema:
+#      type: string
+#    description: Bearer token for authentication
+#  - in: header
 #    name: X-Pillar2-Id
 #    schema:
 #      type: string
 #    description: Pillar2 ID for the submission. Mandatory if the user is an Agent
+#  - in: header
+#    name: Accept
+#    required: false
+#    schema:
+#      type: string
+#      example: application/vnd.hmrc.1.0+json
+#    description: Specifies the expected response format as versioned JSON from the HMRC API (v1.0). If not provided, it will default to application/vnd.hmrc.1.0+json.
 # requestBody:
 #   content:
 #     application/json:
@@ -134,10 +147,23 @@ POST       /uk-tax-return              uk.gov.hmrc.pillar2submissionapi.controll
 # summary: Amend a Pillar2 UK Tax Return
 # parameters:
 #  - in: header
+#    name: Authorization
+#    required: true
+#    schema:
+#      type: string
+#    description: Bearer token for authentication
+#  - in: header
 #    name: X-Pillar2-Id
 #    schema:
 #      type: string
 #    description: Pillar2 ID for the submission. Mandatory if the user is an Agent
+#  - in: header
+#    name: Accept
+#    required: false
+#    schema:
+#      type: string
+#      example: application/vnd.hmrc.1.0+json
+#    description: Specifies the expected response format as versioned JSON from the HMRC API (v1.0). If not provided, it will default to application/vnd.hmrc.1.0+json.
 # requestBody:
 #   content:
 #     application/json:
@@ -262,10 +288,23 @@ PUT        /uk-tax-return              uk.gov.hmrc.pillar2submissionapi.controll
 # summary: Submit a Pillar2 Below-Threshold Notification
 # parameters:
 #  - in: header
+#    name: Authorization
+#    required: true
+#    schema:
+#      type: string
+#    description: Bearer token for authentication
+#  - in: header
 #    name: X-Pillar2-Id
 #    schema:
 #      type: string
 #    description: Pillar2 ID for the submission. Mandatory if the user is an Agent
+#  - in: header
+#    name: Accept
+#    required: false
+#    schema:
+#      type: string
+#      example: application/vnd.hmrc.1.0+json
+#    description: Specifies the expected response format as versioned JSON from the HMRC API (v1.0). If not provided, it will default to application/vnd.hmrc.1.0+json.
 # requestBody:
 #   content:
 #     application/json:
@@ -364,10 +403,23 @@ POST       /below-threshold-notification              uk.gov.hmrc.pillar2submiss
 # summary: Retreive Obligations and Submissions
 # parameters:
 #  - in: header
+#    name: Authorization
+#    required: true
+#    schema:
+#      type: string
+#    description: Bearer token for authentication
+#  - in: header
 #    name: X-Pillar2-Id
 #    schema:
 #      type: string
 #    description: Pillar2 ID for the submission. Mandatory if the user is an Agent
+#  - in: header
+#    name: Accept
+#    required: false
+#    schema:
+#      type: string
+#      example: application/vnd.hmrc.1.0+json
+#    description: Specifies the expected response format as versioned JSON from the HMRC API (v1.0). If not provided, it will default to application/vnd.hmrc.1.0+json.
 # responses:
 #   200:
 #     description: OK Obligations and Submissions retrieved

--- a/resources/public/api/conf/1.0/application.yaml
+++ b/resources/public/api/conf/1.0/application.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.81.0
+  version: 0.90.0
   title: Pillar 2 API
   description: An API for managing and retrieving data in accordance with Pillar 2
     tax rules.
@@ -35,6 +35,14 @@ paths:
           \ the test organisation."
         schema:
           type: string
+        required: false
+      - name: Accept
+        in: header
+        description: Specifies the expected response format as versioned JSON from
+          the HMRC API (v1.0). If not provided, it will default to application/vnd.hmrc.1.0+json.
+        schema:
+          type: string
+          example: application/vnd.hmrc.1.0+json
         required: false
       summary: Create Test Organisation
       responses:
@@ -130,6 +138,14 @@ paths:
         schema:
           type: string
         required: false
+      - name: Accept
+        in: header
+        description: Specifies the expected response format as versioned JSON from
+          the HMRC API (v1.0). If not provided, it will default to application/vnd.hmrc.1.0+json.
+        schema:
+          type: string
+          example: application/vnd.hmrc.1.0+json
+        required: false
       summary: Get Test Organisation
       responses:
         "404":
@@ -213,6 +229,14 @@ paths:
           \ the test organisation."
         schema:
           type: string
+        required: false
+      - name: Accept
+        in: header
+        description: Specifies the expected response format as versioned JSON from
+          the HMRC API (v1.0). If not provided, it will default to application/vnd.hmrc.1.0+json.
+        schema:
+          type: string
+          example: application/vnd.hmrc.1.0+json
         required: false
       summary: Update Test Organisation
       responses:
@@ -308,6 +332,14 @@ paths:
         schema:
           type: string
         required: false
+      - name: Accept
+        in: header
+        description: Specifies the expected response format as versioned JSON from
+          the HMRC API (v1.0). If not provided, it will default to application/vnd.hmrc.1.0+json.
+        schema:
+          type: string
+          example: application/vnd.hmrc.1.0+json
+        required: false
       summary: Delete Test Organisation
       responses:
         "404":
@@ -358,24 +390,37 @@ paths:
         \ a SubmitUKTR or AmendUKTR API request is not processed successfully. Error\
         \ codes still in development are marked as \"awaiting clarification\".</p>\n\
         <table>\n<thead>\n<tr>\n<th>Error Message</th>\n<th>Next Steps</th>\n</tr>\n\
-        </thead>\n<tbody>\n<tr>\n<td>002 - Pillar 2 ID required</td>\n<td>Please provide\
-        \ the request header for your client, to check it contains the Pillar 2 ID\
-        \ they were assigned at registration.</td>\n</tr>\n<tr>\n<td>003 - Request\
-        \ could not be processed</td>\n<td>The message could not be processed due\
-        \ to locking. Please send the request again.</td>\n</tr>\n<tr>\n<td>007 -\
-        \ Business Partner does not have an Active Subscription</td>\n<td>The request\
-        \ Pillar 2 ID is not listed as active by HMRC. Please contact the central\
-        \ support team.</td>\n</tr>\n<tr>\n<td>044 - Tax Obligation Already Fulfilled</td>\n\
-        <td>A UKTR for the specified period has already been submitted. If you are\
-        \ trying to amend a UKTR, please check you are sending the <em>amendUKTR</em>\
-        \ API request.</td>\n</tr>\n<tr>\n<td>093 - Invalid Return</td>\n<td>There\
-        \ is an error with the tax return you’ve submitted in the request. Awaiting\
-        \ clarification.</td>\n</tr>\n<tr>\n<td>094 - Invalid DTT Election</td>\n\
-        <td>The DTT values in the request are invalid. Awaiting clarification.</td>\n\
+        </thead>\n<tbody>\n<tr>\n<td>002 - Pillar 2 ID (SAP Number) is missing or\
+        \ invalid</td>\n<td>Please provide the request header for your client, to\
+        \ check it contains the Pillar 2 ID (SAP Number) they were assigned at registration.</td>\n\
+        </tr>\n<tr>\n<td>003 - Request could not be processed</td>\n<td>The message\
+        \ could not be processed due to locking. Please check if there is currently\
+        \ an open enquiry on your tax account.</td>\n</tr>\n<tr>\n<td>044 - Tax Obligation\
+        \ Already Fulfilled</td>\n<td>A UKTR for the specified period has already\
+        \ been submitted. If you are trying to amend a UKTR, please check you are\
+        \ sending the <em>amendUKTR</em> API request.</td>\n</tr>\n<tr>\n<td>063 -\
+        \ Business Partner does not have an Active Pillar 2 Subscription</td>\n<td>The\
+        \ Pillar 2 ID (SAP Number) in the request header is not listed as active by\
+        \ HMRC for this regime. Please contact the central support team.</td>\n</tr>\n\
+        <tr>\n<td>093 - Invalid Return</td>\n<td>There is an error with the tax return\
+        \ you’ve submitted in the request. Please check the <em>accountingPeriodFrom</em>\
+        \ and <em>accountingPeriodTo</em> fields to ensure the dates are valid. If\
+        \ you need to check or amend the accounting period pattern, you can do this\
+        \ on the Pillar 2 site under “Personal Details”.</td>\n</tr>\n<tr>\n<td>094\
+        \ - Invalid DTT Election</td>\n<td>The DTT values in the request are invalid.\
+        \ Please complete the following checks, then submit the request again. If\
+        \ <em>electionDTTSingleMember</em> is true, the <em>numberSubGroupDTT</em>\
+        \ should be greater than 0. This number represents the number of liable entities\
+        \ that owe a DTT amount greater than 0. The total number of liable entities\
+        \ who owe DTT in the payload should be the same as the number in <em>numberSubGroupDTT</em>.</td>\n\
         </tr>\n<tr>\n<td>095 - Invalid UTPR Election</td>\n<td>The UTPR values in\
-        \ the request are invalid. Awaiting clarification.</td>\n</tr>\n<tr>\n<td>096\
-        \ - Invalid Total Liability</td>\n<td>The <em>totalLiability</em> value in\
-        \ the request does not match the combined values of <em>totalLiabilityDTT</em>,\
+        \ the request are invalid. Please complete the following checks, then submit\
+        \ the request again. If <em>electionUTPRSingleMember</em> is true, the <em>numberSubGroupUTPR</em>\
+        \ should be greater than 0. This number represents the number of liable entities\
+        \ that owe a UTPR amount greater than 0. The total number of liable entities\
+        \ who owe UTPR in the payload should be the same as the number in <em>numberSubGroupUTPR</em>.</td>\n\
+        </tr>\n<tr>\n<td>096 - Invalid Total Liability</td>\n<td>The <em>totalLiability</em>\
+        \ value in the request does not match the combined values of <em>totalLiabilityDTT</em>,\
         \ <em>totalLiabilityIIR</em> and <em>totalLiabilityUTPR</em>. Please check\
         \ the sum of these fields matches the <em>totalLiability</em> value and submit\
         \ the request again.</td>\n</tr>\n<tr>\n<td>097 - Invalid Total Liability\
@@ -401,11 +446,25 @@ paths:
               - $ref: "#/components/schemas/UKTRSubmissionData"
               - $ref: "#/components/schemas/UKTRSubmissionNilReturn"
       parameters:
+      - name: Authorization
+        in: header
+        description: Bearer token for authentication
+        schema:
+          type: string
+        required: true
       - in: header
         name: X-Pillar2-Id
         schema:
           type: string
         description: Pillar2 ID for the submission. Mandatory if the user is an Agent
+      - name: Accept
+        in: header
+        description: Specifies the expected response format as versioned JSON from
+          the HMRC API (v1.0). If not provided, it will default to application/vnd.hmrc.1.0+json.
+        schema:
+          type: string
+          example: application/vnd.hmrc.1.0+json
+        required: false
       summary: SubmitUKTR
       responses:
         "400":
@@ -540,11 +599,25 @@ paths:
               - $ref: "#/components/schemas/UKTRSubmissionData"
               - $ref: "#/components/schemas/UKTRSubmissionNilReturn"
       parameters:
+      - name: Authorization
+        in: header
+        description: Bearer token for authentication
+        schema:
+          type: string
+        required: true
       - in: header
         name: X-Pillar2-Id
         schema:
           type: string
         description: Pillar2 ID for the submission. Mandatory if the user is an Agent
+      - name: Accept
+        in: header
+        description: Specifies the expected response format as versioned JSON from
+          the HMRC API (v1.0). If not provided, it will default to application/vnd.hmrc.1.0+json.
+        schema:
+          type: string
+          example: application/vnd.hmrc.1.0+json
+        required: false
       summary: AmendUKTR
       responses:
         "400":
@@ -674,20 +747,20 @@ paths:
         </thead>
         <tbody>
         <tr>
-        <td>002 - Pillar2 ID is missing or invalid</td>
-        <td>Please provide the request header for your client, to check it contains the Pillar 2 ID they were assigned at registration.</td>
+        <td>002 - Pillar2 ID (SAP Number) is missing or invalid</td>
+        <td>Please provide the request header for your client, to check it contains the Pillar 2 ID (SAP Number) they were assigned at registration.</td>
         </tr>
         <tr>
         <td>003 - Request could not be processed</td>
-        <td>The message could not be processed due to locking. Please send the request again.</td>
-        </tr>
-        <tr>
-        <td>007 - Business Partner does not have an Active Pillar 2 registration</td>
-        <td>The request Pillar 2 ID is not listed as active by HMRC. Please contact the central support team.</td>
+        <td>The message could not be processed due to locking. Please check if there is currently an open enquiry on your tax account.</td>
         </tr>
         <tr>
         <td>044 - Tax Obligation already fulfilled</td>
-        <td>A BTN for the specified period has already been  submitted.</td>
+        <td>A BTN for the specified period has already been submitted.</td>
+        </tr>
+        <tr>
+        <td>063 - Business Partner does not have an Active Pillar 2 Subscription</td>
+        <td>The Pillar 2 ID (SAP Number) in the request header is not listed as active by HMRC for this regime. Please contact the central support team.</td>
         </tr>
         </tbody>
         </table>
@@ -700,11 +773,25 @@ paths:
             schema:
               $ref: "#/components/schemas/BTNSubmission"
       parameters:
+      - name: Authorization
+        in: header
+        description: Bearer token for authentication
+        schema:
+          type: string
+        required: true
       - in: header
         name: X-Pillar2-Id
         schema:
           type: string
         description: Pillar2 ID for the submission. Mandatory if the user is an Agent
+      - name: Accept
+        in: header
+        description: Specifies the expected response format as versioned JSON from
+          the HMRC API (v1.0). If not provided, it will default to application/vnd.hmrc.1.0+json.
+        schema:
+          type: string
+          example: application/vnd.hmrc.1.0+json
+        required: false
       summary: SubmitBTN
       responses:
         "400":

--- a/resources/public/api/conf/1.0/testOnly/application.yaml
+++ b/resources/public/api/conf/1.0/testOnly/application.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.87.0
+  version: 0.90.0
   title: Pillar 2 API
   description: An API for managing and retrieving data in accordance with Pillar 2
     tax rules.
@@ -35,6 +35,14 @@ paths:
           \ the test organisation."
         schema:
           type: string
+        required: false
+      - name: Accept
+        in: header
+        description: "Specifies the expected response format as versioned JSON from\
+          \ the HMRC API (v1.0). If not provided, it will default to application/vnd.hmrc.1.0+json."
+        schema:
+          type: string
+          example: application/vnd.hmrc.1.0+json
         required: false
       summary: Create Test Organisation
       responses:
@@ -130,6 +138,14 @@ paths:
         schema:
           type: string
         required: false
+      - name: Accept
+        in: header
+        description: "Specifies the expected response format as versioned JSON from\
+          \ the HMRC API (v1.0). If not provided, it will default to application/vnd.hmrc.1.0+json."
+        schema:
+          type: string
+          example: application/vnd.hmrc.1.0+json
+        required: false
       summary: Get Test Organisation
       responses:
         "404":
@@ -213,6 +229,14 @@ paths:
           \ the test organisation."
         schema:
           type: string
+        required: false
+      - name: Accept
+        in: header
+        description: "Specifies the expected response format as versioned JSON from\
+          \ the HMRC API (v1.0). If not provided, it will default to application/vnd.hmrc.1.0+json."
+        schema:
+          type: string
+          example: application/vnd.hmrc.1.0+json
         required: false
       summary: Update Test Organisation
       responses:
@@ -307,6 +331,14 @@ paths:
           \ the test organisation."
         schema:
           type: string
+        required: false
+      - name: Accept
+        in: header
+        description: "Specifies the expected response format as versioned JSON from\
+          \ the HMRC API (v1.0). If not provided, it will default to application/vnd.hmrc.1.0+json."
+        schema:
+          type: string
+          example: application/vnd.hmrc.1.0+json
         required: false
       summary: Delete Test Organisation
       responses:
@@ -414,11 +446,25 @@ paths:
               - $ref: "#/components/schemas/UKTRSubmissionData"
               - $ref: "#/components/schemas/UKTRSubmissionNilReturn"
       parameters:
+      - name: Authorization
+        in: header
+        description: Bearer token for authentication
+        schema:
+          type: string
+        required: true
       - in: header
         name: X-Pillar2-Id
         schema:
           type: string
         description: Pillar2 ID for the submission. Mandatory if the user is an Agent
+      - name: Accept
+        in: header
+        description: "Specifies the expected response format as versioned JSON from\
+          \ the HMRC API (v1.0). If not provided, it will default to application/vnd.hmrc.1.0+json."
+        schema:
+          type: string
+          example: application/vnd.hmrc.1.0+json
+        required: false
       summary: SubmitUKTR
       responses:
         "400":
@@ -553,11 +599,25 @@ paths:
               - $ref: "#/components/schemas/UKTRSubmissionData"
               - $ref: "#/components/schemas/UKTRSubmissionNilReturn"
       parameters:
+      - name: Authorization
+        in: header
+        description: Bearer token for authentication
+        schema:
+          type: string
+        required: true
       - in: header
         name: X-Pillar2-Id
         schema:
           type: string
         description: Pillar2 ID for the submission. Mandatory if the user is an Agent
+      - name: Accept
+        in: header
+        description: "Specifies the expected response format as versioned JSON from\
+          \ the HMRC API (v1.0). If not provided, it will default to application/vnd.hmrc.1.0+json."
+        schema:
+          type: string
+          example: application/vnd.hmrc.1.0+json
+        required: false
       summary: AmendUKTR
       responses:
         "400":
@@ -713,11 +773,25 @@ paths:
             schema:
               $ref: "#/components/schemas/BTNSubmission"
       parameters:
+      - name: Authorization
+        in: header
+        description: Bearer token for authentication
+        schema:
+          type: string
+        required: true
       - in: header
         name: X-Pillar2-Id
         schema:
           type: string
         description: Pillar2 ID for the submission. Mandatory if the user is an Agent
+      - name: Accept
+        in: header
+        description: "Specifies the expected response format as versioned JSON from\
+          \ the HMRC API (v1.0). If not provided, it will default to application/vnd.hmrc.1.0+json."
+        schema:
+          type: string
+          example: application/vnd.hmrc.1.0+json
+        required: false
       summary: SubmitBTN
       responses:
         "400":
@@ -851,11 +925,25 @@ paths:
         required: true
         schema:
           type: string
+      - name: Authorization
+        in: header
+        description: Bearer token for authentication
+        schema:
+          type: string
+        required: true
       - in: header
         name: X-Pillar2-Id
         schema:
           type: string
         description: Pillar2 ID for the submission. Mandatory if the user is an Agent
+      - name: Accept
+        in: header
+        description: "Specifies the expected response format as versioned JSON from\
+          \ the HMRC API (v1.0). If not provided, it will default to application/vnd.hmrc.1.0+json."
+        schema:
+          type: string
+          example: application/vnd.hmrc.1.0+json
+        required: false
       summary: Retrieve Obligations and Submissions
       responses:
         "400":


### PR DESCRIPTION
This PR addresses the requirement to add specific headers to the OpenAPI specification. 

Following headers are added 
**Accept Header:**
Optional value: application/vnd.hmrc.1.0+json

**Authorization Header:**
Should contain a bearerToken for proper authentication.