### PR TITLE
PIL-2057 - Update Obligations submissions array to be optional

### DIFF
--- a/app/uk/gov/hmrc/pillar2submissionapi/models/obligationsandsubmissions/ObligationsAndSubmissions.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/models/obligationsandsubmissions/ObligationsAndSubmissions.scala
@@ -41,7 +41,7 @@ object AccountingPeriodDetails {
   implicit val format: OFormat[AccountingPeriodDetails] = Json.format[AccountingPeriodDetails]
 }
 
-case class Obligation(obligationType: ObligationType, status: ObligationStatus, canAmend: Boolean, submissions: Seq[Submission])
+case class Obligation(obligationType: ObligationType, status: ObligationStatus, canAmend: Boolean, submissions: Option[Seq[Submission]])
 
 object Obligation {
   implicit val format: OFormat[Obligation] = Json.format[Obligation]

--- a/conf/swagger.yml
+++ b/conf/swagger.yml
@@ -1062,7 +1062,6 @@ components:
       - obligationType
       - status
       - canAmend
-      - submissions
     ObligationsAndSubmissionsSuccessResponse:
       properties:
         processingDate:

--- a/resources/public/api/conf/1.0/application.yaml
+++ b/resources/public/api/conf/1.0/application.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.142.0
+  version: 0.143.0
   title: Pillar 2 API
   description: An API for managing and retrieving data in accordance with Pillar 2 tax rules.
 tags: []
@@ -1567,6 +1567,7 @@ components:
           - ORN_CREATE
           - ORN_AMEND
           - BTN
+          - GIR
         receivedDate:
           type: string
           format: date-time

--- a/resources/public/api/conf/1.0/application.yaml
+++ b/resources/public/api/conf/1.0/application.yaml
@@ -1567,7 +1567,6 @@ components:
           - ORN_CREATE
           - ORN_AMEND
           - BTN
-          - GIR
         receivedDate:
           type: string
           format: date-time

--- a/resources/public/api/conf/1.0/application.yaml
+++ b/resources/public/api/conf/1.0/application.yaml
@@ -1621,7 +1621,6 @@ components:
       - obligationType
       - status
       - canAmend
-      - submissions
     ObligationsAndSubmissionsSuccessResponse:
       properties:
         processingDate:
@@ -1678,15 +1677,6 @@ components:
       summary: Success response
       value:
         processingDate: 2026-06-26T09:26:17Z
-    responses.CreateTestGlobeInformationReturnResponseExample:
-      summary: Success response
-      value:
-        processingDate: 2026-06-26T09:26:17Z
-    requests.CreateTestGlobeInformationReturnRequestExample:
-      summary: Request example
-      value:
-        accountingPeriodFrom: 2024-01-01
-        accountingPeriodTo: 2024-12-31
     requests.UKTRNilReturnMneAndUk:
       summary: Nil Return - MNE and UK
       value:

--- a/resources/public/api/conf/1.0/testOnly/application.yaml
+++ b/resources/public/api/conf/1.0/testOnly/application.yaml
@@ -1745,7 +1745,6 @@ components:
       - obligationType
       - status
       - canAmend
-      - submissions
     ObligationsAndSubmissionsSuccessResponse:
       properties:
         processingDate:

--- a/resources/public/api/conf/1.0/testOnly/application.yaml
+++ b/resources/public/api/conf/1.0/testOnly/application.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.142.0
+  version: 0.143.0
   title: Pillar 2 API
   description: An API for managing and retrieving data in accordance with Pillar 2 tax rules.
 tags: []

--- a/test/uk/gov/hmrc/pillar2submissionapi/helpers/ObligationsAndSubmissionsDataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/helpers/ObligationsAndSubmissionsDataFixture.scala
@@ -42,9 +42,9 @@ trait ObligationsAndSubmissionsDataFixture {
             UKTR,
             Fulfilled,
             canAmend = false,
-            Seq(Submission(BTN, ZonedDateTime.now(), None))
+            Some(Seq(Submission(BTN, ZonedDateTime.now(), None)))
           ),
-          Obligation(GIR, Open, canAmend = true, Seq.empty)
+          Obligation(GIR, Open, canAmend = true, None)
         )
       )
     )


### PR DESCRIPTION
This PR updates the `Obligation` model to make the `submissions` field optional, and updates the API definition to reflect this change.

There is also a small chnage to remove a GIR example from the openapi spec as it is not needed in ET yet.