### PR TITLE
PIL-1866: Refactor 403 errors

### DIFF
--- a/API Testing/pillar2-submission-api/99-qa/orn/Valid request.bru
+++ b/API Testing/pillar2-submission-api/99-qa/orn/Valid request.bru
@@ -1,7 +1,7 @@
 meta {
   name: Valid request
   type: http
-  seq: 6
+  seq: 7
 }
 
 post {

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandler.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandler.scala
@@ -44,11 +44,11 @@ class Pillar2ErrorHandler extends HttpErrorHandler with Logging {
         val ret = e match {
           case InvalidDateRange | InvalidDateFormat | InvalidJson | EmptyRequestBody | MissingHeader(_) =>
             Results.BadRequest(Pillar2ErrorResponse(e.code, e.message))
-          case MissingCredentials | InvalidCredentials => Results.Unauthorized(Pillar2ErrorResponse(e.code, e.message))
-          case ForbiddenError | TestEndpointDisabled   => Results.Forbidden(Pillar2ErrorResponse(e.code, e.message))
-          case OrganisationNotFound(_)                 => Results.NotFound(Pillar2ErrorResponse(e.code, e.message))
-          case OrganisationAlreadyExists(_)            => Results.Conflict(Pillar2ErrorResponse(e.code, e.message))
-          case DownstreamValidationError(_, _)         => Results.UnprocessableEntity(Pillar2ErrorResponse(e.code, e.message))
+          case MissingCredentials | InvalidCredentials                  => Results.Unauthorized(Pillar2ErrorResponse(e.code, e.message))
+          case ForbiddenError | InvalidEnrolment | TestEndpointDisabled => Results.Forbidden(Pillar2ErrorResponse(e.code, e.message))
+          case OrganisationNotFound(_)                                  => Results.NotFound(Pillar2ErrorResponse(e.code, e.message))
+          case OrganisationAlreadyExists(_)                             => Results.Conflict(Pillar2ErrorResponse(e.code, e.message))
+          case DownstreamValidationError(_, _)                          => Results.UnprocessableEntity(Pillar2ErrorResponse(e.code, e.message))
           case DatabaseError(_) | UnexpectedResponse | NoSubscriptionData(_) =>
             Results.InternalServerError(Pillar2ErrorResponse(e.code, e.message))
         }

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/error/Pillar2Error.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/error/Pillar2Error.scala
@@ -72,8 +72,13 @@ object MissingHeader {
 }
 
 case object ForbiddenError extends Pillar2Error {
-  val code    = "006"
-  val message = "Forbidden"
+  val code    = "FORBIDDEN"
+  val message = "Access to the requested resource is forbidden"
+}
+
+case object InvalidEnrolment extends Pillar2Error {
+  val code    = "INVALID_ENROLMENT"
+  val message = "Invalid Pillar 2 enrolment"
 }
 
 case class DownstreamValidationError(code: String, message: String) extends Pillar2Error
@@ -94,6 +99,6 @@ case class DatabaseError(operation: String) extends Pillar2Error {
 }
 
 case object TestEndpointDisabled extends Pillar2Error {
-  override val code:    String = "403"
+  override val code:    String = "TEST_ENDPOINT_DISABLED"
   override val message: String = "Test endpoints are not available in this environment"
 }

--- a/conf/swagger.yml
+++ b/conf/swagger.yml
@@ -118,8 +118,8 @@ paths:
           content:
             application/json:
               examples:
-                Forbidden:
-                  $ref: "#/components/examples/errors.Submission.Forbidden"
+                Invalid Scope:
+                  $ref: "#/components/examples/errors.InvalidScope"
         "422":
           description: Business Validation Failure
           content:
@@ -216,8 +216,8 @@ paths:
           content:
             application/json:
               examples:
-                Forbidden:
-                  $ref: "#/components/examples/errors.Submission.Forbidden"
+                Invalid Scope:
+                  $ref: "#/components/examples/errors.InvalidScope"
         "422":
           description: Business Validation Failure
           content:
@@ -320,8 +320,8 @@ paths:
           content:
             application/json:
               examples:
-                Forbidden:
-                  $ref: "#/components/examples/errors.Submission.Forbidden"
+                Invalid Scope:
+                  $ref: "#/components/examples/errors.InvalidScope"
         "422":
           description: Business Validation Failure
           content:
@@ -383,8 +383,8 @@ paths:
           content:
             application/json:
               examples:
-                Forbidden:
-                  $ref: "#/components/examples/errors.Submission.Forbidden"
+                Invalid Scope:
+                  $ref: "#/components/examples/errors.InvalidScope"
         "422":
           description: Business Validation Failure
           content:
@@ -458,8 +458,8 @@ paths:
           content:
             application/json:
               examples:
-                Forbidden:
-                  $ref: "#/components/examples/errors.Submission.Forbidden"
+                Invalid Scope:
+                  $ref: "#/components/examples/errors.InvalidScope"
         "422":
           description: Business Validation Failure
           content:
@@ -526,8 +526,10 @@ paths:
           content:
             application/json:
               examples:
-                Forbidden:
-                  $ref: "#/components/examples/errors.TestOrg.Forbidden"
+                Test Endpoint Disabled:
+                  $ref: "#/components/examples/errors.TestOrg.EndpointDisabled"
+                Invalid Scope:
+                  $ref: "#/components/examples/errors.InvalidScope"
       security:
         - userRestricted: [write:pillar2]
     get:
@@ -565,8 +567,10 @@ paths:
           content:
             application/json:
               examples:
-                Forbidden:
-                  $ref: "#/components/examples/errors.TestOrg.Forbidden"
+                Test Endpoint Disabled:
+                  $ref: "#/components/examples/errors.TestOrg.EndpointDisabled"
+                Invalid Scope:
+                  $ref: "#/components/examples/errors.InvalidScope"
         "404":
           description: Not Found
           content:
@@ -617,8 +621,10 @@ paths:
           content:
             application/json:
               examples:
-                Forbidden:
-                  $ref: "#/components/examples/errors.TestOrg.Forbidden"
+                Test Endpoint Disabled:
+                  $ref: "#/components/examples/errors.TestOrg.EndpointDisabled"
+                Invalid Scope:
+                  $ref: "#/components/examples/errors.InvalidScope"
         "404":
           description: Not Found
           content:
@@ -647,8 +653,10 @@ paths:
           content:
             application/json:
               examples:
-                Forbidden:
-                  $ref: "#/components/examples/errors.TestOrg.Forbidden"
+                Test Endpoint Disabled:
+                  $ref: "#/components/examples/errors.TestOrg.EndpointDisabled"
+                Invalid Scope:
+                  $ref: "#/components/examples/errors.InvalidScope"
         "404":
           description: Not Found
           content:
@@ -972,14 +980,14 @@ components:
         processingDate: "2026-06-26T09:26:17Z"
         formBundleNumber: 119000004320
     errors.TestOrg.NotFound:
-      summary: Test endpoints not available
+      summary: Test organisation not found
       value:
         code: "404"
         message: "Organisation not found for pillar2Id: XAPLR1234567890"
-    errors.TestOrg.Forbidden:
+    errors.TestOrg.EndpointDisabled:
       summary: Test endpoints not available
       value:
-        code: 403
+        code: TEST_ENDPOINT_DISABLED
         message: Test endpoints are not available in this environment
     errors.MissingCredentials:
       summary: Missing Credentials
@@ -1031,11 +1039,11 @@ components:
       value:
         code: 500
         message: Internal Server Error
-    errors.Submission.Forbidden:
-      summary: Forbidden
+    errors.InvalidScope:
+      summary: Invalid scope
       value:
-        code: '006'
-        message: Forbidden
+        code: 'INVALID_SCOPE'
+        message: Can not access the required resource. Ensure this token has all the required scopes.
     errors.Submission.InvalidReturn:
       summary: Invalid return
       value:

--- a/resources/public/api/conf/1.0/application.yaml
+++ b/resources/public/api/conf/1.0/application.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.114.0
+  version: 0.116.0
   title: Pillar 2 API
   description: An API for managing and retrieving data in accordance with Pillar 2 tax rules.
 tags: []
@@ -78,8 +78,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
               examples:
-                Forbidden:
-                  $ref: "#/components/examples/errors.TestOrg.Forbidden"
+                Test Endpoint Disabled:
+                  $ref: "#/components/examples/errors.TestOrg.EndpointDisabled"
+                Invalid Scope:
+                  $ref: "#/components/examples/errors.InvalidScope"
         "409":
           description: Organisation Already Exists
           content:
@@ -156,8 +158,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
               examples:
-                Forbidden:
-                  $ref: "#/components/examples/errors.TestOrg.Forbidden"
+                Test Endpoint Disabled:
+                  $ref: "#/components/examples/errors.TestOrg.EndpointDisabled"
+                Invalid Scope:
+                  $ref: "#/components/examples/errors.InvalidScope"
         "404":
           description: Not Found
           content:
@@ -262,8 +266,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
               examples:
-                Forbidden:
-                  $ref: "#/components/examples/errors.TestOrg.Forbidden"
+                Test Endpoint Disabled:
+                  $ref: "#/components/examples/errors.TestOrg.EndpointDisabled"
+                Invalid Scope:
+                  $ref: "#/components/examples/errors.InvalidScope"
         "404":
           description: Not Found
           content:
@@ -333,8 +339,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
               examples:
-                Forbidden:
-                  $ref: "#/components/examples/errors.TestOrg.Forbidden"
+                Test Endpoint Disabled:
+                  $ref: "#/components/examples/errors.TestOrg.EndpointDisabled"
+                Invalid Scope:
+                  $ref: "#/components/examples/errors.InvalidScope"
         "404":
           description: Not Found
           content:
@@ -476,8 +484,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
               examples:
-                Forbidden:
-                  $ref: "#/components/examples/errors.Submission.Forbidden"
+                Invalid Scope:
+                  $ref: "#/components/examples/errors.InvalidScope"
         "500":
           description: Internal Server Error
           content:
@@ -661,8 +669,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
               examples:
-                Forbidden:
-                  $ref: "#/components/examples/errors.Submission.Forbidden"
+                Invalid Scope:
+                  $ref: "#/components/examples/errors.InvalidScope"
         "500":
           description: Internal Server Error
           content:
@@ -753,8 +761,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
               examples:
-                Forbidden:
-                  $ref: "#/components/examples/errors.Submission.Forbidden"
+                Invalid Scope:
+                  $ref: "#/components/examples/errors.InvalidScope"
         "500":
           description: Internal Server Error
           content:
@@ -859,8 +867,8 @@ paths:
           content:
             application/json:
               examples:
-                Forbidden:
-                  $ref: "#/components/examples/errors.Submission.Forbidden"
+                Invalid Scope:
+                  $ref: "#/components/examples/errors.InvalidScope"
         "422":
           description: Business Validation Failure
           content:
@@ -1370,14 +1378,14 @@ components:
         liabilities:
           returnType: NIL_RETURN
     errors.TestOrg.NotFound:
-      summary: Test endpoints not available
+      summary: Test organisation not found
       value:
         code: 404
         message: "Organisation not found for pillar2Id: XAPLR1234567890"
-    errors.TestOrg.Forbidden:
+    errors.TestOrg.EndpointDisabled:
       summary: Test endpoints not available
       value:
-        code: 403
+        code: TEST_ENDPOINT_DISABLED
         message: Test endpoints are not available in this environment
     errors.MissingCredentials:
       summary: Missing Credentials
@@ -1429,11 +1437,11 @@ components:
       value:
         code: 500
         message: Internal Server Error
-    errors.Submission.Forbidden:
-      summary: Forbidden
+    errors.InvalidScope:
+      summary: Invalid scope
       value:
-        code: '006'
-        message: Forbidden
+        code: INVALID_SCOPE
+        message: Can not access the required resource. Ensure this token has all the required scopes.
     errors.Submission.InvalidReturn:
       summary: Invalid return
       value:

--- a/resources/public/api/conf/1.0/testOnly/application.yaml
+++ b/resources/public/api/conf/1.0/testOnly/application.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.114.0
+  version: 0.116.0
   title: Pillar 2 API
   description: An API for managing and retrieving data in accordance with Pillar 2 tax rules.
 tags: []
@@ -78,8 +78,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
               examples:
-                Forbidden:
-                  $ref: "#/components/examples/errors.TestOrg.Forbidden"
+                Test Endpoint Disabled:
+                  $ref: "#/components/examples/errors.TestOrg.EndpointDisabled"
+                Invalid Scope:
+                  $ref: "#/components/examples/errors.InvalidScope"
         "409":
           description: Organisation Already Exists
           content:
@@ -156,8 +158,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
               examples:
-                Forbidden:
-                  $ref: "#/components/examples/errors.TestOrg.Forbidden"
+                Test Endpoint Disabled:
+                  $ref: "#/components/examples/errors.TestOrg.EndpointDisabled"
+                Invalid Scope:
+                  $ref: "#/components/examples/errors.InvalidScope"
         "404":
           description: Not Found
           content:
@@ -262,8 +266,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
               examples:
-                Forbidden:
-                  $ref: "#/components/examples/errors.TestOrg.Forbidden"
+                Test Endpoint Disabled:
+                  $ref: "#/components/examples/errors.TestOrg.EndpointDisabled"
+                Invalid Scope:
+                  $ref: "#/components/examples/errors.InvalidScope"
         "404":
           description: Not Found
           content:
@@ -333,8 +339,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
               examples:
-                Forbidden:
-                  $ref: "#/components/examples/errors.TestOrg.Forbidden"
+                Test Endpoint Disabled:
+                  $ref: "#/components/examples/errors.TestOrg.EndpointDisabled"
+                Invalid Scope:
+                  $ref: "#/components/examples/errors.InvalidScope"
         "404":
           description: Not Found
           content:
@@ -476,8 +484,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
               examples:
-                Forbidden:
-                  $ref: "#/components/examples/errors.Submission.Forbidden"
+                Invalid Scope:
+                  $ref: "#/components/examples/errors.InvalidScope"
         "500":
           description: Internal Server Error
           content:
@@ -661,8 +669,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
               examples:
-                Forbidden:
-                  $ref: "#/components/examples/errors.Submission.Forbidden"
+                Invalid Scope:
+                  $ref: "#/components/examples/errors.InvalidScope"
         "500":
           description: Internal Server Error
           content:
@@ -753,8 +761,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
               examples:
-                Forbidden:
-                  $ref: "#/components/examples/errors.Submission.Forbidden"
+                Invalid Scope:
+                  $ref: "#/components/examples/errors.InvalidScope"
         "500":
           description: Internal Server Error
           content:
@@ -859,8 +867,8 @@ paths:
           content:
             application/json:
               examples:
-                Forbidden:
-                  $ref: "#/components/examples/errors.Submission.Forbidden"
+                Invalid Scope:
+                  $ref: "#/components/examples/errors.InvalidScope"
         "422":
           description: Business Validation Failure
           content:
@@ -983,8 +991,8 @@ paths:
               schema:
                 $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse"
               examples:
-                Forbidden:
-                  $ref: "#/components/examples/errors.Submission.Forbidden"
+                Invalid Scope:
+                  $ref: "#/components/examples/errors.InvalidScope"
         "500":
           description: Internal Server Error
           content:
@@ -1523,14 +1531,14 @@ components:
         processingDate: 2026-06-26T09:26:17Z
         formBundleNumber: 119000004320
     errors.TestOrg.NotFound:
-      summary: Test endpoints not available
+      summary: Test organisation not found
       value:
         code: 404
         message: "Organisation not found for pillar2Id: XAPLR1234567890"
-    errors.TestOrg.Forbidden:
+    errors.TestOrg.EndpointDisabled:
       summary: Test endpoints not available
       value:
-        code: 403
+        code: TEST_ENDPOINT_DISABLED
         message: Test endpoints are not available in this environment
     errors.MissingCredentials:
       summary: Missing Credentials
@@ -1582,11 +1590,11 @@ components:
       value:
         code: 500
         message: Internal Server Error
-    errors.Submission.Forbidden:
-      summary: Forbidden
+    errors.InvalidScope:
+      summary: Invalid scope
       value:
-        code: '006'
-        message: Forbidden
+        code: INVALID_SCOPE
+        message: Can not access the required resource. Ensure this token has all the required scopes.
     errors.Submission.InvalidReturn:
       summary: Invalid return
       value:

--- a/test/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandlerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandlerSpec.scala
@@ -157,8 +157,16 @@ class Pillar2ErrorHandlerSpec extends AnyFunSuite with ScalaCheckDrivenPropertyC
     val response = classUnderTest.onServerError(dummyRequest, ForbiddenError)
     status(response) mustEqual 403
     val result = contentAsJson(response).as[Pillar2ErrorResponse]
-    result.code mustEqual "006"
-    result.message mustEqual "Forbidden"
+    result.code mustEqual "FORBIDDEN"
+    result.message mustEqual "Access to the requested resource is forbidden"
+  }
+
+  test("InvalidEnrolment error response") {
+    val response = classUnderTest.onServerError(dummyRequest, InvalidEnrolment)
+    status(response) mustEqual 403
+    val result = contentAsJson(response).as[Pillar2ErrorResponse]
+    result.code mustEqual "INVALID_ENROLMENT"
+    result.message mustEqual "Invalid Pillar 2 enrolment"
   }
 
   test("NoSubscriptionData error response") {
@@ -181,7 +189,7 @@ class Pillar2ErrorHandlerSpec extends AnyFunSuite with ScalaCheckDrivenPropertyC
     val response = classUnderTest.onServerError(dummyRequest, TestEndpointDisabled)
     status(response) mustEqual 403
     val result = contentAsJson(response).as[Pillar2ErrorResponse]
-    result.code mustEqual "403"
+    result.code mustEqual "TEST_ENDPOINT_DISABLED"
     result.message mustEqual "Test endpoints are not available in this environment"
   }
 

--- a/test/uk/gov/hmrc/pillar2submissionapi/controllers/actions/AuthenticatedIdentifierActionSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/controllers/actions/AuthenticatedIdentifierActionSpec.scala
@@ -35,7 +35,7 @@ import uk.gov.hmrc.pillar2submissionapi.base.ActionBaseSpec
 import uk.gov.hmrc.pillar2submissionapi.config.AppConfig
 import uk.gov.hmrc.pillar2submissionapi.controllers.actions.AuthenticatedIdentifierAction._
 import uk.gov.hmrc.pillar2submissionapi.controllers.actions.AuthenticatedIdentifierActionSpec._
-import uk.gov.hmrc.pillar2submissionapi.controllers.error.{ForbiddenError, InvalidCredentials, MissingCredentials}
+import uk.gov.hmrc.pillar2submissionapi.controllers.error._
 import uk.gov.hmrc.pillar2submissionapi.helpers.TestAuthRetrievals._
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
@@ -95,13 +95,9 @@ class AuthenticatedIdentifierActionSpec extends ActionBaseSpec {
             Future.successful(Some(id) ~ Some(groupId) ~ pillar2Enrolments ~ Some(Agent) ~ None ~ Some(Credentials(providerId, providerType)))
           )
 
-        val result = intercept[ForbiddenError.type](
-          await(
-            identifierAction.refine(fakeRequestWithPillar2Id)
-          )
-        )
+        val result = intercept[ForbiddenError.type](await(identifierAction.refine(fakeRequestWithPillar2Id)))
 
-        result.message mustEqual "Forbidden"
+        result.message mustEqual "Access to the requested resource is forbidden"
       }
 
       "pass if agent is a test user and test users are enabled" in {
@@ -234,13 +230,9 @@ class AuthenticatedIdentifierActionSpec extends ActionBaseSpec {
             )
           )
 
-        val result = intercept[ForbiddenError.type](
-          await(
-            identifierAction.refine(fakeRequestWithPillar2Id)
-          )
-        )
+        val result = intercept[ForbiddenError.type](await(identifierAction.refine(fakeRequestWithPillar2Id)))
 
-        result.message mustEqual "Forbidden"
+        result.message mustEqual "Access to the requested resource is forbidden"
       }
     }
   }
@@ -260,13 +252,9 @@ class AuthenticatedIdentifierActionSpec extends ActionBaseSpec {
             )
           )
 
-        val result = intercept[ForbiddenError.type](
-          await(
-            identifierAction.refine(fakeRequestWithPillar2Id)
-          )
-        )
+        val result = intercept[ForbiddenError.type](await(identifierAction.refine(fakeRequestWithPillar2Id)))
 
-        result.message mustEqual "Forbidden"
+        result.message mustEqual "Access to the requested resource is forbidden"
       }
     }
 
@@ -282,13 +270,9 @@ class AuthenticatedIdentifierActionSpec extends ActionBaseSpec {
             Future.successful(Some(id) ~ None ~ pillar2Enrolments ~ Some(Organisation) ~ Some(User) ~ Some(Credentials(providerId, providerType)))
           )
 
-        val result = intercept[ForbiddenError.type](
-          await(
-            identifierAction.refine(fakeRequestWithPillar2Id)
-          )
-        )
+        val result = intercept[ForbiddenError.type](await(identifierAction.refine(fakeRequestWithPillar2Id)))
 
-        result.message mustEqual "Forbidden"
+        result.message mustEqual "Access to the requested resource is forbidden"
       }
     }
 
@@ -304,13 +288,9 @@ class AuthenticatedIdentifierActionSpec extends ActionBaseSpec {
             Future.successful(Some(id) ~ Some(groupId) ~ pillar2Enrolments ~ None ~ Some(User) ~ Some(Credentials(providerId, providerType)))
           )
 
-        val result = intercept[ForbiddenError.type](
-          await(
-            identifierAction.refine(fakeRequestWithPillar2Id)
-          )
-        )
+        val result = intercept[ForbiddenError.type](await(identifierAction.refine(fakeRequestWithPillar2Id)))
 
-        result.message mustEqual "Forbidden"
+        result.message mustEqual "Access to the requested resource is forbidden"
       }
     }
 
@@ -359,13 +339,9 @@ class AuthenticatedIdentifierActionSpec extends ActionBaseSpec {
             Future.successful(Some(id) ~ Some(groupId) ~ pillar2Enrolments ~ Some(Organisation) ~ None ~ Some(Credentials(providerId, providerType)))
           )
 
-        val result = intercept[ForbiddenError.type](
-          await(
-            identifierAction.refine(fakeRequestWithPillar2Id)
-          )
-        )
+        val result = intercept[ForbiddenError.type](await(identifierAction.refine(fakeRequestWithPillar2Id)))
 
-        result.message mustEqual "Forbidden"
+        result.message mustEqual "Access to the requested resource is forbidden"
       }
     }
   }
@@ -385,13 +361,9 @@ class AuthenticatedIdentifierActionSpec extends ActionBaseSpec {
             )
           )
 
-        val result = intercept[ForbiddenError.type](
-          await(
-            identifierAction.refine(fakeRequestWithPillar2Id)
-          )
-        )
+        val result = intercept[InvalidEnrolment.type](await(identifierAction.refine(fakeRequestWithPillar2Id)))
 
-        result.message mustEqual "Forbidden"
+        result.message mustEqual "Invalid Pillar 2 enrolment"
       }
     }
   }


### PR DESCRIPTION
Adds the API Platform 403 `INVALID_SCOPE` and restructures the existing 403s to have a consistent snake-cased all-caps `code`.