### PR TITLE
PIL-1992: Add AP date range validation to Setup endpoints

### DIFF
--- a/conf/swagger.yml
+++ b/conf/swagger.yml
@@ -585,6 +585,8 @@ paths:
                   $ref: "#/components/examples/errors.InvalidJson"
                 Empty Body:
                   $ref: "#/components/examples/errors.EmptyBody"
+                Invalid Date Range:
+                  $ref: "#/components/examples/errors.InvalidDateRange"
         "401":
           description: Unauthorized
           content:
@@ -680,6 +682,8 @@ paths:
                   $ref: "#/components/examples/errors.InvalidJson"
                 Empty Body:
                   $ref: "#/components/examples/errors.EmptyBody"
+                Invalid Date Range:
+                  $ref: "#/components/examples/errors.InvalidDateRange"
         "401":
           description: Unauthorized
           content:

--- a/resources/public/api/conf/1.0/testOnly/application.yaml
+++ b/resources/public/api/conf/1.0/testOnly/application.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.123.0
+  version: 0.126.0
   title: Pillar 2 API
   description: An API for managing and retrieving data in accordance with Pillar 2 tax rules.
 tags: []
@@ -60,6 +60,8 @@ paths:
                   $ref: "#/components/examples/errors.InvalidJson"
                 Empty Body:
                   $ref: "#/components/examples/errors.EmptyBody"
+                Invalid Date Range:
+                  $ref: "#/components/examples/errors.InvalidDateRange"
         "401":
           description: Unauthorized
           content:
@@ -248,6 +250,8 @@ paths:
                   $ref: "#/components/examples/errors.InvalidJson"
                 Empty Body:
                   $ref: "#/components/examples/errors.EmptyBody"
+                Invalid Date Range:
+                  $ref: "#/components/examples/errors.InvalidDateRange"
         "401":
           description: Unauthorized
           content:

--- a/test/uk/gov/hmrc/pillar2submissionapi/controllers/TestOrganisationControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/controllers/TestOrganisationControllerSpec.scala
@@ -19,13 +19,13 @@ package uk.gov.hmrc.pillar2submissionapi.controllers
 import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.when
 import play.api.http.Status._
-import play.api.libs.json.{JsValue, Json}
+import play.api.libs.json.{JsObject, JsValue, Json}
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{contentAsJson, defaultAwaitTimeout, status}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2submissionapi.base.ControllerBaseSpec
 import uk.gov.hmrc.pillar2submissionapi.config.AppConfig
-import uk.gov.hmrc.pillar2submissionapi.controllers.error.{EmptyRequestBody, InvalidJson, TestEndpointDisabled}
+import uk.gov.hmrc.pillar2submissionapi.controllers.error._
 import uk.gov.hmrc.pillar2submissionapi.controllers.test.TestOrganisationController
 import uk.gov.hmrc.pillar2submissionapi.models.organisation._
 
@@ -65,6 +65,13 @@ class TestOrganisationControllerSpec extends ControllerBaseSpec {
 
           result shouldFailWith EmptyRequestBody
         }
+
+        "return InvalidDateRange for invalid accounting period" in {
+          val result =
+            controller().createTestOrganisation(FakeRequest().withHeaders("X-Pillar2-Id" -> pillar2Id).withJsonBody(invalidAccountingPeriodJson))
+
+          result shouldFailWith InvalidDateRange
+        }
       }
 
       "getTestOrganisation" must {
@@ -100,6 +107,13 @@ class TestOrganisationControllerSpec extends ControllerBaseSpec {
           val result = controller().updateTestOrganisation(FakeRequest().withHeaders("X-Pillar2-Id" -> pillar2Id))
 
           result shouldFailWith EmptyRequestBody
+        }
+
+        "return InvalidDateRange for invalid accounting period" in {
+          val result =
+            controller().updateTestOrganisation(FakeRequest().withHeaders("X-Pillar2-Id" -> pillar2Id).withJsonBody(invalidAccountingPeriodJson))
+
+          result shouldFailWith InvalidDateRange
         }
       }
 
@@ -165,6 +179,10 @@ class TestOrganisationControllerSpec extends ControllerBaseSpec {
       "endDate"   -> "2024-12-31"
     )
   )
+
+  val invalidAccountingPeriodJson: JsValue = validRequestJson
+    .as[JsObject]
+    .deepMerge(Json.obj("accountingPeriod" -> Json.obj("endDate" -> "2000-12-31")))
 
   val invalidRequestJson: JsValue = Json.obj(
     "invalidField" -> "invalidValue"


### PR DESCRIPTION
Returns the error `INVALID_DATE_RANGE` when `from` is not before `to`