### PR TITLE
PIL - 1845 : Submit ORN via Submissions API

### DIFF
--- a/API Testing/orn/Submit Empty ORN.bru
+++ b/API Testing/orn/Submit Empty ORN.bru
@@ -1,0 +1,31 @@
+meta {
+  name: Submit Empty ORN
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{submissionsApiBaseUrl}}/overseas-return-notification
+  body: json
+  auth: none
+}
+
+headers {
+  Authorization: {{bearerToken}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+  }
+}
+
+tests {
+  test("should return 400 Bad Request", function() {
+    expect(res.getStatus()).to.equal(400);
+  });
+  
+  test("should contain correct error message", function() {
+    expect(res.body.message).to.equal("Invalid JSON Payload");
+  });
+}

--- a/API Testing/orn/Submit Invalid ORN.bru
+++ b/API Testing/orn/Submit Invalid ORN.bru
@@ -1,0 +1,32 @@
+meta {
+  name: Submit Invalid ORN
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{submissionsApiBaseUrl}}/overseas-return-notification
+  body: json
+  auth: none
+}
+
+headers {
+  Authorization: {{bearerToken}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "badRequest": ""
+  }
+}
+
+tests {
+  test("should return 400 Bad Request", function() {
+    expect(res.getStatus()).to.equal(400);
+  });
+  
+  test("should contain correct error message", function() {
+    expect(res.body.message).to.equal("Invalid JSON Payload");
+  });
+}

--- a/API Testing/orn/Submit ORN Success.bru
+++ b/API Testing/orn/Submit ORN Success.bru
@@ -1,0 +1,39 @@
+meta {
+  name: Submit ORN Success
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{submissionsApiBaseUrl}}/overseas-return-notification
+  body: json
+  auth: none
+}
+
+headers {
+  Authorization: {{bearerToken}}
+  Content-Type: application/json
+  ~X-Pillar2-Id: XMPLR0012345674
+}
+
+body:json {
+  {
+    "accountingPeriodFrom": "2024-01-01",
+    "accountingPeriodTo": "2024-12-31",
+    "filedDateGIR": "2025-01-10",
+    "countryGIR": "US",
+    "reportingEntityName": "Newco PLC",
+    "TIN": "US12345678",
+    "issuingCountryTIN": "US"
+  }
+}
+
+tests {
+  test("should return 201 Created", function() {
+    expect(res.getStatus()).to.equal(201);
+  });
+  
+  test("should contain all required fields", function() {
+    expect(res.body.processingDate).to.not.be.undefined;
+  });
+}

--- a/API Testing/orn/Submit ORN Unauthorized.bru
+++ b/API Testing/orn/Submit ORN Unauthorized.bru
@@ -1,0 +1,33 @@
+meta {
+  name: Submit ORN Unauthorized
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{submissionsApiBaseUrl}}/overseas-return-notification
+  body: json
+  auth: none
+}
+
+headers {
+  Authorization: "Bearer invalid-token"
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "accountingPeriodFrom": "2024-01-01",
+    "accountingPeriodTo": "2025-01-01"
+  }
+}
+
+tests {
+  test("should return 401 Unauthorized", function() {
+    expect(res.getStatus()).to.equal(401);
+  });
+  
+  test("should contain correct error message", function() {
+    expect(res.body.message).to.equal("Not authorized");
+  });
+}

--- a/API Testing/orn/Submit ORN with Duplicate Fields.bru
+++ b/API Testing/orn/Submit ORN with Duplicate Fields.bru
@@ -1,0 +1,37 @@
+meta {
+  name: Submit ORN with Duplicate Fields
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{submissionsApiBaseUrl}}/overseas-return-notification
+  body: json
+  auth: none
+}
+
+headers {
+  Authorization: {{bearerToken}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "accountingPeriodFrom": "2024-01-01",
+    "accountingPeriodTo": "2025-01-01",
+    "accountingPeriodFrom": "2024-01-01",
+    "accountingPeriodTo": "2025-01-01",
+    "extraField1": "value1",
+    "extraField1": "value2"
+  }
+}
+
+tests {
+  test("should return 201 Created", function() {
+    expect(res.getStatus()).to.equal(201);
+  });
+  
+  test("should contain all required fields", function() {
+    expect(res.body.processingDate).to.not.be.undefined;
+  });
+}

--- a/app/uk/gov/hmrc/pillar2submissionapi/connectors/SubmitORNConnector.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/connectors/SubmitORNConnector.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2submissionapi.connectors
+
+import play.api.Logging
+import play.api.libs.json.Format.GenericFormat
+import play.api.libs.json.Json
+import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.http.client.HttpClientV2
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.pillar2submissionapi.config.AppConfig
+import uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification.ORNSubmission
+
+import java.net.URI
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class SubmitORNConnector @Inject() (val config: AppConfig, val http: HttpClientV2)(implicit ec: ExecutionContext) extends Logging {
+
+  private val ORNSubmissionUrl: String = s"${config.pillar2BaseUrl}/report-pillar2-top-up-taxes/overseas-return-notification/submit"
+
+  def submitORN(ORNSubmission: ORNSubmission)(implicit hc: HeaderCarrier): Future[HttpResponse] = {
+    logger.info(s"Calling $ORNSubmissionUrl to submit a BTN")
+    http
+      .post(URI.create(ORNSubmissionUrl).toURL)
+      .withBody(Json.toJson(ORNSubmission))
+      .execute[HttpResponse]
+  }
+}

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandler.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandler.scala
@@ -50,6 +50,7 @@ class Pillar2ErrorHandler extends HttpErrorHandler with Logging {
           case e @ DatabaseError(_)                               => Results.InternalServerError(Pillar2ErrorResponse(e.code, e.message))
           case e @ UnexpectedResponse                             => Results.InternalServerError(Pillar2ErrorResponse(e.code, e.message))
           case e @ TestEndpointDisabled()                         => Results.Forbidden(Pillar2ErrorResponse(e.code, e.message))
+          case e @ ORNValidationError(_, _)                       => Results.UnprocessableEntity(Pillar2ErrorResponse(e.code, e.message))
         }
         logger.warn(s"Caught Pillar2Error. Returning ${ret.header.status} statuscode", exception)
         Future.successful(ret)

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandler.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandler.scala
@@ -45,12 +45,12 @@ class Pillar2ErrorHandler extends HttpErrorHandler with Logging {
           case e @ UktrValidationError(_, _)                      => Results.UnprocessableEntity(Pillar2ErrorResponse(e.code, e.message))
           case e @ BTNValidationError(_, _)                       => Results.UnprocessableEntity(Pillar2ErrorResponse(e.code, e.message))
           case e @ ObligationsAndSubmissionsValidationError(_, _) => Results.UnprocessableEntity(Pillar2ErrorResponse(e.code, e.message))
+          case e @ ORNValidationError(_, _)                       => Results.UnprocessableEntity(Pillar2ErrorResponse(e.code, e.message))
           case e @ OrganisationAlreadyExists(_)                   => Results.Conflict(Pillar2ErrorResponse(e.code, e.message))
           case e @ OrganisationNotFound(_)                        => Results.NotFound(Pillar2ErrorResponse(e.code, e.message))
           case e @ DatabaseError(_)                               => Results.InternalServerError(Pillar2ErrorResponse(e.code, e.message))
           case e @ UnexpectedResponse                             => Results.InternalServerError(Pillar2ErrorResponse(e.code, e.message))
           case e @ TestEndpointDisabled()                         => Results.Forbidden(Pillar2ErrorResponse(e.code, e.message))
-          case e @ ORNValidationError(_, _)                       => Results.UnprocessableEntity(Pillar2ErrorResponse(e.code, e.message))
         }
         logger.warn(s"Caught Pillar2Error. Returning ${ret.header.status} statuscode", exception)
         Future.successful(ret)

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/error/Pillar2Error.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/error/Pillar2Error.scala
@@ -85,3 +85,5 @@ case class TestEndpointDisabled() extends Pillar2Error {
   override val code:    String = "403"
   override val message: String = "Test endpoints are not available in this environment"
 }
+
+case class ORNValidationError(code: String, message: String) extends Pillar2Error

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/submission/ORNSubmissionController.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/submission/ORNSubmissionController.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2submissionapi.controllers.submission
+
+import play.api.libs.json.{JsError, JsSuccess, Json}
+import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.pillar2submissionapi.controllers.actions.{IdentifierAction, SubscriptionDataRetrievalAction}
+import uk.gov.hmrc.pillar2submissionapi.controllers.error.{EmptyRequestBody, InvalidJson}
+import uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification.ORNSubmission
+import uk.gov.hmrc.pillar2submissionapi.services.SubmitORNService
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class ORNSubmissionController @Inject() (
+  cc:               ControllerComponents,
+  identify:         IdentifierAction,
+  getSubscription:  SubscriptionDataRetrievalAction,
+  submitORNService: SubmitORNService
+)(implicit ec:      ExecutionContext)
+    extends BackendController(cc) {
+
+  def submitORN: Action[AnyContent] = (identify andThen getSubscription).async { request =>
+    implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequest(request).withExtraHeaders("X-Pillar2-Id" -> request.clientPillar2Id)
+    request.body.asJson match {
+      case Some(request) =>
+        request.validate[ORNSubmission] match {
+          case JsSuccess(value, _) =>
+            submitORNService
+              .submitORN(value)
+              .map(response => Created(Json.toJson(response)))
+          case JsError(_) => Future.failed(InvalidJson)
+        }
+      case None => Future.failed(EmptyRequestBody)
+    }
+  }
+}

--- a/app/uk/gov/hmrc/pillar2submissionapi/models/overseasreturnnotification/ORNErrorResponse.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/models/overseasreturnnotification/ORNErrorResponse.scala
@@ -18,8 +18,8 @@ package uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification
 
 import play.api.libs.json.{Json, OFormat}
 
-case class SubmitORNErrorResponse(code: String, message: String)
+case class ORNErrorResponse(code: String, message: String)
 
-case object SubmitORNErrorResponse {
-  implicit val errorFormat: OFormat[SubmitORNErrorResponse] = Json.format[SubmitORNErrorResponse]
+case object ORNErrorResponse {
+  implicit val errorFormat: OFormat[ORNErrorResponse] = Json.format[ORNErrorResponse]
 }

--- a/app/uk/gov/hmrc/pillar2submissionapi/models/overseasreturnnotification/ORNSubmission.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/models/overseasreturnnotification/ORNSubmission.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification
+
+import play.api.libs.json.{Json, OFormat}
+
+import java.time.LocalDate
+
+case class ORNSubmission(
+  accountingPeriodFrom: LocalDate,
+  accountingPeriodTo:   LocalDate,
+  filedDateGIR:         LocalDate,
+  countryGIR:           String,
+  reportingEntityName:  String,
+  TIN:                  String,
+  issuingCountryTIN:    String
+)
+
+object ORNSubmission {
+  implicit val ORNSubmission: OFormat[ORNSubmission] = Json.format[ORNSubmission]
+}

--- a/app/uk/gov/hmrc/pillar2submissionapi/models/overseasreturnnotification/ORNSuccessResponse.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/models/overseasreturnnotification/ORNSuccessResponse.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification
+
+import play.api.libs.json.{Json, OFormat}
+
+case class ORNSuccessResponse(processingDate: String, formBundleNumber: String)
+
+case object ORNSuccessResponse {
+  implicit val successFormat: OFormat[ORNSuccessResponse] = Json.format[ORNSuccessResponse]
+}

--- a/app/uk/gov/hmrc/pillar2submissionapi/models/overseasreturnnotification/SubmitORNErrorResponse.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/models/overseasreturnnotification/SubmitORNErrorResponse.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification
+
+import play.api.libs.json.{Json, OFormat}
+
+case class SubmitORNErrorResponse(code: String, message: String)
+
+case object SubmitORNErrorResponse {
+  implicit val errorFormat: OFormat[SubmitORNErrorResponse] = Json.format[SubmitORNErrorResponse]
+}

--- a/app/uk/gov/hmrc/pillar2submissionapi/models/overseasreturnnotification/SubmitORNSuccessResponse.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/models/overseasreturnnotification/SubmitORNSuccessResponse.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification
+
+import play.api.libs.json.{Json, OFormat}
+
+case class SubmitORNSuccessResponse(processingDate: String, formBundleNumber: String)
+
+case object SubmitORNSuccessResponse {
+  implicit val successFormat: OFormat[SubmitORNSuccessResponse] = Json.format[SubmitORNSuccessResponse]
+}

--- a/app/uk/gov/hmrc/pillar2submissionapi/services/SubmitORNService.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/services/SubmitORNService.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2submissionapi.services
+
+import com.google.inject.{Inject, Singleton}
+import play.api.Logging
+import play.api.libs.json.{JsError, JsSuccess}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.pillar2submissionapi.connectors.SubmitORNConnector
+import uk.gov.hmrc.pillar2submissionapi.controllers.error.{ORNValidationError, UnexpectedResponse}
+import uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification.{ORNSubmission, SubmitORNErrorResponse, SubmitORNSuccessResponse}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class SubmitORNService @Inject() (submitORNConnector: SubmitORNConnector)(implicit val ec: ExecutionContext) extends Logging {
+
+  def submitORN(request: ORNSubmission)(implicit hc: HeaderCarrier): Future[SubmitORNSuccessResponse] =
+    submitORNConnector.submitORN(request).map(convertToResult)
+
+  private def convertToResult(response: HttpResponse): SubmitORNSuccessResponse =
+    response.status match {
+      case 201 =>
+        response.json.validate[SubmitORNSuccessResponse] match {
+          case JsSuccess(success, _) => success
+          case JsError(_) =>
+            logger.error("Failed to parse success response")
+            throw UnexpectedResponse
+        }
+      case 422 =>
+        response.json.validate[SubmitORNErrorResponse] match {
+          case JsSuccess(response, _) => throw ORNValidationError(response.code, response.message)
+          case JsError(_) =>
+            logger.error("Failed to parse unprocessible entity response")
+            throw UnexpectedResponse
+        }
+      case status =>
+        logger.error(s"Error calling pillar2 backend. Got response: $status")
+        throw UnexpectedResponse
+    }
+}

--- a/app/uk/gov/hmrc/pillar2submissionapi/services/SubmitORNService.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/services/SubmitORNService.scala
@@ -22,27 +22,27 @@ import play.api.libs.json.{JsError, JsSuccess}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2submissionapi.connectors.SubmitORNConnector
 import uk.gov.hmrc.pillar2submissionapi.controllers.error.{ORNValidationError, UnexpectedResponse}
-import uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification.{ORNSubmission, SubmitORNErrorResponse, SubmitORNSuccessResponse}
+import uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification.{ORNErrorResponse, ORNSubmission, ORNSuccessResponse}
 
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class SubmitORNService @Inject() (submitORNConnector: SubmitORNConnector)(implicit val ec: ExecutionContext) extends Logging {
 
-  def submitORN(request: ORNSubmission)(implicit hc: HeaderCarrier): Future[SubmitORNSuccessResponse] =
+  def submitORN(request: ORNSubmission)(implicit hc: HeaderCarrier): Future[ORNSuccessResponse] =
     submitORNConnector.submitORN(request).map(convertToResult)
 
-  private def convertToResult(response: HttpResponse): SubmitORNSuccessResponse =
+  private def convertToResult(response: HttpResponse): ORNSuccessResponse =
     response.status match {
       case 201 =>
-        response.json.validate[SubmitORNSuccessResponse] match {
+        response.json.validate[ORNSuccessResponse] match {
           case JsSuccess(success, _) => success
           case JsError(_) =>
             logger.error("Failed to parse success response")
             throw UnexpectedResponse
         }
       case 422 =>
-        response.json.validate[SubmitORNErrorResponse] match {
+        response.json.validate[ORNErrorResponse] match {
           case JsSuccess(response, _) => throw ORNValidationError(response.code, response.message)
           case JsError(_) =>
             logger.error("Failed to parse unprocessible entity response")

--- a/conf/submission.routes
+++ b/conf/submission.routes
@@ -525,7 +525,7 @@ GET       /obligations-and-submissions              uk.gov.hmrc.pillar2submissio
 #     content:
 #       application/json:
 #         schema:
-#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification.SubmitORNSuccessResponse'
+#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification.ORNSuccessResponse'
 #         example:
 #           processingDate: "2025-01-31T09:26:17Z"
 #           formBundleNumber: "123456789012345"

--- a/conf/submission.routes
+++ b/conf/submission.routes
@@ -492,3 +492,125 @@ POST       /below-threshold-notification              uk.gov.hmrc.pillar2submiss
 #               message: "Internal Server Error"
 ###
 GET       /obligations-and-submissions              uk.gov.hmrc.pillar2submissionapi.controllers.obligationsandsubmissions.ObligationsAndSubmissionsController.retrieveData(fromDate: String, toDate: String)
+
+###
+# summary: Submit a Pillar2  Overseas Return Notification
+# parameters:
+#   - in: header
+#     name: X-Pillar2-Id
+#     schema:
+#       type: string
+#     description: Pillar2 ID for the submission. Mandatory if the user is an Agent
+#   - in: header
+#     name: Authorization
+#     required: true
+#     schema:
+#       type: string
+#     description: Bearer token for authentication
+#   - in: header
+#     name: Accept
+#     required: false
+#     schema:
+#       type: string
+#       example: application/vnd.hmrc.1.0+json
+#     description: Specifies the expected response format as versioned JSON from the HMRC API (v1.0). If not provided, it will default to application/vnd.hmrc.1.0+json.
+# requestBody:
+#   content:
+#     application/json:
+#       schema:
+#         $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification.ORNSubmission'
+# responses:
+#   201:
+#     description: Overseas Return Notification Submission Created
+#     content:
+#       application/json:
+#         schema:
+#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification.SubmitORNSuccessResponse'
+#         example:
+#           processingDate: "2025-01-31T09:26:17Z"
+#           formBundleNumber: "123456789012345"
+#   401:
+#     description: Unauthorized
+#     content:
+#       application/json:
+#         schema:
+#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
+#         example:
+#           code: '003'
+#           message: Not authorized
+#   422:
+#     description: Business Validation Failure
+#     content:
+#       application/json:
+#         schema:
+#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
+#         examples:
+#           Invalid Pillar2ID:
+#             value:
+#               code: '002'
+#               message: Pillar 2 ID missing or invalid
+#           Invalid Request:
+#             value:
+#               code: '003'
+#               message: Request could not be processed
+#           Duplicate Acknowledgment:
+#             value:
+#               code: '004'
+#               message: Duplicate acknowledgment reference
+#           No Active Submission:
+#             value:
+#               code: '007'
+#               message: Business Partner does not have an Active Pillar 2 registration
+#           Tax Obligation Fulfilled:
+#             value:
+#               code: '044'
+#               message: Tax Obligation already fulfilled
+#           Invalid Return:
+#             value:
+#               code: '093'
+#               message: Invalid Return
+#   400:
+#     description: Bad Request
+#     content:
+#       application/json:
+#         schema:
+#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
+#         examples:
+#           Invalid Json:
+#             value:
+#               code: "001"
+#               message: "Invalid JSON payload"
+#           Empty Request Body:
+#             value:
+#               code: "002"
+#               message: "Empty body in request"
+#           Missing Header:
+#             value:
+#               code: "005"
+#               message: "Missing Header in request"
+#   403:
+#     description: Forbidden
+#     content:
+#       application/json:
+#         schema:
+#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
+#         example:
+#           code: "006"
+#           message: "Forbidden"
+#   500:
+#     description: Internal Server Error
+#     content:
+#       application/json:
+#         schema:
+#           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
+#         examples:
+#           Generic Server Error:
+#             value:
+#               code: "500"
+#               message: "Internal Server Error"
+#           No Subscription Data:
+#             value:
+#               code: "004"
+#               message: "No Pillar2 subscription found for [pillar2Id]"
+###
+POST /overseas-return-notification  uk.gov.hmrc.pillar2submissionapi.controllers.submission.ORNSubmissionController.submitORN

--- a/conf/submission.routes
+++ b/conf/submission.routes
@@ -547,8 +547,8 @@ GET       /obligations-and-submissions              uk.gov.hmrc.pillar2submissio
 #         examples:
 #           Invalid Pillar2ID:
 #             value:
-#               code: '002'
-#               message: Pillar 2 ID missing or invalid
+#               code: '089'
+#               message: ID number missing or invalid
 #           Invalid Request:
 #             value:
 #               code: '003'
@@ -559,8 +559,8 @@ GET       /obligations-and-submissions              uk.gov.hmrc.pillar2submissio
 #               message: Duplicate acknowledgment reference
 #           No Active Submission:
 #             value:
-#               code: '007'
-#               message: Business Partner does not have an Active Pillar 2 registration
+#               code: '063'
+#               message: Business Partner does not have an Active Subscription for this Regime
 #           Tax Obligation Fulfilled:
 #             value:
 #               code: '044'

--- a/it/test/uk/gov/hmrc/pillar2submissionapi/ORNSubmissionISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2submissionapi/ORNSubmissionISpec.scala
@@ -34,7 +34,7 @@ import uk.gov.hmrc.pillar2submissionapi.base.IntegrationSpecBase
 import uk.gov.hmrc.pillar2submissionapi.controllers.error.AuthenticationError
 import uk.gov.hmrc.pillar2submissionapi.controllers.submission.routes
 import uk.gov.hmrc.pillar2submissionapi.helpers.TestAuthRetrievals.Ops
-import uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification.{SubmitORNErrorResponse, SubmitORNSuccessResponse}
+import uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification.{ORNErrorResponse, ORNSuccessResponse}
 import uk.gov.hmrc.pillar2submissionapi.models.subscription.SubscriptionSuccess
 import uk.gov.hmrc.play.bootstrap.http.HttpClientV2Provider
 
@@ -63,10 +63,10 @@ class ORNSubmissionISpec extends IntegrationSpecBase with OptionValues {
           "POST",
           submitUrl,
           CREATED,
-          Json.toJson(SubmitORNSuccessResponse("2022-01-31T09:26:17Z", "123456789012345"))
+          Json.toJson(ORNSuccessResponse("2022-01-31T09:26:17Z", "123456789012345"))
         )
 
-        val result = Await.result(baseRequest.withBody(validRequestJson).execute[SubmitORNSuccessResponse], 5.seconds)
+        val result = Await.result(baseRequest.withBody(validRequestJson).execute[ORNSuccessResponse], 5.seconds)
 
         result.processingDate mustEqual "2022-01-31T09:26:17Z"
         result.formBundleNumber mustEqual "123456789012345"
@@ -118,11 +118,11 @@ class ORNSubmissionISpec extends IntegrationSpecBase with OptionValues {
           "POST",
           submitUrl,
           CREATED,
-          Json.toJson(SubmitORNSuccessResponse("2022-01-31T09:26:17Z", "123456789012345"))
+          Json.toJson(ORNSuccessResponse("2022-01-31T09:26:17Z", "123456789012345"))
         )
 
         val result =
-          Await.result(baseRequest.withBody(validRequestJson_duplicateFieldsAndAdditionalFields).execute[SubmitORNSuccessResponse], 5.seconds)
+          Await.result(baseRequest.withBody(validRequestJson_duplicateFieldsAndAdditionalFields).execute[ORNSuccessResponse], 5.seconds)
 
         result.processingDate mustEqual "2022-01-31T09:26:17Z"
         result.formBundleNumber mustEqual "123456789012345"
@@ -137,7 +137,7 @@ class ORNSubmissionISpec extends IntegrationSpecBase with OptionValues {
         val result = Await.result(baseRequest.withBody(validRequestJson).execute[HttpResponse], 5.seconds)
 
         result.status mustEqual UNAUTHORIZED
-        val errorResponse = result.json.as[SubmitORNErrorResponse]
+        val errorResponse = result.json.as[ORNErrorResponse]
         errorResponse.code mustEqual "003"
         errorResponse.message mustEqual "Not authorized"
       }
@@ -152,13 +152,13 @@ class ORNSubmissionISpec extends IntegrationSpecBase with OptionValues {
           "POST",
           submitUrl,
           UNPROCESSABLE_ENTITY,
-          Json.toJson(SubmitORNErrorResponse("093", "Invalid Return"))
+          Json.toJson(ORNErrorResponse("093", "Invalid Return"))
         )
 
         val result = Await.result(baseRequest.withBody(validRequestJson).execute[HttpResponse], 5.seconds)
 
         result.status mustEqual UNPROCESSABLE_ENTITY
-        val errorResponse = result.json.as[SubmitORNErrorResponse]
+        val errorResponse = result.json.as[ORNErrorResponse]
         errorResponse.code mustEqual "093"
         errorResponse.message mustEqual "Invalid Return"
       }
@@ -173,13 +173,13 @@ class ORNSubmissionISpec extends IntegrationSpecBase with OptionValues {
           "POST",
           submitUrl,
           UNAUTHORIZED,
-          Json.toJson(SubmitORNErrorResponse("001", "Unauthorized"))
+          Json.toJson(ORNErrorResponse("001", "Unauthorized"))
         )
 
         val result = Await.result(baseRequest.withBody(validRequestJson).execute[HttpResponse], 5.seconds)
 
         result.status mustEqual INTERNAL_SERVER_ERROR
-        val errorResponse = result.json.as[SubmitORNErrorResponse]
+        val errorResponse = result.json.as[ORNErrorResponse]
         errorResponse.code mustEqual "500"
         errorResponse.message mustEqual "Internal Server Error"
       }
@@ -194,13 +194,13 @@ class ORNSubmissionISpec extends IntegrationSpecBase with OptionValues {
           "POST",
           submitUrl,
           INTERNAL_SERVER_ERROR,
-          Json.toJson(SubmitORNErrorResponse("999", "internal_server_error"))
+          Json.toJson(ORNErrorResponse("999", "internal_server_error"))
         )
 
         val result = Await.result(baseRequest.withBody(validRequestJson).execute[HttpResponse], 5.seconds)
 
         result.status mustEqual INTERNAL_SERVER_ERROR
-        val errorResponse = result.json.as[SubmitORNErrorResponse]
+        val errorResponse = result.json.as[ORNErrorResponse]
         errorResponse.code mustEqual "500"
         errorResponse.message mustEqual "Internal Server Error"
       }
@@ -236,11 +236,11 @@ class ORNSubmissionISpec extends IntegrationSpecBase with OptionValues {
           "POST",
           submitUrl,
           CREATED,
-          Json.toJson(SubmitORNSuccessResponse("2022-01-31T09:26:17Z", "123456789012345"))
+          Json.toJson(ORNSuccessResponse("2022-01-31T09:26:17Z", "123456789012345"))
         )
 
         val result =
-          Await.result(baseRequest.withBody(validRequestJson).setHeader("X-Pillar2-Id" -> plrReference).execute[SubmitORNSuccessResponse], 5.seconds)
+          Await.result(baseRequest.withBody(validRequestJson).setHeader("X-Pillar2-Id" -> plrReference).execute[ORNSuccessResponse], 5.seconds)
 
         result.processingDate mustEqual "2022-01-31T09:26:17Z"
         result.formBundleNumber mustEqual "123456789012345"

--- a/it/test/uk/gov/hmrc/pillar2submissionapi/ORNSubmissionISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2submissionapi/ORNSubmissionISpec.scala
@@ -1,0 +1,283 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2submissionapi
+
+import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatest.OptionValues
+import play.api.http.Status._
+import play.api.libs.json.{JsObject, JsValue, Json}
+import uk.gov.hmrc.auth.core.AffinityGroup.Agent
+import uk.gov.hmrc.auth.core.User
+import uk.gov.hmrc.auth.core.authorise.Predicate
+import uk.gov.hmrc.auth.core.retrieve.{Credentials, Retrieval}
+import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.pillar2submissionapi.ORNSubmissionISpec._
+import uk.gov.hmrc.pillar2submissionapi.base.IntegrationSpecBase
+import uk.gov.hmrc.pillar2submissionapi.controllers.error.AuthenticationError
+import uk.gov.hmrc.pillar2submissionapi.controllers.submission.routes
+import uk.gov.hmrc.pillar2submissionapi.helpers.TestAuthRetrievals.Ops
+import uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification.{SubmitORNErrorResponse, SubmitORNSuccessResponse}
+import uk.gov.hmrc.pillar2submissionapi.models.subscription.SubscriptionSuccess
+import uk.gov.hmrc.play.bootstrap.http.HttpClientV2Provider
+
+import java.net.URI
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, ExecutionContext, Future}
+
+class ORNSubmissionISpec extends IntegrationSpecBase with OptionValues {
+
+  lazy val provider: HttpClientV2Provider = app.injector.instanceOf[HttpClientV2Provider]
+  lazy val client:   HttpClientV2         = provider.get()
+  lazy val str = s"http://localhost:$port${routes.ORNSubmissionController.submitORN.url}"
+  lazy val baseRequest: RequestBuilder = client.post(URI.create(str).toURL)
+
+  private val submitUrl = "/report-pillar2-top-up-taxes/overseas-return-notification/submit"
+
+  "ORNSubmissionController" when {
+    "submitORN as a organisation" must {
+      "return 201 CREATED when given valid submission data" in {
+        stubGet(
+          "/report-pillar2-top-up-taxes/subscription/read-subscription/XCCVRUGFJG788",
+          OK,
+          Json.toJson(SubscriptionSuccess(subscriptionData)).toString()
+        )
+        stubRequest(
+          "POST",
+          submitUrl,
+          CREATED,
+          Json.toJson(SubmitORNSuccessResponse("2022-01-31T09:26:17Z", "123456789012345"))
+        )
+
+        val result = Await.result(baseRequest.withBody(validRequestJson).execute[SubmitORNSuccessResponse], 5.seconds)
+
+        result.processingDate mustEqual "2022-01-31T09:26:17Z"
+        result.formBundleNumber mustEqual "123456789012345"
+      }
+
+      "return 400 BAD_REQUEST for invalid request body" in {
+        stubGet(
+          "/report-pillar2-top-up-taxes/subscription/read-subscription/XCCVRUGFJG788",
+          OK,
+          Json.toJson(SubscriptionSuccess(subscriptionData)).toString()
+        )
+
+        val result = Await.result(baseRequest.withBody(invalidRequestJson).execute[HttpResponse], 5.seconds)
+
+        result.status mustEqual BAD_REQUEST
+      }
+
+      "return 400 BAD_REQUEST for empty request body" in {
+        stubGet(
+          "/report-pillar2-top-up-taxes/subscription/read-subscription/XCCVRUGFJG788",
+          OK,
+          Json.toJson(SubscriptionSuccess(subscriptionData)).toString()
+        )
+
+        val result = Await.result(baseRequest.withBody(JsObject.empty).execute[HttpResponse], 5.seconds)
+
+        result.status mustEqual BAD_REQUEST
+      }
+
+      "return 400 BAD_REQUEST for missing request body" in {
+        stubGet(
+          "/report-pillar2-top-up-taxes/subscription/read-subscription/XCCVRUGFJG788",
+          OK,
+          Json.toJson(SubscriptionSuccess(subscriptionData)).toString()
+        )
+
+        val result = Await.result(baseRequest.execute[HttpResponse], 5.seconds)
+
+        result.status mustEqual BAD_REQUEST
+      }
+
+      "return 201 CREATED for request with duplicate fields and additional fields" in {
+        stubGet(
+          "/report-pillar2-top-up-taxes/subscription/read-subscription/XCCVRUGFJG788",
+          OK,
+          Json.toJson(SubscriptionSuccess(subscriptionData)).toString()
+        )
+        stubRequest(
+          "POST",
+          submitUrl,
+          CREATED,
+          Json.toJson(SubmitORNSuccessResponse("2022-01-31T09:26:17Z", "123456789012345"))
+        )
+
+        val result =
+          Await.result(baseRequest.withBody(validRequestJson_duplicateFieldsAndAdditionalFields).execute[SubmitORNSuccessResponse], 5.seconds)
+
+        result.processingDate mustEqual "2022-01-31T09:26:17Z"
+        result.formBundleNumber mustEqual "123456789012345"
+      }
+
+      "return 401 UNAUTHORIZED when user cannot be identified" in {
+        when(
+          mockAuthConnector
+            .authorise[RetrievalsType](any[Predicate](), any[Retrieval[RetrievalsType]]())(any[HeaderCarrier](), any[ExecutionContext]())
+        ).thenReturn(Future.failed(AuthenticationError))
+
+        val result = Await.result(baseRequest.withBody(validRequestJson).execute[HttpResponse], 5.seconds)
+
+        result.status mustEqual UNAUTHORIZED
+        val errorResponse = result.json.as[SubmitORNErrorResponse]
+        errorResponse.code mustEqual "003"
+        errorResponse.message mustEqual "Not authorized"
+      }
+
+      "return 422 UNPROCESSABLE_ENTITY for invalid return from ETMP" in {
+        stubGet(
+          "/report-pillar2-top-up-taxes/subscription/read-subscription/XCCVRUGFJG788",
+          OK,
+          Json.toJson(SubscriptionSuccess(subscriptionData)).toString()
+        )
+        stubRequest(
+          "POST",
+          submitUrl,
+          UNPROCESSABLE_ENTITY,
+          Json.toJson(SubmitORNErrorResponse("093", "Invalid Return"))
+        )
+
+        val result = Await.result(baseRequest.withBody(validRequestJson).execute[HttpResponse], 5.seconds)
+
+        result.status mustEqual UNPROCESSABLE_ENTITY
+        val errorResponse = result.json.as[SubmitORNErrorResponse]
+        errorResponse.code mustEqual "093"
+        errorResponse.message mustEqual "Invalid Return"
+      }
+
+      "return 500 INTERNAL_SERVER_ERROR for unauthorized response from ETMP" in {
+        stubGet(
+          "/report-pillar2-top-up-taxes/subscription/read-subscription/XCCVRUGFJG788",
+          OK,
+          Json.toJson(SubscriptionSuccess(subscriptionData)).toString()
+        )
+        stubRequest(
+          "POST",
+          submitUrl,
+          UNAUTHORIZED,
+          Json.toJson(SubmitORNErrorResponse("001", "Unauthorized"))
+        )
+
+        val result = Await.result(baseRequest.withBody(validRequestJson).execute[HttpResponse], 5.seconds)
+
+        result.status mustEqual INTERNAL_SERVER_ERROR
+        val errorResponse = result.json.as[SubmitORNErrorResponse]
+        errorResponse.code mustEqual "500"
+        errorResponse.message mustEqual "Internal Server Error"
+      }
+
+      "return 500 INTERNAL_SERVER_ERROR for internal server error from ETMP" in {
+        stubGet(
+          "/report-pillar2-top-up-taxes/subscription/read-subscription/XCCVRUGFJG788",
+          OK,
+          Json.toJson(SubscriptionSuccess(subscriptionData)).toString()
+        )
+        stubRequest(
+          "POST",
+          submitUrl,
+          INTERNAL_SERVER_ERROR,
+          Json.toJson(SubmitORNErrorResponse("999", "internal_server_error"))
+        )
+
+        val result = Await.result(baseRequest.withBody(validRequestJson).execute[HttpResponse], 5.seconds)
+
+        result.status mustEqual INTERNAL_SERVER_ERROR
+        val errorResponse = result.json.as[SubmitORNErrorResponse]
+        errorResponse.code mustEqual "500"
+        errorResponse.message mustEqual "Internal Server Error"
+      }
+    }
+
+    "submitORN as an agent" must {
+      "return 201 CREATED when given valid submission data" in {
+        when(
+          mockAuthConnector.authorise[RetrievalsType](ArgumentMatchers.eq(requiredGatewayPredicate), ArgumentMatchers.eq(requiredRetrievals))(
+            any[HeaderCarrier](),
+            any[ExecutionContext]()
+          )
+        )
+          .thenReturn(
+            Future.successful(Some(id) ~ Some(groupId) ~ pillar2Enrolments ~ Some(Agent) ~ Some(User) ~ Some(Credentials(providerId, providerType)))
+          )
+
+        when(
+          mockAuthConnector.authorise[RetrievalsType](ArgumentMatchers.eq(requiredAgentPredicate), ArgumentMatchers.eq(requiredRetrievals))(
+            any[HeaderCarrier](),
+            any[ExecutionContext]()
+          )
+        )
+          .thenReturn(
+            Future.successful(Some(id) ~ Some(groupId) ~ pillar2Enrolments ~ Some(Agent) ~ Some(User) ~ Some(Credentials(providerId, providerType)))
+          )
+        stubGet(
+          "/report-pillar2-top-up-taxes/subscription/read-subscription/XCCVRUGFJG788",
+          OK,
+          Json.toJson(SubscriptionSuccess(subscriptionData)).toString()
+        )
+        stubRequest(
+          "POST",
+          submitUrl,
+          CREATED,
+          Json.toJson(SubmitORNSuccessResponse("2022-01-31T09:26:17Z", "123456789012345"))
+        )
+
+        val result =
+          Await.result(baseRequest.withBody(validRequestJson).setHeader("X-Pillar2-Id" -> plrReference).execute[SubmitORNSuccessResponse], 5.seconds)
+
+        result.processingDate mustEqual "2022-01-31T09:26:17Z"
+        result.formBundleNumber mustEqual "123456789012345"
+      }
+    }
+  }
+}
+
+object ORNSubmissionISpec {
+  val validRequestJson: JsValue =
+    Json.parse("""{
+                 |  "accountingPeriodFrom": "2023-01-01",
+                 |  "accountingPeriodTo": "2024-12-31",
+                 |  "filedDateGIR": "2024-12-31",
+                 |  "countryGIR":"US",
+                 |  "reportingEntityName" : "Newco PLC",
+                 |  "TIN" : "US12345678",
+                 |  "issuingCountryTIN" : "US"
+                 |}""".stripMargin)
+
+  val invalidRequestJson: JsValue =
+    Json.parse("""{
+                 |  "badRequest": ""
+                 |}""".stripMargin)
+
+  val validRequestJson_duplicateFieldsAndAdditionalFields: JsValue =
+    Json.parse("""{
+                 |  "accountingPeriodFrom": "2023-01-01",
+                 |  "accountingPeriodTo": "2024-12-31",
+                 |  "accountingPeriodFrom": "2023-01-01",
+                 |  "accountingPeriodTo": "2024-12-31",
+                 |  "extraField1": "value1",
+                 |  "extraField1": "value2",
+                 |  "filedDateGIR": "2024-12-31",
+                 |  "countryGIR":"US",
+                 |  "reportingEntityName" : "Newco PLC",
+                 |  "TIN" : "US12345678",
+                 |  "issuingCountryTIN" : "US"
+                 |}""".stripMargin)
+}

--- a/project/PlaySwagger.scala
+++ b/project/PlaySwagger.scala
@@ -9,7 +9,8 @@ object PlaySwagger {
       "uk.gov.hmrc.pillar2submissionapi.models.obligationsandsubmissions",
       "uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse",
       "uk.gov.hmrc.pillar2submissionapi.models.response.StubErrorResponse",
-      "uk.gov.hmrc.pillar2submissionapi.models.organisation"
+      "uk.gov.hmrc.pillar2submissionapi.models.organisation",
+      "uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification"
     ),
     swaggerRoutesFile := "public.routes",
     swaggerV3 := true,

--- a/resources/public/api/conf/1.0/testOnly/application.yaml
+++ b/resources/public/api/conf/1.0/testOnly/application.yaml
@@ -380,6 +380,280 @@ paths:
               example:
                 code: '003'
                 message: Not authorized
+  /organisations/pillar-two/below-threshold-notification:
+    post:
+      security:
+      - userRestricted:
+        - write:pillar2
+      description: |
+        Submits a Below-Threshold Notification for a specified accounting period when the group no longer meets the threshold for the Pillar 2 top-up tax.
+        ### Error Codes
+        <p>This table contains a list of 422 error codes returned when a SubmitBTN API request is not processed successfully.</p>
+        <table>
+        <thead>
+        <tr>
+        <th>Error Message</th>
+        <th>Next Steps</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+        <td>002 - Pillar2 ID (SAP Number) is missing or invalid</td>
+        <td>Please provide the request header for your client, to check it contains the Pillar 2 ID (SAP Number) they were assigned at registration.</td>
+        </tr>
+        <tr>
+        <td>003 - Request could not be processed</td>
+        <td>The message could not be processed due to locking. Please check if there is currently an open enquiry on your tax account.</td>
+        </tr>
+        <tr>
+        <td>044 - Tax Obligation already fulfilled</td>
+        <td>A BTN for the specified period has already been submitted.</td>
+        </tr>
+        <tr>
+        <td>063 - Business Partner does not have an Active Pillar 2 Subscription</td>
+        <td>The Pillar 2 ID (SAP Number) in the request header is not listed as active by HMRC for this regime. Please contact the central support team.</td>
+        </tr>
+        </tbody>
+        </table>
+      tags:
+      - submission
+      operationId: submitBTN
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BTNSubmission"
+      parameters:
+      - name: Authorization
+        in: header
+        description: Bearer token for authentication
+        schema:
+          type: string
+        required: true
+      - in: header
+        name: X-Pillar2-Id
+        schema:
+          type: string
+        description: Pillar2 ID for the submission. Mandatory if the user is an Agent
+      - name: Accept
+        in: header
+        description: "Specifies the expected response format as versioned JSON from\
+          \ the HMRC API (v1.0). If not provided, it will default to application/vnd.hmrc.1.0+json."
+        schema:
+          type: string
+          example: application/vnd.hmrc.1.0+json
+        required: false
+      summary: SubmitBTN
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              examples:
+                Invalid Json:
+                  value:
+                    code: '001'
+                    message: Invalid JSON payload
+                Empty Request Body:
+                  value:
+                    code: '002'
+                    message: Empty body in request
+                Missing Header:
+                  value:
+                    code: '005'
+                    message: Missing Header in request
+        "201":
+          description: Below-Threshold Notification Submission Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SubmitBTNSuccessResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              examples:
+                Generic Server Error:
+                  value:
+                    code: 500
+                    message: Internal Server Error
+                No Subscription Data:
+                  value:
+                    code: '004'
+                    message: No Pillar2 subscription found for -pillar2Id
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              example:
+                code: '006'
+                message: Forbidden
+        "422":
+          description: Business Validation Failure
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              examples:
+                Invalid Pillar2ID:
+                  value:
+                    code: '002'
+                    message: Pillar 2 ID missing or invalid
+                Invalid Request:
+                  value:
+                    code: '003'
+                    message: Request could not be processed
+                Tax Obligation Fulfilled:
+                  value:
+                    code: '044'
+                    message: Tax Obligation already fulfilled
+                Duplicate Acknowledgment:
+                  value:
+                    code: '004'
+                    message: Duplicate acknowledgment reference
+                No Active Submission:
+                  value:
+                    code: '007'
+                    message: Business Partner does not have an Active Pillar 2 registration
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              example:
+                code: '003'
+                message: Not authorized
+  /organisations/pillar-two/overseas-return-notification:
+    post:
+      tags:
+      - submission
+      operationId: submitORN
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ORNSubmission"
+      parameters:
+      - in: header
+        name: X-Pillar2-Id
+        schema:
+          type: string
+        description: Pillar2 ID for the submission. Mandatory if the user is an Agent
+      - name: Authorization
+        in: header
+        description: Bearer token for authentication
+        schema:
+          type: string
+        required: true
+      - name: Accept
+        in: header
+        description: "Specifies the expected response format as versioned JSON from\
+          \ the HMRC API (v1.0). If not provided, it will default to application/vnd.hmrc.1.0+json."
+        schema:
+          type: string
+          example: application/vnd.hmrc.1.0+json
+        required: false
+      summary: Submit a Pillar2  Overseas Return Notification
+      responses:
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              examples:
+                Invalid Json:
+                  value:
+                    code: '001'
+                    message: Invalid JSON payload
+                Empty Request Body:
+                  value:
+                    code: '002'
+                    message: Empty body in request
+                Missing Header:
+                  value:
+                    code: '005'
+                    message: Missing Header in request
+        "201":
+          description: Overseas Return Notification Submission Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SubmitORNSuccessResponse"
+              example:
+                processingDate: 2025-01-31T09:26:17Z
+                formBundleNumber: 123456789012345
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              examples:
+                Generic Server Error:
+                  value:
+                    code: 500
+                    message: Internal Server Error
+                No Subscription Data:
+                  value:
+                    code: '004'
+                    message: No Pillar2 subscription found for -pillar2Id
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              example:
+                code: '006'
+                message: Forbidden
+        "422":
+          description: Business Validation Failure
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              examples:
+                Invalid Pillar2ID:
+                  value:
+                    code: '002'
+                    message: Pillar 2 ID missing or invalid
+                Invalid Return:
+                  value:
+                    code: '093'
+                    message: Invalid Return
+                Invalid Request:
+                  value:
+                    code: '003'
+                    message: Request could not be processed
+                Tax Obligation Fulfilled:
+                  value:
+                    code: '044'
+                    message: Tax Obligation already fulfilled
+                Duplicate Acknowledgment:
+                  value:
+                    code: '004'
+                    message: Duplicate acknowledgment reference
+                No Active Submission:
+                  value:
+                    code: '007'
+                    message: Business Partner does not have an Active Pillar 2 registration
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
+              example:
+                code: '003'
+                message: Not authorized
   /organisations/pillar-two/uk-tax-return:
     post:
       security:
@@ -729,156 +1003,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/responses.UKTRSubmitSuccessResponse"
-  /organisations/pillar-two/below-threshold-notification:
-    post:
-      security:
-      - userRestricted:
-        - write:pillar2
-      description: |
-        Submits a Below-Threshold Notification for a specified accounting period when the group no longer meets the threshold for the Pillar 2 top-up tax.
-        ### Error Codes
-        <p>This table contains a list of 422 error codes returned when a SubmitBTN API request is not processed successfully.</p>
-        <table>
-        <thead>
-        <tr>
-        <th>Error Message</th>
-        <th>Next Steps</th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr>
-        <td>002 - Pillar2 ID (SAP Number) is missing or invalid</td>
-        <td>Please provide the request header for your client, to check it contains the Pillar 2 ID (SAP Number) they were assigned at registration.</td>
-        </tr>
-        <tr>
-        <td>003 - Request could not be processed</td>
-        <td>The message could not be processed due to locking. Please check if there is currently an open enquiry on your tax account.</td>
-        </tr>
-        <tr>
-        <td>044 - Tax Obligation already fulfilled</td>
-        <td>A BTN for the specified period has already been submitted.</td>
-        </tr>
-        <tr>
-        <td>063 - Business Partner does not have an Active Pillar 2 Subscription</td>
-        <td>The Pillar 2 ID (SAP Number) in the request header is not listed as active by HMRC for this regime. Please contact the central support team.</td>
-        </tr>
-        </tbody>
-        </table>
-      tags:
-      - submission
-      operationId: submitBTN
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/BTNSubmission"
-      parameters:
-      - name: Authorization
-        in: header
-        description: Bearer token for authentication
-        schema:
-          type: string
-        required: true
-      - in: header
-        name: X-Pillar2-Id
-        schema:
-          type: string
-        description: Pillar2 ID for the submission. Mandatory if the user is an Agent
-      - name: Accept
-        in: header
-        description: "Specifies the expected response format as versioned JSON from\
-          \ the HMRC API (v1.0). If not provided, it will default to application/vnd.hmrc.1.0+json."
-        schema:
-          type: string
-          example: application/vnd.hmrc.1.0+json
-        required: false
-      summary: SubmitBTN
-      responses:
-        "400":
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
-              examples:
-                Invalid Json:
-                  value:
-                    code: '001'
-                    message: Invalid JSON payload
-                Empty Request Body:
-                  value:
-                    code: '002'
-                    message: Empty body in request
-                Missing Header:
-                  value:
-                    code: '005'
-                    message: Missing Header in request
-        "201":
-          description: Below-Threshold Notification Submission Created
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/SubmitBTNSuccessResponse"
-        "500":
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
-              examples:
-                Generic Server Error:
-                  value:
-                    code: 500
-                    message: Internal Server Error
-                No Subscription Data:
-                  value:
-                    code: '004'
-                    message: No Pillar2 subscription found for -pillar2Id
-        "403":
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
-              example:
-                code: '006'
-                message: Forbidden
-        "422":
-          description: Business Validation Failure
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
-              examples:
-                Invalid Pillar2ID:
-                  value:
-                    code: '002'
-                    message: Pillar 2 ID missing or invalid
-                Invalid Request:
-                  value:
-                    code: '003'
-                    message: Request could not be processed
-                Tax Obligation Fulfilled:
-                  value:
-                    code: '044'
-                    message: Tax Obligation already fulfilled
-                Duplicate Acknowledgment:
-                  value:
-                    code: '004'
-                    message: Duplicate acknowledgment reference
-                No Active Submission:
-                  value:
-                    code: '007'
-                    message: Business Partner does not have an Active Pillar 2 registration
-        "401":
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
-              example:
-                code: '003'
-                message: Not authorized
   /organisations/pillar-two/obligations-and-submissions:
     get:
       security:
@@ -1094,6 +1218,15 @@ components:
       - dueDate
       - underEnquiry
       - obligations
+    SubmitORNSuccessResponse:
+      properties:
+        processingDate:
+          type: string
+        formBundleNumber:
+          type: string
+      required:
+      - processingDate
+      - formBundleNumber
     SubmitBTNSuccessResponse:
       properties:
         processingDate:
@@ -1302,6 +1435,33 @@ components:
       - status
       - canAmend
       - submissions
+    ORNSubmission:
+      properties:
+        TIN:
+          type: string
+        countryGIR:
+          type: string
+        accountingPeriodFrom:
+          type: string
+          format: date
+        reportingEntityName:
+          type: string
+        issuingCountryTIN:
+          type: string
+        filedDateGIR:
+          type: string
+          format: date
+        accountingPeriodTo:
+          type: string
+          format: date
+      required:
+      - accountingPeriodFrom
+      - accountingPeriodTo
+      - filedDateGIR
+      - countryGIR
+      - reportingEntityName
+      - TIN
+      - issuingCountryTIN
   securitySchemes:
     userRestricted:
       type: oauth2

--- a/resources/public/api/conf/1.0/testOnly/application.yaml
+++ b/resources/public/api/conf/1.0/testOnly/application.yaml
@@ -586,7 +586,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SubmitORNSuccessResponse"
+                $ref: "#/components/schemas/ORNSuccessResponse"
               example:
                 processingDate: 2025-01-31T09:26:17Z
                 formBundleNumber: 123456789012345
@@ -1218,15 +1218,6 @@ components:
       - dueDate
       - underEnquiry
       - obligations
-    SubmitORNSuccessResponse:
-      properties:
-        processingDate:
-          type: string
-        formBundleNumber:
-          type: string
-      required:
-      - processingDate
-      - formBundleNumber
     SubmitBTNSuccessResponse:
       properties:
         processingDate:
@@ -1357,6 +1348,15 @@ components:
       - obligationMTT
       - electionUKGAAP
       - liabilities
+    ORNSuccessResponse:
+      properties:
+        processingDate:
+          type: string
+        formBundleNumber:
+          type: string
+      required:
+      - processingDate
+      - formBundleNumber
     LiabilityData:
       properties:
         electionUTPRSingleMember:

--- a/resources/public/api/conf/1.0/testOnly/application.yaml
+++ b/resources/public/api/conf/1.0/testOnly/application.yaml
@@ -623,8 +623,8 @@ paths:
               examples:
                 Invalid Pillar2ID:
                   value:
-                    code: '002'
-                    message: Pillar 2 ID missing or invalid
+                    code: '089'
+                    message: ID number missing or invalid
                 Invalid Return:
                   value:
                     code: '093'
@@ -643,8 +643,9 @@ paths:
                     message: Duplicate acknowledgment reference
                 No Active Submission:
                   value:
-                    code: '007'
-                    message: Business Partner does not have an Active Pillar 2 registration
+                    code: '063'
+                    message: Business Partner does not have an Active Subscription
+                      for this Regime
         "401":
           description: Unauthorized
           content:

--- a/test/uk/gov/hmrc/pillar2submissionapi/base/ControllerBaseSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/base/ControllerBaseSpec.scala
@@ -52,6 +52,7 @@ trait ControllerBaseSpec extends PlaySpec with Results with Matchers with Mockit
   val mockObligationsAndSubmissionsService: ObligationsAndSubmissionsService = mock[ObligationsAndSubmissionsService]
   val mockTestOrganisationService:          TestOrganisationService          = mock[TestOrganisationService]
   val appConfig:                            AppConfig                        = AppConfig(new ServicesConfig(Configuration.empty))
+  val mockSubmitORNService:                 SubmitORNService                 = mock[SubmitORNService]
   implicit val identifierAction: AuthenticatedIdentifierAction = new AuthenticatedIdentifierAction(
     mockAuthConnector,
     new BodyParsers.Default,

--- a/test/uk/gov/hmrc/pillar2submissionapi/base/UnitTestBaseSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/base/UnitTestBaseSpec.scala
@@ -58,4 +58,5 @@ trait UnitTestBaseSpec
   protected val mockSubmitBTNConnector:                SubmitBTNConnector                = mock[SubmitBTNConnector]
   protected val mockObligationAndSubmissionsConnector: ObligationAndSubmissionsConnector = mock[ObligationAndSubmissionsConnector]
   protected val mockTestOrganisationConnector:         TestOrganisationConnector         = mock[TestOrganisationConnector]
+  protected val mockSubmitORNConnector:                SubmitORNConnector                = mock[SubmitORNConnector]
 }

--- a/test/uk/gov/hmrc/pillar2submissionapi/connectors/SubmitORNConnectorSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/connectors/SubmitORNConnectorSpec.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2submissionapi.connectors
+
+import com.github.tomakehurst.wiremock.client.WireMock._
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import play.api.http.Status._
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.json.JsObject
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
+import play.api.{Application, Configuration}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.pillar2submissionapi.base.UnitTestBaseSpec
+import uk.gov.hmrc.pillar2submissionapi.connectors.SubmitORNConnectorSpec.validORNSubmission
+import uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification.ORNSubmission
+
+import java.time.LocalDate
+
+class SubmitORNConnectorSpec extends UnitTestBaseSpec {
+
+  lazy val submitORNConnector: SubmitORNConnector = app.injector.instanceOf[SubmitORNConnector]
+  override def fakeApplication(): Application = new GuiceApplicationBuilder()
+    .configure(Configuration("microservice.services.pillar2.port" -> server.port()))
+    .build()
+
+  private val submitUrl = "/report-pillar2-top-up-taxes/overseas-return-notification/submit"
+
+  "SubmitORNConnector" when {
+    "submitORN" must {
+      "forward the X-Pillar2-Id header" in {
+        implicit val hc: HeaderCarrier = HeaderCarrier().withExtraHeaders("X-Pillar2-Id" -> pillar2Id)
+        stubRequestWithPillar2Id("POST", submitUrl, CREATED, JsObject.empty)
+
+        val result = await(submitORNConnector.submitORN(validORNSubmission))
+
+        result.status should be(CREATED)
+        server.verify(
+          postRequestedFor(urlEqualTo(submitUrl)).withHeader("X-Pillar2-Id", equalTo(pillar2Id))
+        )
+      }
+
+      "return 201 CREATED for valid request" in {
+        stubRequest("POST", submitUrl, CREATED, JsObject.empty)
+
+        val result = await(submitORNConnector.submitORN(validORNSubmission)(hc))
+
+        result.status should be(CREATED)
+      }
+
+      "return 400 BAD_REQUEST for invalid request" in {
+        stubRequest("POST", submitUrl, BAD_REQUEST, JsObject.empty)
+
+        val result = await(submitORNConnector.submitORN(validORNSubmission)(hc))
+
+        result.status should be(BAD_REQUEST)
+      }
+
+      "return 404 NOT_FOUND for incorrect URL" in {
+        stubRequest("POST", "/INCORRECT_URL", NOT_FOUND, JsObject.empty)
+
+        val result = await(submitORNConnector.submitORN(validORNSubmission)(hc))
+
+        result.status should be(NOT_FOUND)
+      }
+    }
+  }
+}
+
+object SubmitORNConnectorSpec {
+  val validORNSubmission: ORNSubmission = new ORNSubmission(
+    accountingPeriodFrom = LocalDate.now(),
+    accountingPeriodTo = LocalDate.now().plusYears(1),
+    filedDateGIR = LocalDate.now().plusYears(1),
+    countryGIR = "US",
+    reportingEntityName = "Newco PLC",
+    TIN = "US12345678",
+    issuingCountryTIN = "US"
+  )
+}

--- a/test/uk/gov/hmrc/pillar2submissionapi/controllers/ORNSubmissionControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/controllers/ORNSubmissionControllerSpec.scala
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2submissionapi.controllers
+
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import play.api.http.Status.CREATED
+import play.api.libs.json.{JsObject, JsValue, Json}
+import play.api.mvc.Result
+import play.api.test.FakeRequest
+import play.api.test.Helpers.{defaultAwaitTimeout, status}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.pillar2submissionapi.base.ControllerBaseSpec
+import uk.gov.hmrc.pillar2submissionapi.controllers.ORNSubmissionControllerSpec._
+import uk.gov.hmrc.pillar2submissionapi.controllers.error.{EmptyRequestBody, InvalidJson}
+import uk.gov.hmrc.pillar2submissionapi.controllers.submission.ORNSubmissionController
+import uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification.{ORNSubmission, SubmitORNSuccessResponse}
+
+import scala.concurrent.Future
+
+class ORNSubmissionControllerSpec extends ControllerBaseSpec {
+
+  val ORNSubmissionController: ORNSubmissionController =
+    new ORNSubmissionController(cc, identifierAction, subscriptionDataRetrievalAction, mockSubmitORNService)
+
+  def result(jsRequest: JsValue): Future[Result] = ORNSubmissionController.submitORN(
+    FakeRequest()
+      .withJsonBody(jsRequest)
+  )
+
+  "ORNSubmissionController" when {
+    "submitORN() called with a valid request" should {
+      "return 201 CREATED response" in {
+
+        when(mockSubmitORNService.submitORN(any[ORNSubmission])(any[HeaderCarrier]))
+          .thenReturn(
+            Future.successful(
+              SubmitORNSuccessResponse("2022-01-31T09:26:17Z", "123456789012345")
+            )
+          )
+
+        status(result(validRequestJson_data)) mustEqual CREATED
+      }
+    }
+
+    "submitORN called with an invalid request" should {
+      "return InvalidJson response" in {
+
+        result(invalidRequestJson_data) shouldFailWith InvalidJson
+      }
+    }
+
+    "submitORN called with an invalid json request" should {
+      "return InvalidJson response" in {
+
+        result(invalidRequest_Json) shouldFailWith InvalidJson
+      }
+    }
+
+    "submitORN called with an empty json object" should {
+      "return InvalidJson response" in {
+
+        result(invalidRequest_emptyBody) shouldFailWith InvalidJson
+      }
+    }
+
+    "submitORN called with an non-json request" should {
+      "return EmptyRequestBody response" in {
+        val result: Future[Result] = ORNSubmissionController.submitORN(
+          FakeRequest()
+            .withTextBody(invalidRequest_wrongType)
+        )
+        result shouldFailWith EmptyRequestBody
+      }
+    }
+
+    "submitORN called with no request body" should {
+      "return EmptyRequestBody response" in {
+        val result: Future[Result] = ORNSubmissionController.submitORN(
+          FakeRequest()
+        )
+        result shouldFailWith EmptyRequestBody
+      }
+    }
+
+    "submitORN called with valid request body that contains duplicate entries" should {
+      "return 201 CREATED response" in {
+
+        status(result(validRequestJson_duplicateFields)) mustEqual CREATED
+      }
+    }
+
+    "submitORN called with valid request body that contains additional fields" should {
+      "return 201 CREATED response" in {
+
+        status(result(validRequestJson_additionalFields)) mustEqual CREATED
+      }
+    }
+  }
+}
+
+object ORNSubmissionControllerSpec {
+  val validRequestJson_data: JsValue =
+    Json.parse("""{
+        |  "accountingPeriodFrom": "2023-01-01",
+        |  "accountingPeriodTo": "2024-12-31",
+        |  "filedDateGIR": "2024-12-31",
+        |  "countryGIR":"US",
+        |  "reportingEntityName" : "Newco PLC",
+        |  "TIN" : "US12345678",
+        |  "issuingCountryTIN" : "US"
+        |}""".stripMargin)
+
+  val invalidRequestJson_data: JsValue =
+    Json.parse("""{
+        |  "data1": "value1",
+        |  "data2": "value2"
+        |}""".stripMargin)
+
+  val invalidRequest_Json: JsValue =
+    Json.parse("""{
+        |  "badRequest": ""
+        |}""".stripMargin)
+
+  val invalidRequest_emptyBody: JsValue = JsObject.empty
+
+  val invalidRequest_wrongType: String = "This is not Json."
+
+  val validRequestJson_duplicateFields: JsValue =
+    Json.parse("""{
+                 |  "accountingPeriodFrom": "2023-01-01",
+                 |  "accountingPeriodTo": "2024-12-31",
+                 |  "accountingPeriodFrom": "2023-01-01",
+                 |  "accountingPeriodTo": "2024-12-31",
+                 |  "filedDateGIR": "2024-12-31",
+                 |  "countryGIR":"US",
+                 |  "reportingEntityName" : "Newco PLC",
+                 |  "TIN" : "US12345678",
+                 |  "issuingCountryTIN" : "US"
+                 |}""".stripMargin)
+
+  val validRequestJson_additionalFields: JsValue =
+    Json.parse("""{
+                 |  "accountingPeriodFrom": "2023-01-01",
+                 |  "accountingPeriodTo": "2024-12-31",
+                 |  "extraField1": "value1",
+                 |  "extraField1": "value2",
+                 |  "filedDateGIR": "2024-12-31",
+                 |  "countryGIR":"US",
+                 |  "reportingEntityName" : "Newco PLC",
+                 |  "TIN" : "US12345678",
+                 |  "issuingCountryTIN" : "US"
+                 |}""".stripMargin)
+
+}

--- a/test/uk/gov/hmrc/pillar2submissionapi/helpers/ORNDataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/helpers/ORNDataFixture.scala
@@ -14,12 +14,23 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification
+package uk.gov.hmrc.pillar2submissionapi.helpers
 
-import play.api.libs.json.{Json, OFormat}
+import play.api.libs.json.{JsObject, JsValue, Json}
+import uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification.ORNSubmission
 
-case class SubmitORNSuccessResponse(processingDate: String, formBundleNumber: String)
+import java.time.LocalDate
 
-case object SubmitORNSuccessResponse {
-  implicit val successFormat: OFormat[SubmitORNSuccessResponse] = Json.format[SubmitORNSuccessResponse]
+trait ORNDataFixture {
+
+  val ornRequestFixture = ORNSubmission(
+    accountingPeriodFrom = LocalDate.now(),
+    accountingPeriodTo = LocalDate.now().plusYears(1),
+    filedDateGIR = LocalDate.now().plusYears(1),
+    countryGIR = "US",
+    reportingEntityName = "Newco PLC",
+    TIN = "US12345678",
+    issuingCountryTIN = "US"
+  )
+  val ornRequestJs: JsValue = Json.toJson(ornRequestFixture)
 }

--- a/test/uk/gov/hmrc/pillar2submissionapi/helpers/ORNDataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/helpers/ORNDataFixture.scala
@@ -16,14 +16,14 @@
 
 package uk.gov.hmrc.pillar2submissionapi.helpers
 
-import play.api.libs.json.{JsObject, JsValue, Json}
+import play.api.libs.json.{JsValue, Json}
 import uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification.ORNSubmission
 
 import java.time.LocalDate
 
 trait ORNDataFixture {
 
-  val ornRequestFixture = ORNSubmission(
+  val ornRequestFixture: ORNSubmission = ORNSubmission(
     accountingPeriodFrom = LocalDate.now(),
     accountingPeriodTo = LocalDate.now().plusYears(1),
     filedDateGIR = LocalDate.now().plusYears(1),

--- a/test/uk/gov/hmrc/pillar2submissionapi/services/SubmitORNServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/services/SubmitORNServiceSpec.scala
@@ -24,7 +24,7 @@ import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2submissionapi.base.UnitTestBaseSpec
 import uk.gov.hmrc.pillar2submissionapi.controllers.error._
-import uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification.{ORNSubmission, SubmitORNErrorResponse, SubmitORNSuccessResponse}
+import uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification.{ORNErrorResponse, ORNSubmission, ORNSuccessResponse}
 import uk.gov.hmrc.pillar2submissionapi.services.SubmitORNServiceSpec.{okResponse, validORNSubmission}
 
 import java.time.LocalDate
@@ -62,7 +62,7 @@ class SubmitORNServiceSpec extends UnitTestBaseSpec {
     "Runtime exception thrown" in {
 
       when(mockSubmitORNConnector.submitORN(any[ORNSubmission])(any[HeaderCarrier]))
-        .thenReturn(Future.successful(HttpResponse.apply(422, Json.toJson(SubmitORNErrorResponse("093", "Invalid Return")), Map.empty)))
+        .thenReturn(Future.successful(HttpResponse.apply(422, Json.toJson(ORNErrorResponse("093", "Invalid Return")), Map.empty)))
 
       intercept[ORNValidationError](await(submitORNService.submitORN(validORNSubmission)))
     }
@@ -100,5 +100,5 @@ object SubmitORNServiceSpec {
     issuingCountryTIN = "US"
   )
 
-  val okResponse: SubmitORNSuccessResponse = SubmitORNSuccessResponse("2022-01-31", "123456789012345")
+  val okResponse: ORNSuccessResponse = ORNSuccessResponse("2022-01-31", "123456789012345")
 }

--- a/test/uk/gov/hmrc/pillar2submissionapi/services/SubmitORNServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/services/SubmitORNServiceSpec.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2submissionapi.services
+
+import junit.framework.TestCase.assertEquals
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import play.api.libs.json.Json
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.pillar2submissionapi.base.UnitTestBaseSpec
+import uk.gov.hmrc.pillar2submissionapi.controllers.error._
+import uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification.{ORNSubmission, SubmitORNErrorResponse, SubmitORNSuccessResponse}
+import uk.gov.hmrc.pillar2submissionapi.services.SubmitORNServiceSpec.{okResponse, validORNSubmission}
+
+import java.time.LocalDate
+import scala.concurrent.Future
+
+class SubmitORNServiceSpec extends UnitTestBaseSpec {
+
+  val submitORNService: SubmitORNService = new SubmitORNService(mockSubmitORNConnector)
+
+  "submitORNService" when {
+    "submitORN() called with a valid tax return" should {
+      "return 201 CREATED response" in {
+
+        when(mockSubmitORNConnector.submitORN(any[ORNSubmission])(any[HeaderCarrier]))
+          .thenReturn(Future.successful(HttpResponse.apply(201, Json.toJson(okResponse), Map.empty)))
+
+        val result = await(submitORNService.submitORN(validORNSubmission))
+
+        assertEquals(okResponse, result)
+      }
+    }
+  }
+
+  "submitORN() unexpected 201 response back" should {
+    "Runtime exception thrown" in {
+
+      when(mockSubmitORNConnector.submitORN(any[ORNSubmission])(any[HeaderCarrier]))
+        .thenReturn(Future.successful(HttpResponse.apply(201, Json.toJson("unexpected success response"), Map.empty)))
+
+      intercept[UnexpectedResponse.type](await(submitORNService.submitORN(validORNSubmission)))
+    }
+  }
+
+  "submitORN() valid 422 response back" should {
+    "Runtime exception thrown" in {
+
+      when(mockSubmitORNConnector.submitORN(any[ORNSubmission])(any[HeaderCarrier]))
+        .thenReturn(Future.successful(HttpResponse.apply(422, Json.toJson(SubmitORNErrorResponse("093", "Invalid Return")), Map.empty)))
+
+      intercept[ORNValidationError](await(submitORNService.submitORN(validORNSubmission)))
+    }
+  }
+
+  "submitORN() unexpected 422 response back" should {
+    "Runtime exception thrown" in {
+
+      when(mockSubmitORNConnector.submitORN(any[ORNSubmission])(any[HeaderCarrier]))
+        .thenReturn(Future.successful(HttpResponse.apply(422, Json.toJson("unexpected error response"), Map.empty)))
+
+      intercept[UnexpectedResponse.type](await(submitORNService.submitORN(validORNSubmission)))
+    }
+  }
+
+  "submitORN() 500 response back" should {
+    "Runtime exception thrown " in {
+
+      when(mockSubmitORNConnector.submitORN(any[ORNSubmission])(any[HeaderCarrier]))
+        .thenReturn(Future.successful(HttpResponse.apply(500, Json.toJson(InternalServerError.toString()), Map.empty)))
+
+      intercept[UnexpectedResponse.type](await(submitORNService.submitORN(validORNSubmission)))
+    }
+  }
+}
+
+object SubmitORNServiceSpec {
+  val validORNSubmission = new ORNSubmission(
+    accountingPeriodFrom = LocalDate.now(),
+    accountingPeriodTo = LocalDate.now().plusYears(1),
+    filedDateGIR = LocalDate.now().plusYears(1),
+    countryGIR = "US",
+    reportingEntityName = "Newco PLC",
+    TIN = "US12345678",
+    issuingCountryTIN = "US"
+  )
+
+  val okResponse: SubmitORNSuccessResponse = SubmitORNSuccessResponse("2022-01-31", "123456789012345")
+}


### PR DESCRIPTION
This PR integrates the ORN submit endpoint backend functionality with the Pillar 2 submission API to enable the submission of third-party supplier data to ETMP.

**Changes made:**
Implemented a call to the Pillar 2 ORN submit endpoint from the submission API.
Updated unit tests to cover the new integration.
Updated integration tests to validate the end-to-end functionality.
Open API Specs updated for the new endpoint

**Testing:**
Successful invocation of the Pillar 2 ORN submit endpoint from the submission API.

<img width="943" alt="Screenshot 2025-04-02 at 10 09 03" src="https://github.com/user-attachments/assets/73662075-7151-419c-badc-898941133912" />

