### PR TITLE
[PIL-1781-correct-order] Maintain order of attributes

### DIFF
--- a/project/JsonToYaml.scala
+++ b/project/JsonToYaml.scala
@@ -1,17 +1,27 @@
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.dataformat.yaml.{YAMLFactory, YAMLGenerator}
+import com.fasterxml.jackson.dataformat.yaml.{YAMLFactory, YAMLGenerator, YAMLMapper}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import com.iheart.sbtPlaySwagger.SwaggerPlugin.autoImport.{swagger, swaggerDomainNameSpaces}
-import sbt.Keys._
-import sbt._
+import com.iheart.sbtPlaySwagger.SwaggerPlugin.autoImport.swagger
+import play.api.libs.functional.syntax.*
+import play.api.libs.json.*
+import play.api.libs.json.Reads.*
+import sbt.*
+import sbt.Keys.*
 
-import scala.collection.mutable
-import scala.util.Try
+import scala.language.postfixOps
 
 object JsonToYaml {
 
   val apiContext      = "/organisations/pillar-two"
   val routesToYamlOas = taskKey[Unit]("Generate YAML OpenAPI specification from JSON")
+
+  val updateVersion = (__ \ "info" \ "version").json.update(
+    __.read[String]
+      .map { obj =>
+        JsString(obj.stripSuffix("-SNAPSHOT"))
+      }
+  )
+
   def settings: Seq[Setting[_]] = Seq(
     routesToYamlOas := {
       swagger.value
@@ -20,30 +30,43 @@ object JsonToYaml {
         .configure(YAMLGenerator.Feature.WRITE_DOC_START_MARKER, false)
         .configure(YAMLGenerator.Feature.MINIMIZE_QUOTES, true)
       val jsonMapper = new ObjectMapper().registerModule(DefaultScalaModule)
-      val yamlMapper = new ObjectMapper(yamlFactory).registerModule(DefaultScalaModule)
+      val yamlMapper = new YAMLMapper().registerModule(DefaultScalaModule)
 
       val jsonFile: File = baseDirectory.value / "target/swagger/swagger.json"
       val yamlFile: File = baseDirectory.value / "target/swagger/application.yaml"
 
-      Try {
-        val jsonString = IO.read(jsonFile)
-        val jsonMap    = jsonMapper.readValue(jsonString, classOf[Map[String, Any]])
+      val jsonString = IO.read(jsonFile)
+      val paths      = (Json.parse(jsonString) \ "paths").as[JsObject].keys.toList.reverse
 
-        val specification = mutable.LinkedHashMap(
-          "openapi" -> jsonMap("openapi"),
-          "info"    -> (jsonMap("info").asInstanceOf[Map[String, Any]] + ("version" -> version.value.stripSuffix("-SNAPSHOT"))),
-          "tags"    -> jsonMap("tags"),
-          "paths" -> jsonMap("paths")
-            .asInstanceOf[Map[String, Any]]
-            .map((t: (String, Any)) => s"$apiContext${t._1}" -> t._2),
-          "components" -> jsonMap("components")
-        )
+      val parsedJson = Json
+        .parse(jsonString)
 
-        val yamlString    = yamlMapper.writeValueAsString(specification)
-        val formattedYaml = swaggerDomainNameSpaces.value.foldLeft(yamlString)((line, path) => line.replace(s"$path.", ""))
-        IO.write(yamlFile, formattedYaml)
-      }.map(_ => jsonFile.delete)
-        .recover { case ex: Exception => streams.value.log.error(s"Failed to convert JSON to YAML: $ex") }
+      val copyToNewPaths: Reads[JsObject] = paths
+        .map { path =>
+          __.read[JsObject]
+            .flatMapResult { obj =>
+              obj.transform(
+                __.read[JsObject]
+                  .map(o =>
+                    o ++ JsObject(
+                      List(s"$apiContext$path" -> (parsedJson \ "paths" \ path).as[JsObject])
+                    )
+                  )
+              )
+            }
+        }
+        .fold(__.read[JsObject].map(identity))((a, b) => (a and b).reduce)
+
+      val removeOldPaths = paths.map(path => (__ \ "paths" \ path).json.prune).fold(__.read[JsObject].map(identity))((a, b) => a andThen b)
+
+      val json = parsedJson
+        .transform(updateVersion andThen (__ \ "paths").json.update(copyToNewPaths) andThen removeOldPaths)
+        .get
+
+      val jsonNodeTree = jsonMapper.readTree(json.toString)
+
+      val jsonAsYaml = yamlMapper.writeValueAsString(jsonNodeTree)
+      IO.write(yamlFile, jsonAsYaml)
     }
   )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,9 +2,10 @@ resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefac
 resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 resolvers += Resolver.typesafeRepo("releases")
 libraryDependencies ++= Seq(
-  "com.fasterxml.jackson.module"    %% "jackson-module-scala"    % "2.18.2",
-  "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % "2.17.2",
-  "io.swagger.parser.v3"             % "swagger-parser"          % "2.1.23"
+  "com.fasterxml.jackson.module"    %% "jackson-module-scala"    % "2.18.3",
+  "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % "2.18.3",
+  "io.swagger.parser.v3"             % "swagger-parser"          % "2.1.26",
+  "org.playframework"               %% "play-json"               % "3.0.4"
 )
 
 addSbtPlugin("uk.gov.hmrc"            % "sbt-auto-build"     % "3.24.0")


### PR DESCRIPTION
Maintain order of attributes. This was an issue because anything created in swagger.yaml doesn't come out in the same order.

This happened because the jsonMapper is parsing the JSON as:
```
val jsonMap    = jsonMapper.readValue(jsonString, classOf[Map[String, Any]])
```

This created all objects as `Map[String, Any]` which is not ordered. This creates a random ordering of attributes that is carried forward into the yaml.

**The fix**
Now, instead of using Jackson to parse into a Map and modify keys, we are using Play Json transformation. This maintains the order of attributes because the JSON isn't being parsed.