### PR TITLE
PIL - 1862 : Restructure the 422 error codes as per EPID

### DIFF
--- a/conf/submission.routes
+++ b/conf/submission.routes
@@ -318,26 +318,18 @@ GET       /obligations-and-submissions              uk.gov.hmrc.pillar2submissio
 #         schema:
 #           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
 #         examples:
-#           Invalid Pillar2ID:
-#             value:
-#               code: '089'
-#               message: ID number missing or invalid
 #           Invalid Request:
 #             value:
 #               code: '003'
 #               message: Request could not be processed
-#           Duplicate Acknowledgment:
-#             value:
-#               code: '004'
-#               message: Duplicate acknowledgment reference
 #           No Active Submission:
 #             value:
 #               code: '063'
-#               message: Business Partner does not have an Active Subscription for this Regime
+#               message: Business Partner does not have an Active Subscription for this regime
 #           Tax Obligation Fulfilled:
 #             value:
 #               code: '044'
-#               message: Tax Obligation already fulfilled
+#               message: Tax Obligation already Fulfilled
 #           Invalid Return:
 #             value:
 #               code: '093'

--- a/conf/submission.routes
+++ b/conf/submission.routes
@@ -299,83 +299,35 @@ GET       /obligations-and-submissions              uk.gov.hmrc.pillar2submissio
 #       application/json:
 #         schema:
 #           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification.ORNSuccessResponse'
-#         example:
-#           processingDate: "2025-01-31T09:26:17Z"
-#           formBundleNumber: "123456789012345"
 #   401:
 #     description: Unauthorized
 #     content:
 #       application/json:
 #         schema:
 #           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
-#         example:
-#           code: '003'
-#           message: Not authorized
 #   422:
 #     description: Business Validation Failure
 #     content:
 #       application/json:
 #         schema:
 #           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
-#         examples:
-#           Invalid Request:
-#             value:
-#               code: '003'
-#               message: Request could not be processed
-#           No Active Submission:
-#             value:
-#               code: '063'
-#               message: Business Partner does not have an Active Subscription for this regime
-#           Tax Obligation Fulfilled:
-#             value:
-#               code: '044'
-#               message: Tax Obligation already Fulfilled
-#           Invalid Return:
-#             value:
-#               code: '093'
-#               message: Invalid Return
 #   400:
 #     description: Bad Request
 #     content:
 #       application/json:
 #         schema:
 #           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
-#         examples:
-#           Invalid Json:
-#             value:
-#               code: "001"
-#               message: "Invalid JSON payload"
-#           Empty Request Body:
-#             value:
-#               code: "002"
-#               message: "Empty body in request"
-#           Missing Header:
-#             value:
-#               code: "005"
-#               message: "Missing Header in request"
 #   403:
 #     description: Forbidden
 #     content:
 #       application/json:
 #         schema:
 #           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
-#         example:
-#           code: "006"
-#           message: "Forbidden"
 #   500:
 #     description: Internal Server Error
 #     content:
 #       application/json:
 #         schema:
 #           $ref: '#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse'
-#         examples:
-#           Generic Server Error:
-#             value:
-#               code: "500"
-#               message: "Internal Server Error"
-#           No Subscription Data:
-#             value:
-#               code: "004"
-#               message: "No Pillar2 subscription found for [pillar2Id]"
 ###
 POST /overseas-return-notification  uk.gov.hmrc.pillar2submissionapi.controllers.submission.ORNSubmissionController.submitORN

--- a/conf/swagger.yml
+++ b/conf/swagger.yml
@@ -127,8 +127,6 @@ paths:
               examples:
                 Invalid UTPR Election:
                   $ref: "#/components/examples/errors.Submission.InvalidUTPR"
-                Invalid Pillar2ID:
-                  $ref: "#/components/examples/errors.Submission.InvalidPillar2ID"
                 Invalid Total Liability IIR:
                   $ref: "#/components/examples/errors.Submission.InvalidTotalLiabilityIIR"
                 Invalid DTT Election:
@@ -137,16 +135,14 @@ paths:
                   $ref: "#/components/examples/errors.Submission.InvalidReturn"
                 Invalid Request:
                   $ref: "#/components/examples/errors.Submission.InvalidRequest"
-                Duplicate Submission:
-                  $ref: "#/components/examples/errors.Submission.DuplicateSubmission"
                 Invalid Total Liability UTPR:
                   $ref: "#/components/examples/errors.Submission.InvalidTotalLiabilityUTPR"
                 Invalid Total Liability:
                   $ref: "#/components/examples/errors.Submission.InvalidTotalLiability"
                 Tax Obligation Fulfilled:
                   $ref: "#/components/examples/errors.Submission.TaxObligationFulfilled"
-                No Active Submission:
-                  $ref: "#/components/examples/errors.Submission.NoActiveSubmission"
+                No Active Subscription:
+                  $ref: "#/components/examples/errors.Submission.NoActiveSubscription"
                 Invalid Total Liability DTT:
                   $ref: "#/components/examples/errors.Submission.InvalidTotalLiabilityDTT"
         "401":
@@ -227,8 +223,6 @@ paths:
               examples:
                 Invalid UTPR Election:
                   $ref: "#/components/examples/errors.Submission.InvalidUTPR"
-                Invalid Pillar2ID:
-                  $ref: "#/components/examples/errors.Submission.InvalidPillar2ID"
                 Invalid Total Liability IIR:
                   $ref: "#/components/examples/errors.Submission.InvalidTotalLiabilityIIR"
                 Invalid DTT Election:
@@ -237,14 +231,12 @@ paths:
                   $ref: "#/components/examples/errors.Submission.InvalidReturn"
                 Invalid Request:
                   $ref: "#/components/examples/errors.Submission.InvalidRequest"
-                Duplicate Submission:
-                  $ref: "#/components/examples/errors.Submission.DuplicateSubmission"
                 Invalid Total Liability UTPR:
                   $ref: "#/components/examples/errors.Submission.InvalidTotalLiabilityUTPR"
                 Invalid Total Liability:
                   $ref: "#/components/examples/errors.Submission.InvalidTotalLiability"
-                No Active Submission:
-                  $ref: "#/components/examples/errors.Submission.NoActiveSubmission"
+                No Active Subscription:
+                  $ref: "#/components/examples/errors.Submission.NoActiveSubscription"
                 Invalid Total Liability DTT:
                   $ref: "#/components/examples/errors.Submission.InvalidTotalLiabilityDTT"
         "401":
@@ -332,18 +324,12 @@ paths:
           content:
             application/json:
               examples:
-                Invalid Pillar2ID:
-                  $ref: "#/components/examples/errors.Submission.InvalidPillar2ID"
                 Invalid Request:
                   $ref: "#/components/examples/errors.Submission.InvalidRequest"
                 Tax Obligation Fulfilled:
                   $ref: "#/components/examples/errors.Submission.TaxObligationFulfilled"
-                Duplicate Acknowledgment:
-                  value:
-                    code: '004'
-                    message: Duplicate acknowledgment reference
-                No Active Submission:
-                  $ref: "#/components/examples/errors.Submission.NoActiveSubmission"
+                No Active Subscription:
+                  $ref: "#/components/examples/errors.Submission.NoActiveSubscription"
         "401":
           description: Unauthorized
           content:
@@ -399,14 +385,10 @@ paths:
           content:
             application/json:
               examples:
-                Invalid Pillar2ID:
-                  $ref: "#/components/examples/errors.Submission.InvalidPillar2ID"
                 Invalid Request:
                   $ref: "#/components/examples/errors.Submission.InvalidRequest"
-                Duplicate Acknowledgment:
-                  $ref: "#/components/examples/errors.Submission.DuplicateSubmission"
-                No associated data found:
-                  $ref: "#/components/examples/errors.Submission.NoActiveSubmission"
+                No Data Found:
+                  $ref: "#/components/examples/errors.Submission.NoDataFound"
         "401":
           description: Unauthorized
           content:
@@ -427,6 +409,61 @@ paths:
       summary: Submit Overseas Return Notification
       description: |
         Submit an Overseas Return Notification
+      responses:
+        "201":
+          description: Overseas Return Notification Submission Created
+          content:
+            application/json:
+              examples:
+                responses.ORNSuccessResponseExample:
+                  $ref: "#/components/examples/responses.ORNSuccessResponseExample"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              examples:
+                Invalid Json:
+                  $ref: "#/components/examples/errors.InvalidJson"
+                Empty Request Body:
+                  $ref: "#/components/examples/errors.EmptyBody"
+                Missing Header:
+                  $ref: "#/components/examples/errors.Submission.MissingHeader"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              examples:
+                Generic Server Error:
+                  $ref: "#/components/examples/errors.Submission.GenericServerError"
+                No Subscription Data:
+                  $ref: "#/components/examples/errors.Submission.NoSubscriptionData"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              examples:
+                Forbidden:
+                  $ref: "#/components/examples/errors.Submission.Forbidden"
+        "422":
+          description: Business Validation Failure
+          content:
+            application/json:
+              examples:
+                Invalid Request:
+                  $ref: "#/components/examples/errors.Submission.InvalidRequest"
+                No Active Subscription Found:
+                  $ref: "#/components/examples/errors.Submission.NoActiveSubscription"
+                Tax Obligation Fulfilled:
+                  $ref: "#/components/examples/errors.Submission.TaxObligationFulfilled"
+                Invalid Return:
+                  $ref: "#/components/examples/errors.Submission.InvalidReturn"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              examples:
+                Unauthorized:
+                  $ref: "#/components/examples/errors.Submission.Unauthorized"
       security:
         - userRestricted: [write:pillar2]
   /setup/organisation:
@@ -877,6 +914,11 @@ components:
         electionUKGAAP: true
         liabilities:
           returnType: "NIL_RETURN"
+    responses.ORNSuccessResponseExample:
+      summary: ORN Success response
+      value:
+        processingDate: "2026-06-26T09:26:17Z"
+        formBundleNumber: 119000004320
     errors.TestOrg.NotFound:
       summary: Test endpoints not available
       value:
@@ -947,16 +989,16 @@ components:
       value:
         code: '044'
         message: Tax Obligation already fulfilled
-    errors.Submission.NoActiveSubmission:
-      summary: No active submission
+    errors.Submission.NoActiveSubscription:
+      summary: No active subscription
       value:
-        code: '007'
-        message: Business Partner does not have an active subscription
+        code: '063'
+        message: Business Partner does not have an Active Subscription for this Regime
     errors.Submission.DuplicateSubmission:
       summary: Duplicate submission
       value:
         code: '004'
-        message: Duplicate submission acknowledgment reference
+        message: Duplicate submission
     errors.Submission.InvalidUTPR:
       summary: Invalid UTPR Election
       value:
@@ -987,6 +1029,11 @@ components:
       value:
         code: '098'
         message: Invalid Total Liability DTT
+    errors.Submission.NoDataFound:
+      summary: No data found
+      value:
+        code: '014'
+        message: No data found
 
   securitySchemes:
     userRestricted:

--- a/conf/swagger.yml
+++ b/conf/swagger.yml
@@ -436,7 +436,7 @@ paths:
                 Empty Request Body:
                   $ref: "#/components/examples/errors.EmptyBody"
                 Missing Header:
-                  $ref: "#/components/examples/errors.Submission.MissingHeader"
+                  $ref: "#/components/examples/errors.Submission.MissingPillar2Header"
         "500":
           description: Internal Server Error
           content:

--- a/resources/public/api/conf/1.0/application.yaml
+++ b/resources/public/api/conf/1.0/application.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.105.0
+  version: 0.106.0
   title: Pillar 2 API
   description: An API for managing and retrieving data in accordance with Pillar 2 tax rules.
 tags: []
@@ -428,8 +428,6 @@ paths:
               examples:
                 Invalid UTPR Election:
                   $ref: "#/components/examples/errors.Submission.InvalidUTPR"
-                Invalid Pillar2ID:
-                  $ref: "#/components/examples/errors.Submission.InvalidPillar2ID"
                 Invalid Total Liability IIR:
                   $ref: "#/components/examples/errors.Submission.InvalidTotalLiabilityIIR"
                 Invalid DTT Election:
@@ -438,16 +436,14 @@ paths:
                   $ref: "#/components/examples/errors.Submission.InvalidReturn"
                 Invalid Request:
                   $ref: "#/components/examples/errors.Submission.InvalidRequest"
-                Duplicate Submission:
-                  $ref: "#/components/examples/errors.Submission.DuplicateSubmission"
                 Invalid Total Liability UTPR:
                   $ref: "#/components/examples/errors.Submission.InvalidTotalLiabilityUTPR"
                 Invalid Total Liability:
                   $ref: "#/components/examples/errors.Submission.InvalidTotalLiability"
                 Tax Obligation Fulfilled:
                   $ref: "#/components/examples/errors.Submission.TaxObligationFulfilled"
-                No Active Submission:
-                  $ref: "#/components/examples/errors.Submission.NoActiveSubmission"
+                No Active Subscription:
+                  $ref: "#/components/examples/errors.Submission.NoActiveSubscription"
                 Invalid Total Liability DTT:
                   $ref: "#/components/examples/errors.Submission.InvalidTotalLiabilityDTT"
         "400":
@@ -617,8 +613,6 @@ paths:
               examples:
                 Invalid UTPR Election:
                   $ref: "#/components/examples/errors.Submission.InvalidUTPR"
-                Invalid Pillar2ID:
-                  $ref: "#/components/examples/errors.Submission.InvalidPillar2ID"
                 Invalid Total Liability IIR:
                   $ref: "#/components/examples/errors.Submission.InvalidTotalLiabilityIIR"
                 Invalid DTT Election:
@@ -627,14 +621,12 @@ paths:
                   $ref: "#/components/examples/errors.Submission.InvalidReturn"
                 Invalid Request:
                   $ref: "#/components/examples/errors.Submission.InvalidRequest"
-                Duplicate Submission:
-                  $ref: "#/components/examples/errors.Submission.DuplicateSubmission"
                 Invalid Total Liability UTPR:
                   $ref: "#/components/examples/errors.Submission.InvalidTotalLiabilityUTPR"
                 Invalid Total Liability:
                   $ref: "#/components/examples/errors.Submission.InvalidTotalLiability"
-                No Active Submission:
-                  $ref: "#/components/examples/errors.Submission.NoActiveSubmission"
+                No Active Subscription:
+                  $ref: "#/components/examples/errors.Submission.NoActiveSubscription"
                 Invalid Total Liability DTT:
                   $ref: "#/components/examples/errors.Submission.InvalidTotalLiabilityDTT"
         "400":
@@ -734,18 +726,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
               examples:
-                Invalid Pillar2ID:
-                  $ref: "#/components/examples/errors.Submission.InvalidPillar2ID"
                 Invalid Request:
                   $ref: "#/components/examples/errors.Submission.InvalidRequest"
                 Tax Obligation Fulfilled:
                   $ref: "#/components/examples/errors.Submission.TaxObligationFulfilled"
-                Duplicate Acknowledgment:
-                  value:
-                    code: '004'
-                    message: Duplicate acknowledgment reference
-                No Active Submission:
-                  $ref: "#/components/examples/errors.Submission.NoActiveSubmission"
+                No Active Subscription:
+                  $ref: "#/components/examples/errors.Submission.NoActiveSubscription"
         "403":
           description: Forbidden
           content:
@@ -866,14 +852,10 @@ paths:
           content:
             application/json:
               examples:
-                Invalid Pillar2ID:
-                  $ref: "#/components/examples/errors.Submission.InvalidPillar2ID"
                 Invalid Request:
                   $ref: "#/components/examples/errors.Submission.InvalidRequest"
-                Duplicate Acknowledgment:
-                  $ref: "#/components/examples/errors.Submission.DuplicateSubmission"
-                No associated data found:
-                  $ref: "#/components/examples/errors.Submission.NoActiveSubmission"
+                No Data Found:
+                  $ref: "#/components/examples/errors.Submission.NoDataFound"
         "401":
           description: Unauthorized
           content:
@@ -892,6 +874,42 @@ paths:
         - write:pillar2
 components:
   schemas:
+    uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification.ORNSuccessResponse:
+      properties:
+        processingDate:
+          type: string
+        formBundleNumber:
+          type: string
+      required:
+      - processingDate
+      - formBundleNumber
+    uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification.ORNSubmission:
+      properties:
+        accountingPeriodFrom:
+          type: string
+          format: date
+        accountingPeriodTo:
+          type: string
+          format: date
+        filedDateGIR:
+          type: string
+          format: date
+        countryGIR:
+          type: string
+        reportingEntityName:
+          type: string
+        TIN:
+          type: string
+        issuingCountryTIN:
+          type: string
+      required:
+      - accountingPeriodFrom
+      - accountingPeriodTo
+      - filedDateGIR
+      - countryGIR
+      - reportingEntityName
+      - TIN
+      - issuingCountryTIN
     uk.gov.hmrc.pillar2submissionapi.models.belowthresholdnotification.SubmitBTNSuccessResponse:
       properties:
         processingDate:
@@ -1432,16 +1450,16 @@ components:
       value:
         code: '044'
         message: Tax Obligation already fulfilled
-    errors.Submission.NoActiveSubmission:
-      summary: No active submission
+    errors.Submission.NoActiveSubscription:
+      summary: No active subscription
       value:
-        code: '007'
-        message: Business Partner does not have an active subscription
+        code: '063'
+        message: Business Partner does not have an Active Subscription for this Regime
     errors.Submission.DuplicateSubmission:
       summary: Duplicate submission
       value:
         code: '004'
-        message: Duplicate submission acknowledgment reference
+        message: Duplicate submission
     errors.Submission.InvalidUTPR:
       summary: Invalid UTPR Election
       value:
@@ -1472,6 +1490,11 @@ components:
       value:
         code: '098'
         message: Invalid Total Liability DTT
+    errors.Submission.NoDataFound:
+      summary: No data found
+      value:
+        code: '014'
+        message: No data found
   securitySchemes:
     userRestricted:
       type: oauth2

--- a/resources/public/api/conf/1.0/application.yaml
+++ b/resources/public/api/conf/1.0/application.yaml
@@ -874,42 +874,6 @@ paths:
         - write:pillar2
 components:
   schemas:
-    uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification.ORNSuccessResponse:
-      properties:
-        processingDate:
-          type: string
-        formBundleNumber:
-          type: string
-      required:
-      - processingDate
-      - formBundleNumber
-    uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification.ORNSubmission:
-      properties:
-        accountingPeriodFrom:
-          type: string
-          format: date
-        accountingPeriodTo:
-          type: string
-          format: date
-        filedDateGIR:
-          type: string
-          format: date
-        countryGIR:
-          type: string
-        reportingEntityName:
-          type: string
-        TIN:
-          type: string
-        issuingCountryTIN:
-          type: string
-      required:
-      - accountingPeriodFrom
-      - accountingPeriodTo
-      - filedDateGIR
-      - countryGIR
-      - reportingEntityName
-      - TIN
-      - issuingCountryTIN
     uk.gov.hmrc.pillar2submissionapi.models.belowthresholdnotification.SubmitBTNSuccessResponse:
       properties:
         processingDate:

--- a/resources/public/api/conf/1.0/testOnly/application.yaml
+++ b/resources/public/api/conf/1.0/testOnly/application.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.105.0
+  version: 0.106.0
   title: Pillar 2 API
   description: An API for managing and retrieving data in accordance with Pillar 2 tax rules.
 tags: []
@@ -428,8 +428,6 @@ paths:
               examples:
                 Invalid UTPR Election:
                   $ref: "#/components/examples/errors.Submission.InvalidUTPR"
-                Invalid Pillar2ID:
-                  $ref: "#/components/examples/errors.Submission.InvalidPillar2ID"
                 Invalid Total Liability IIR:
                   $ref: "#/components/examples/errors.Submission.InvalidTotalLiabilityIIR"
                 Invalid DTT Election:
@@ -438,16 +436,14 @@ paths:
                   $ref: "#/components/examples/errors.Submission.InvalidReturn"
                 Invalid Request:
                   $ref: "#/components/examples/errors.Submission.InvalidRequest"
-                Duplicate Submission:
-                  $ref: "#/components/examples/errors.Submission.DuplicateSubmission"
                 Invalid Total Liability UTPR:
                   $ref: "#/components/examples/errors.Submission.InvalidTotalLiabilityUTPR"
                 Invalid Total Liability:
                   $ref: "#/components/examples/errors.Submission.InvalidTotalLiability"
                 Tax Obligation Fulfilled:
                   $ref: "#/components/examples/errors.Submission.TaxObligationFulfilled"
-                No Active Submission:
-                  $ref: "#/components/examples/errors.Submission.NoActiveSubmission"
+                No Active Subscription:
+                  $ref: "#/components/examples/errors.Submission.NoActiveSubscription"
                 Invalid Total Liability DTT:
                   $ref: "#/components/examples/errors.Submission.InvalidTotalLiabilityDTT"
         "400":
@@ -617,8 +613,6 @@ paths:
               examples:
                 Invalid UTPR Election:
                   $ref: "#/components/examples/errors.Submission.InvalidUTPR"
-                Invalid Pillar2ID:
-                  $ref: "#/components/examples/errors.Submission.InvalidPillar2ID"
                 Invalid Total Liability IIR:
                   $ref: "#/components/examples/errors.Submission.InvalidTotalLiabilityIIR"
                 Invalid DTT Election:
@@ -627,14 +621,12 @@ paths:
                   $ref: "#/components/examples/errors.Submission.InvalidReturn"
                 Invalid Request:
                   $ref: "#/components/examples/errors.Submission.InvalidRequest"
-                Duplicate Submission:
-                  $ref: "#/components/examples/errors.Submission.DuplicateSubmission"
                 Invalid Total Liability UTPR:
                   $ref: "#/components/examples/errors.Submission.InvalidTotalLiabilityUTPR"
                 Invalid Total Liability:
                   $ref: "#/components/examples/errors.Submission.InvalidTotalLiability"
-                No Active Submission:
-                  $ref: "#/components/examples/errors.Submission.NoActiveSubmission"
+                No Active Subscription:
+                  $ref: "#/components/examples/errors.Submission.NoActiveSubscription"
                 Invalid Total Liability DTT:
                   $ref: "#/components/examples/errors.Submission.InvalidTotalLiabilityDTT"
         "400":
@@ -734,18 +726,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
               examples:
-                Invalid Pillar2ID:
-                  $ref: "#/components/examples/errors.Submission.InvalidPillar2ID"
                 Invalid Request:
                   $ref: "#/components/examples/errors.Submission.InvalidRequest"
                 Tax Obligation Fulfilled:
                   $ref: "#/components/examples/errors.Submission.TaxObligationFulfilled"
-                Duplicate Acknowledgment:
-                  value:
-                    code: '004'
-                    message: Duplicate acknowledgment reference
-                No Active Submission:
-                  $ref: "#/components/examples/errors.Submission.NoActiveSubmission"
+                No Active Subscription:
+                  $ref: "#/components/examples/errors.Submission.NoActiveSubscription"
         "403":
           description: Forbidden
           content:
@@ -866,14 +852,10 @@ paths:
           content:
             application/json:
               examples:
-                Invalid Pillar2ID:
-                  $ref: "#/components/examples/errors.Submission.InvalidPillar2ID"
                 Invalid Request:
                   $ref: "#/components/examples/errors.Submission.InvalidRequest"
-                Duplicate Acknowledgment:
-                  $ref: "#/components/examples/errors.Submission.DuplicateSubmission"
-                No associated data found:
-                  $ref: "#/components/examples/errors.Submission.NoActiveSubmission"
+                No Data Found:
+                  $ref: "#/components/examples/errors.Submission.NoDataFound"
         "401":
           description: Unauthorized
           content:
@@ -927,18 +909,18 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification.ORNSuccessResponse"
-              example:
-                processingDate: 2025-01-31T09:26:17Z
-                formBundleNumber: 123456789012345
+              examples:
+                responses.ORNSuccessResponseExample:
+                  $ref: "#/components/examples/responses.ORNSuccessResponseExample"
         "401":
           description: Unauthorized
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
-              example:
-                code: '003'
-                message: Not authorized
+              examples:
+                Unauthorized:
+                  $ref: "#/components/examples/errors.Submission.Unauthorized"
         "422":
           description: Business Validation Failure
           content:
@@ -946,30 +928,14 @@ paths:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
               examples:
-                Invalid Pillar2ID:
-                  value:
-                    code: '089'
-                    message: ID number missing or invalid
                 Invalid Request:
-                  value:
-                    code: '003'
-                    message: Request could not be processed
-                Duplicate Acknowledgment:
-                  value:
-                    code: '004'
-                    message: Duplicate acknowledgment reference
-                No Active Submission:
-                  value:
-                    code: '063'
-                    message: Business Partner does not have an Active Subscription for this Regime
+                  $ref: "#/components/examples/errors.Submission.InvalidRequest"
+                No Active Subscription Found:
+                  $ref: "#/components/examples/errors.Submission.NoActiveSubscription"
                 Tax Obligation Fulfilled:
-                  value:
-                    code: '044'
-                    message: Tax Obligation already fulfilled
+                  $ref: "#/components/examples/errors.Submission.TaxObligationFulfilled"
                 Invalid Return:
-                  value:
-                    code: '093'
-                    message: Invalid Return
+                  $ref: "#/components/examples/errors.Submission.InvalidReturn"
         "400":
           description: Bad Request
           content:
@@ -978,26 +944,20 @@ paths:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
               examples:
                 Invalid Json:
-                  value:
-                    code: '001'
-                    message: Invalid JSON payload
+                  $ref: "#/components/examples/errors.InvalidJson"
                 Empty Request Body:
-                  value:
-                    code: '002'
-                    message: Empty body in request
+                  $ref: "#/components/examples/errors.EmptyBody"
                 Missing Header:
-                  value:
-                    code: '005'
-                    message: Missing Header in request
+                  $ref: "#/components/examples/errors.Submission.MissingHeader"
         "403":
           description: Forbidden
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
-              example:
-                code: '006'
-                message: Forbidden
+              examples:
+                Forbidden:
+                  $ref: "#/components/examples/errors.Submission.Forbidden"
         "500":
           description: Internal Server Error
           content:
@@ -1006,13 +966,9 @@ paths:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
               examples:
                 Generic Server Error:
-                  value:
-                    code: 500
-                    message: Internal Server Error
+                  $ref: "#/components/examples/errors.Submission.GenericServerError"
                 No Subscription Data:
-                  value:
-                    code: '004'
-                    message: No Pillar2 subscription found for -pillar2Id
+                  $ref: "#/components/examples/errors.Submission.NoSubscriptionData"
       description: |
         Submit an Overseas Return Notification
       security:
@@ -1526,6 +1482,11 @@ components:
         electionUKGAAP: true
         liabilities:
           returnType: NIL_RETURN
+    responses.ORNSuccessResponseExample:
+      summary: ORN Success response
+      value:
+        processingDate: 2026-06-26T09:26:17Z
+        formBundleNumber: 119000004320
     errors.TestOrg.NotFound:
       summary: Test endpoints not available
       value:
@@ -1596,16 +1557,16 @@ components:
       value:
         code: '044'
         message: Tax Obligation already fulfilled
-    errors.Submission.NoActiveSubmission:
-      summary: No active submission
+    errors.Submission.NoActiveSubscription:
+      summary: No active subscription
       value:
-        code: '007'
-        message: Business Partner does not have an active subscription
+        code: '063'
+        message: Business Partner does not have an Active Subscription for this Regime
     errors.Submission.DuplicateSubmission:
       summary: Duplicate submission
       value:
         code: '004'
-        message: Duplicate submission acknowledgment reference
+        message: Duplicate submission
     errors.Submission.InvalidUTPR:
       summary: Invalid UTPR Election
       value:
@@ -1636,6 +1597,11 @@ components:
       value:
         code: '098'
         message: Invalid Total Liability DTT
+    errors.Submission.NoDataFound:
+      summary: No data found
+      value:
+        code: '014'
+        message: No data found
   securitySchemes:
     userRestricted:
       type: oauth2

--- a/resources/public/api/conf/1.0/testOnly/application.yaml
+++ b/resources/public/api/conf/1.0/testOnly/application.yaml
@@ -937,6 +937,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
               examples:
+                Invalid Request:
+                  $ref: "#/components/examples/errors.Submission.InvalidRequest"
                 No Active Subscription Found:
                   $ref: "#/components/examples/errors.Submission.NoActiveSubscription"
                 Tax Obligation Fulfilled:


### PR DESCRIPTION
The error codes and messages are updated as per latest HIP EPIDs. Below are the changes that are done as part of this change.

1. Error code 014 added for obligation and submission endpoint
2. Error codes 002/089/004 are removed for UKTR, BTN, Obligation and submission and ORN endpoints.
3. Error code 007 is replaced with 063 for UKTR, BTN, and ORN endpoints.
4. Error messages are updated as per latest HIP EPIDs for UKTR, BTN, Obligation and submission and ORN endpoints.