### PR TITLE
PIL-1780 Update bounds to be in spec

### DIFF
--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandler.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandler.scala
@@ -50,7 +50,6 @@ class Pillar2ErrorHandler extends HttpErrorHandler with Logging {
           case e @ DatabaseError(_)                               => Results.InternalServerError(Pillar2ErrorResponse(e.code, e.message))
           case e @ UnexpectedResponse                             => Results.InternalServerError(Pillar2ErrorResponse(e.code, e.message))
           case e @ TestEndpointDisabled()                         => Results.Forbidden(Pillar2ErrorResponse(e.code, e.message))
-          case e: MonetaryValidationError => Results.BadRequest(Pillar2ErrorResponse(e.code, e.message))
         }
         logger.warn(s"Caught Pillar2Error. Returning ${ret.header.status} statuscode", exception)
         Future.successful(ret)

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/error/Pillar2Error.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/error/Pillar2Error.scala
@@ -85,11 +85,3 @@ case class TestEndpointDisabled() extends Pillar2Error {
   override val code:    String = "403"
   override val message: String = "Test endpoints are not available in this environment"
 }
-
-sealed trait MonetaryValidationError extends Pillar2Error {
-  val code = "400"
-}
-
-case object MonetaryValidationError extends MonetaryValidationError {
-  val message = "Number field invalid length"
-}

--- a/conf/swagger-custom-mappings.yml
+++ b/conf/swagger-custom-mappings.yml
@@ -3,3 +3,9 @@
   specAsParameter:
     - type: string
       format: date-time
+- type: BigDecimal
+  specAsParameter:
+    - type: number
+      format: double
+      minimum: 0
+      maximum: 9999999999999.99

--- a/resources/public/api/conf/1.0/testOnly/application.yaml
+++ b/resources/public/api/conf/1.0/testOnly/application.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.87.0
+  version: 0.93.0
   title: Pillar 2 API
   description: An API for managing and retrieving data in accordance with Pillar 2
     tax rules.
@@ -1043,12 +1043,18 @@ components:
         amountOwedUTPR:
           type: number
           format: double
+          minimum: 0
+          maximum: 9.99999999999999E12
         amountOwedIIR:
           type: number
           format: double
+          minimum: 0
+          maximum: 9.99999999999999E12
         amountOwedDTT:
           type: number
           format: double
+          minimum: 0
+          maximum: 9.99999999999999E12
       required:
       - ukChargeableEntityName
       - idType
@@ -1142,9 +1148,13 @@ components:
         totalLiabilityDTT:
           type: number
           format: double
+          minimum: 0
+          maximum: 9.99999999999999E12
         totalLiabilityUTPR:
           type: number
           format: double
+          minimum: 0
+          maximum: 9.99999999999999E12
         numberSubGroupUTPR:
           type: integer
           format: int32
@@ -1155,9 +1165,13 @@ components:
         totalLiabilityIIR:
           type: number
           format: double
+          minimum: 0
+          maximum: 9.99999999999999E12
         totalLiability:
           type: number
           format: double
+          minimum: 0
+          maximum: 9.99999999999999E12
       required:
       - electionDTTSingleMember
       - electionUTPRSingleMember

--- a/test/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandlerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandlerSpec.scala
@@ -153,12 +153,4 @@ class Pillar2ErrorHandlerSpec extends AnyFunSuite with ScalaCheckDrivenPropertyC
     result.code mustEqual "500"
     result.message mustEqual "Internal Server Error"
   }
-
-  test("MonetaryValidationError error response") {
-    val response = classUnderTest.onServerError(dummyRequest, MonetaryValidationError)
-    status(response) mustEqual 400
-    val result = contentAsJson(response).as[Pillar2ErrorResponse]
-    result.code mustEqual "400"
-    result.message mustEqual "Number field invalid length"
-  }
 }


### PR DESCRIPTION
Add bounds to API spec for our bigdecimals

As a note the openapi spec yaml shows
```
maximum: 9.99999999999999E12
```

but the actual rendered spec looks fine:
![image](https://github.com/user-attachments/assets/6c9748dc-ea88-4e87-b50d-ddce0acf6c3f)
