### PR TITLE
PIL-1852 Fix_update orn not found message

### DIFF
--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/error/Pillar2Error.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/error/Pillar2Error.scala
@@ -110,5 +110,5 @@ case object TestEndpointDisabled extends Pillar2Error {
 
 case object ResourceNotFoundException extends Pillar2Error {
   override val code:    String = "RESOURCE_NOT_FOUND"
-  override val message: String = "The requested resource could not be found"
+  override val message: String = "Not Found"
 }

--- a/test/uk/gov/hmrc/pillar2submissionapi/services/OverseasReturnNotificationServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/services/OverseasReturnNotificationServiceSpec.scala
@@ -164,18 +164,18 @@ class OverseasReturnNotificationServiceSpec extends UnitTestBaseSpec with ORNDat
   }
 
   "retrieveORN() 404 response back" should {
-    "UnexpectedResponse thrown" in {
+    "ResourceNotFoundException thrown" in {
       when(mockOverseasReturnNotificationConnector.retrieveORN(any[String], any[String])(any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse.apply(404, Json.toJson("Not Found"), Map.empty)))
 
-      intercept[UnexpectedResponse.type](await(ornService.retrieveORN("2024-01-01", "2024-12-31")))
+      intercept[ResourceNotFoundException.type](await(ornService.retrieveORN("2024-01-01", "2024-12-31")))
     }
   }
 
   "retrieveORN() 422 response with No Form bundle found" should {
     "ResourceNotFoundException thrown" in {
       when(mockOverseasReturnNotificationConnector.retrieveORN(any[String], any[String])(any[HeaderCarrier]))
-        .thenReturn(Future.successful(HttpResponse.apply(422, Json.toJson(ORNErrorResponse("005", "No Form Bundle found")), Map.empty)))
+        .thenReturn(Future.successful(HttpResponse.apply(422, Json.toJson(ORNErrorResponse("005", "No Form bundle found")), Map.empty)))
 
       intercept[ResourceNotFoundException.type](await(ornService.retrieveORN("2024-01-01", "2024-12-31")))
     }


### PR DESCRIPTION
Updated the ResourceNotFoundException message from "The requested resource could not be found" to "Not Found" to exactly match the requirement in Scenario 4.
Modified the controller to use the ResourceNotFoundException's code and message values directly instead of hardcoding them.
Updated all tests to expect the new message format.