### PR TITLE
PIL-1978: Require HIP Headers (Bruno tests)

### DIFF
--- a/API Testing/pillar2-external-test-stub/02-btn/Submit BTN.bru
+++ b/API Testing/pillar2-external-test-stub/02-btn/Submit BTN.bru
@@ -13,6 +13,10 @@ post {
 headers {
   X-Pillar2-Id: {{testPlrId}}
   Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/02-oas/Retrieve OaS.bru
+++ b/API Testing/pillar2-external-test-stub/02-oas/Retrieve OaS.bru
@@ -18,4 +18,8 @@ params:query {
 headers {
   X-Pillar2-Id: {{testPlrId}}
   Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }

--- a/API Testing/pillar2-external-test-stub/02-orn/Amend ORN.bru
+++ b/API Testing/pillar2-external-test-stub/02-orn/Amend ORN.bru
@@ -13,6 +13,10 @@ put {
 headers {
   X-Pillar2-Id: {{testPlrId}}
   Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/02-orn/Get ORN.bru
+++ b/API Testing/pillar2-external-test-stub/02-orn/Get ORN.bru
@@ -13,4 +13,8 @@ get {
 headers {
   X-Pillar2-Id: {{testPlrId}}
   Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }

--- a/API Testing/pillar2-external-test-stub/02-orn/Submit ORN.bru
+++ b/API Testing/pillar2-external-test-stub/02-orn/Submit ORN.bru
@@ -13,6 +13,10 @@ post {
 headers {
   X-Pillar2-Id: {{testPlrId}}
   Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/02-uktr/Amend UKTR - Liability (Domestic).bru
+++ b/API Testing/pillar2-external-test-stub/02-uktr/Amend UKTR - Liability (Domestic).bru
@@ -13,6 +13,10 @@ put {
 headers {
   X-Pillar2-Id: {{testPlrId}}
   Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/02-uktr/Amend UKTR - Liability.bru
+++ b/API Testing/pillar2-external-test-stub/02-uktr/Amend UKTR - Liability.bru
@@ -13,6 +13,10 @@ put {
 headers {
   X-Pillar2-Id: {{testPlrId}}
   Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/02-uktr/Amend UKTR - Nil (Domestic).bru
+++ b/API Testing/pillar2-external-test-stub/02-uktr/Amend UKTR - Nil (Domestic).bru
@@ -13,6 +13,10 @@ put {
 headers {
   X-Pillar2-Id: {{testPlrId}}
   Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/02-uktr/Amend UKTR - Nil.bru
+++ b/API Testing/pillar2-external-test-stub/02-uktr/Amend UKTR - Nil.bru
@@ -13,6 +13,10 @@ put {
 headers {
   X-Pillar2-Id: {{testPlrId}}
   Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/02-uktr/Submit UKTR - Liability (Domestic).bru
+++ b/API Testing/pillar2-external-test-stub/02-uktr/Submit UKTR - Liability (Domestic).bru
@@ -13,6 +13,10 @@ post {
 headers {
   X-Pillar2-Id: {{testPlrId}}
   Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/02-uktr/Submit UKTR - Liability.bru
+++ b/API Testing/pillar2-external-test-stub/02-uktr/Submit UKTR - Liability.bru
@@ -13,6 +13,10 @@ post {
 headers {
   X-Pillar2-Id: {{testPlrId}}
   Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/02-uktr/Submit UKTR - Nil (Domestic).bru
+++ b/API Testing/pillar2-external-test-stub/02-uktr/Submit UKTR - Nil (Domestic).bru
@@ -13,6 +13,10 @@ post {
 headers {
   X-Pillar2-Id: {{testPlrId}}
   Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/02-uktr/Submit UKTR - Nil.bru
+++ b/API Testing/pillar2-external-test-stub/02-uktr/Submit UKTR - Nil.bru
@@ -13,6 +13,10 @@ post {
 headers {
   X-Pillar2-Id: {{testPlrId}}
   Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/99-qa/btn/Invalid Accounting Period.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/btn/Invalid Accounting Period.bru
@@ -13,6 +13,10 @@ post {
 headers {
   X-Pillar2-Id: {{testPlrId}}
   Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/99-qa/btn/Invalid Date.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/btn/Invalid Date.bru
@@ -13,6 +13,10 @@ post {
 headers {
   X-Pillar2-Id: {{testPlrId}}
   Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/99-qa/btn/Invalid JSON.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/btn/Invalid JSON.bru
@@ -13,6 +13,10 @@ post {
 headers {
   X-Pillar2-Id: {{testPlrId}}
   Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/99-qa/btn/Missing X-Pillar2-Id Header.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/btn/Missing X-Pillar2-Id Header.bru
@@ -12,6 +12,10 @@ post {
 
 headers {
   Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/99-qa/btn/Valid Submission.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/btn/Valid Submission.bru
@@ -14,6 +14,10 @@ headers {
 
   X-Pillar2-Id: {{testPlrId}}
   Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/99-qa/btn/unauthorized.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/btn/unauthorized.bru
@@ -12,6 +12,10 @@ post {
 
 headers {
   X-Pillar2-Id: {{testPlrId}}
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/99-qa/oas/Invalid date range.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/oas/Invalid date range.bru
@@ -17,6 +17,10 @@ params:query {
 
 headers {
   Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
   X-Pillar2-Id: {{testPlrId}}
 }
 

--- a/API Testing/pillar2-external-test-stub/99-qa/oas/Invalid query param.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/oas/Invalid query param.bru
@@ -17,6 +17,10 @@ params:query {
 
 headers {
   Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
   X-Pillar2-Id: {{testPlrId}}
 }
 

--- a/API Testing/pillar2-external-test-stub/99-qa/oas/Missing query param (fromDate).bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/oas/Missing query param (fromDate).bru
@@ -12,6 +12,10 @@ get {
 
 headers {
   Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
   X-Pillar2-Id: {{testPlrId}}
 }
 

--- a/API Testing/pillar2-external-test-stub/99-qa/oas/Missing query param (toDate).bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/oas/Missing query param (toDate).bru
@@ -16,6 +16,10 @@ params:query {
 
 headers {
   Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
   X-Pillar2-Id: {{testPlrId}}
 }
 

--- a/API Testing/pillar2-external-test-stub/99-qa/oas/Unauthorized.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/oas/Unauthorized.bru
@@ -17,6 +17,10 @@ params:query {
 
 headers {
   X-Pillar2-Id: {{testPlrId}}
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 tests {

--- a/API Testing/pillar2-external-test-stub/99-qa/oas/Valid request.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/oas/Valid request.bru
@@ -17,6 +17,10 @@ params:query {
 
 headers {
   Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
   X-Pillar2-Id: {{testPlrId}}
 }
 

--- a/API Testing/pillar2-external-test-stub/99-qa/orn/Delete Test Organisation.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/orn/Delete Test Organisation.bru
@@ -1,20 +1,15 @@
 meta {
-  name: Delete Organisation
+  name: Delete Test Organisation
   type: http
-  seq: 4
+  seq: 14
 }
 
 delete {
   url: {{externalTestStubUrl}}/pillar2/test/organisation/{{testPlrId}}
+  body: none
   auth: none
 }
 
 headers {
   Authorization: valid bearerToken
-} 
-
-tests {
-  test("Status code is 204", function() {
-    expect(res.getStatus()).to.equal(204)
-  });
 }

--- a/API Testing/pillar2-external-test-stub/99-qa/orn/Duplicate Submission.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/orn/Duplicate Submission.bru
@@ -12,7 +12,11 @@ post {
 
 headers {
   X-Pillar2-Id: {{testPlrId}}
-  Authorization: validBearerToken
+  Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/99-qa/orn/Invalid Date Format.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/orn/Invalid Date Format.bru
@@ -12,7 +12,11 @@ post {
 
 headers {
   X-Pillar2-Id: {{testPlrId}}
-  Authorization: validBearerToken
+  Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/99-qa/orn/Invalid JSON.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/orn/Invalid JSON.bru
@@ -12,7 +12,11 @@ post {
 
 headers {
   X-Pillar2-Id: {{testPlrId}}
-  Authorization: validBearerToken
+  Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/99-qa/orn/Missing Pillar2-ID Header.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/orn/Missing Pillar2-ID Header.bru
@@ -11,7 +11,11 @@ post {
 }
 
 headers {
-  Authorization: validBearerToken
+  Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/99-qa/orn/No Submission Found.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/orn/No Submission Found.bru
@@ -12,7 +12,11 @@ get {
 
 headers {
   X-Pillar2-Id: {{testPlrId}}
-  Authorization: validBearerToken
+  Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 tests {

--- a/API Testing/pillar2-external-test-stub/99-qa/orn/Server Error.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/orn/Server Error.bru
@@ -12,7 +12,11 @@ post {
 
 headers {
   X-Pillar2-Id: {{serverErrorPillar2Id}}
-  Authorization: validBearerToken
+  Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/99-qa/orn/Unauthorized.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/orn/Unauthorized.bru
@@ -12,6 +12,10 @@ post {
 
 headers {
   X-Pillar2-Id: {{testPlrId}}
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/99-qa/orn/Valid Amendment.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/orn/Valid Amendment.bru
@@ -12,7 +12,11 @@ put {
 
 headers {
   X-Pillar2-Id: {{testPlrId}}
-  Authorization: validBearerToken
+  Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/99-qa/orn/Valid Request.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/orn/Valid Request.bru
@@ -12,7 +12,11 @@ post {
 
 headers {
   X-Pillar2-Id: {{testPlrId}}
-  Authorization: validBearerToken
+  Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/99-qa/orn/Valid Retrieval.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/orn/Valid Retrieval.bru
@@ -12,7 +12,11 @@ get {
 
 headers {
   X-Pillar2-Id: {{testPlrId}}
-  Authorization: validBearerToken
+  Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 tests {

--- a/API Testing/pillar2-external-test-stub/99-qa/orn/filedDateGIR in future (Amend).bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/orn/filedDateGIR in future (Amend).bru
@@ -12,7 +12,11 @@ put {
 
 headers {
   X-Pillar2-Id: {{testPlrId}}
-  Authorization: validBearerToken
+  Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/99-qa/orn/filedDateGIR in future.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/orn/filedDateGIR in future.bru
@@ -12,7 +12,11 @@ post {
 
 headers {
   X-Pillar2-Id: {{testPlrId}}
-  Authorization: validBearerToken
+  Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/99-qa/setup/create-organisation.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/setup/create-organisation.bru
@@ -11,7 +11,6 @@ post {
 }
 
 headers {
-
   Authorization: valid bearerToken
 }
 

--- a/API Testing/pillar2-external-test-stub/99-qa/setup/get-organisation.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/setup/get-organisation.bru
@@ -11,7 +11,6 @@ get {
 }
 
 headers {
-
   Authorization: valid bearerToken
 }
 

--- a/API Testing/pillar2-external-test-stub/99-qa/setup/update-organisation.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/setup/update-organisation.bru
@@ -11,7 +11,6 @@ put {
 }
 
 headers {
-
   Authorization: valid bearerToken
 }
 

--- a/API Testing/pillar2-external-test-stub/99-qa/uktr/Empty liable entities.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/uktr/Empty liable entities.bru
@@ -12,7 +12,11 @@ post {
 
 headers {
   X-Pillar2-Id: {{testPlrId}}
-  Authorization: validBearerToken
+  Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/99-qa/uktr/Liability return - Valid.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/uktr/Liability return - Valid.bru
@@ -12,7 +12,11 @@ post {
 
 headers {
   X-Pillar2-Id: {{testPlrId}}
-  Authorization: validBearerToken
+  Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/99-qa/uktr/Nil return - Valid.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/uktr/Nil return - Valid.bru
@@ -12,7 +12,11 @@ post {
 
 headers {
   X-Pillar2-Id: {{testPlrId}}
-  Authorization: validBearerToken
+  Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/99-qa/uktr/No Pillar2Id.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/uktr/No Pillar2Id.bru
@@ -11,7 +11,11 @@ post {
 }
 
 headers {
-  Authorization: validBearerToken
+  Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/99-qa/uktr/electionUKGAAP/Liability return - GAAP invalid.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/uktr/electionUKGAAP/Liability return - GAAP invalid.bru
@@ -12,7 +12,11 @@ post {
 
 headers {
   X-Pillar2-Id: {{testPlrId}}
-  Authorization: validBearerToken
+  Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/99-qa/uktr/electionUKGAAP/Nil return - GAAP invalid.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/uktr/electionUKGAAP/Nil return - GAAP invalid.bru
@@ -12,7 +12,11 @@ post {
 
 headers {
   X-Pillar2-Id: {{testPlrId}}
-  Authorization: validBearerToken
+  Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/99-qa/uktr/obligationMTT/Liability return - obligationMTT invalid.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/uktr/obligationMTT/Liability return - obligationMTT invalid.bru
@@ -12,7 +12,11 @@ post {
 
 headers {
   X-Pillar2-Id: {{testPlrId}}
-  Authorization: validBearerToken
+  Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/99-qa/uktr/obligationMTT/Nil return - obligationMTT invalid.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/uktr/obligationMTT/Nil return - obligationMTT invalid.bru
@@ -12,7 +12,11 @@ post {
 
 headers {
   X-Pillar2-Id: {{testPlrId}}
-  Authorization: validBearerToken
+  Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/99-qa/uktr/totalLiability/total liability invalid decimals.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/uktr/totalLiability/total liability invalid decimals.bru
@@ -12,7 +12,11 @@ post {
 
 headers {
   X-Pillar2-Id: {{testPlrId}}
-  Authorization: validBearerToken
+  Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/99-qa/uktr/totalLiability/total liability invalid sum.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/uktr/totalLiability/total liability invalid sum.bru
@@ -12,7 +12,11 @@ post {
 
 headers {
   X-Pillar2-Id: {{testPlrId}}
-  Authorization: validBearerToken
+  Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/99-qa/uktr/totalLiability/total liability too high.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/uktr/totalLiability/total liability too high.bru
@@ -12,7 +12,11 @@ post {
 
 headers {
   X-Pillar2-Id: {{testPlrId}}
-  Authorization: validBearerToken
+  Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/99-qa/uktr/totalLiability/total liabilityDTT invalid decimals.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/uktr/totalLiability/total liabilityDTT invalid decimals.bru
@@ -12,7 +12,11 @@ post {
 
 headers {
   X-Pillar2-Id: {{testPlrId}}
-  Authorization: validBearerToken
+  Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/99-qa/uktr/totalLiability/total liabilityDTT too high.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/uktr/totalLiability/total liabilityDTT too high.bru
@@ -12,7 +12,11 @@ post {
 
 headers {
   X-Pillar2-Id: {{testPlrId}}
-  Authorization: validBearerToken
+  Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/99-qa/uktr/totalLiability/total liabilityIIR invalid decimals.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/uktr/totalLiability/total liabilityIIR invalid decimals.bru
@@ -12,7 +12,11 @@ post {
 
 headers {
   X-Pillar2-Id: {{testPlrId}}
-  Authorization: validBearerToken
+  Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/99-qa/uktr/totalLiability/total liabilityIIR too high.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/uktr/totalLiability/total liabilityIIR too high.bru
@@ -12,7 +12,11 @@ post {
 
 headers {
   X-Pillar2-Id: {{testPlrId}}
-  Authorization: validBearerToken
+  Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/99-qa/uktr/totalLiability/total liabilityUTPR invalid decimals.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/uktr/totalLiability/total liabilityUTPR invalid decimals.bru
@@ -12,7 +12,11 @@ post {
 
 headers {
   X-Pillar2-Id: {{testPlrId}}
-  Authorization: validBearerToken
+  Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {

--- a/API Testing/pillar2-external-test-stub/99-qa/uktr/totalLiability/total liabilityUTPR too high.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/uktr/totalLiability/total liabilityUTPR too high.bru
@@ -12,7 +12,11 @@ post {
 
 headers {
   X-Pillar2-Id: {{testPlrId}}
-  Authorization: validBearerToken
+  Authorization: valid bearerToken
+  X-Receipt-Date: 2025-05-01T19:50:48Z
+  correlationid: 6e6e8428-6682-482c-a691-ae16cf3df183
+  X-Originating-System: MDTP
+  X-Transmitting-System: HIP
 }
 
 body:json {


### PR DESCRIPTION
Refactor Bruno tests following the introduction of checks for 4 new HIP headers in the stateful stub.