### PR TITLE
PIL-2049: Add optional underEnquiry field to testOrg accounting periods

### DIFF
--- a/API Testing/pillar2-external-test-stub/01-setup/Update Organisation.bru
+++ b/API Testing/pillar2-external-test-stub/01-setup/Update Organisation.bru
@@ -19,8 +19,7 @@ body:json {
     },
     "accountingPeriod": {
       "startDate": "2024-01-01",
-      "endDate": "2024-12-31",
-      "dueDate": "2024-04-07"
+      "endDate": "2024-12-31"
     }
   }
 }

--- a/API Testing/pillar2-external-test-stub/99-qa/setup/update-organisation.bru
+++ b/API Testing/pillar2-external-test-stub/99-qa/setup/update-organisation.bru
@@ -23,8 +23,7 @@ body:json {
     },
     "accountingPeriod": {
       "startDate": "2024-01-01",
-      "endDate": "2024-12-31",
-      "dueDate": "2024-04-07"
+      "endDate": "2024-12-31"
     }
   }
 }

--- a/API Testing/pillar2-submission-api/02-setup/Update Organisation.bru
+++ b/API Testing/pillar2-submission-api/02-setup/Update Organisation.bru
@@ -24,8 +24,7 @@ body:json {
     },
     "accountingPeriod": {
       "startDate": "2024-01-01",
-      "endDate": "2024-12-31",
-      "dueDate": "2024-04-07"
+      "endDate": "2024-12-31"
     }
   }
 }

--- a/API Testing/pillar2-submission-api/99-qa/setup/update-organisation.bru
+++ b/API Testing/pillar2-submission-api/99-qa/setup/update-organisation.bru
@@ -24,8 +24,7 @@ body:json {
     },
     "accountingPeriod": {
       "startDate": "2024-01-01",
-      "endDate": "2024-12-31",
-      "dueDate": "2024-04-07"
+      "endDate": "2024-12-31"
     }
   }
 }

--- a/API Testing/pillar2/02-setup/Update Organisation.bru
+++ b/API Testing/pillar2/02-setup/Update Organisation.bru
@@ -19,8 +19,7 @@ body:json {
     },
     "accountingPeriod": {
       "startDate": "2024-01-01",
-      "endDate": "2024-12-31",
-      "dueDate": "2024-04-07"
+      "endDate": "2024-12-31"
     }
   }
 }

--- a/app/uk/gov/hmrc/pillar2submissionapi/models/organisation/TestOrganisation.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/models/organisation/TestOrganisation.scala
@@ -31,8 +31,9 @@ object OrgDetails {
 }
 
 case class AccountingPeriod(
-  startDate: LocalDate,
-  endDate:   LocalDate
+  startDate:    LocalDate,
+  endDate:      LocalDate,
+  underEnquiry: Option[Boolean]
 )
 
 object AccountingPeriod {

--- a/conf/swagger.yml
+++ b/conf/swagger.yml
@@ -283,6 +283,10 @@ paths:
         <td>063 - Business partner does not have an Active Subscription for this Regime</td>
         <td>The Pillar 2 ID in the request header is not listed as active by HMRC for this regime. Please contact the central support team.</td>
         </tr>
+        <tr>
+        <td>100 - Accounting period under enquiry</td>
+        <td>A BTN cannot be submitted for this particular accounting period as it is currently subject to an HMRC enquiry.</td>
+        </tr>
         </tbody>
         </table>
       requestBody:
@@ -339,6 +343,8 @@ paths:
                   $ref: "#/components/examples/errors.Submission.TaxObligationFulfilled"
                 No Active Subscription:
                   $ref: "#/components/examples/errors.Submission.NoActiveSubscription"
+                Accounting Period Under Enquiry:
+                  $ref: "#/components/examples/errors.Submission.AccountingPeriodUnderEnquiry"
         "401":
           description: Unauthorized
           content:
@@ -1433,6 +1439,11 @@ components:
       value:
         code: '098'
         message: Invalid Total Liability DTT
+    errors.Submission.AccountingPeriodUnderEnquiry:
+      summary: Accounting Period Under Enquiry
+      value:
+        code: '100'
+        message: Accounting period under enquiry
     errors.Submission.NoDataFound:
       summary: No data found
       value:

--- a/it/test/uk/gov/hmrc/pillar2submissionapi/TestOrganisationISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2submissionapi/TestOrganisationISpec.scala
@@ -254,7 +254,8 @@ class TestOrganisationISpec extends IntegrationSpecBase with OptionValues {
     ),
     accountingPeriod = AccountingPeriod(
       startDate = LocalDate.of(2024, 1, 1),
-      endDate = LocalDate.of(2024, 12, 31)
+      endDate = LocalDate.of(2024, 12, 31),
+      None
     ),
     lastUpdated = Instant.parse("2024-01-01T12:00:00Z")
   )

--- a/resources/public/api/conf/1.0/application.yaml
+++ b/resources/public/api/conf/1.0/application.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.150.0
+  version: 0.151.0
   title: Pillar 2 API
   description: An API for managing and retrieving data in accordance with Pillar 2 tax rules.
 tags: []
@@ -881,6 +881,8 @@ paths:
                   $ref: "#/components/examples/errors.Submission.TaxObligationFulfilled"
                 No Active Subscription:
                   $ref: "#/components/examples/errors.Submission.NoActiveSubscription"
+                Accounting Period Under Enquiry:
+                  $ref: "#/components/examples/errors.Submission.AccountingPeriodUnderEnquiry"
         "403":
           description: Forbidden
           content:
@@ -937,6 +939,10 @@ paths:
         <tr>
         <td>063 - Business partner does not have an Active Subscription for this Regime</td>
         <td>The Pillar 2 ID in the request header is not listed as active by HMRC for this regime. Please contact the central support team.</td>
+        </tr>
+        <tr>
+        <td>100 - Accounting period under enquiry</td>
+        <td>A BTN cannot be submitted for this particular accounting period as it is currently subject to an HMRC enquiry.</td>
         </tr>
         </tbody>
         </table>
@@ -2101,6 +2107,11 @@ components:
       value:
         code: '098'
         message: Invalid Total Liability DTT
+    errors.Submission.AccountingPeriodUnderEnquiry:
+      summary: Accounting Period Under Enquiry
+      value:
+        code: 100
+        message: Accounting period under enquiry
     errors.Submission.NoDataFound:
       summary: No data found
       value:

--- a/resources/public/api/conf/1.0/application.yaml
+++ b/resources/public/api/conf/1.0/application.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.145.0
+  version: 0.150.0
   title: Pillar 2 API
   description: An API for managing and retrieving data in accordance with Pillar 2 tax rules.
 tags: []
@@ -1651,6 +1651,9 @@ components:
         endDate:
           type: string
           format: date
+        underEnquiry:
+          type: boolean
+          nullable: true
       required:
       - startDate
       - endDate

--- a/resources/public/api/conf/1.0/testOnly/application.yaml
+++ b/resources/public/api/conf/1.0/testOnly/application.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.150.0
+  version: 0.151.0
   title: Pillar 2 API
   description: An API for managing and retrieving data in accordance with Pillar 2 tax rules.
 tags: []
@@ -881,6 +881,8 @@ paths:
                   $ref: "#/components/examples/errors.Submission.TaxObligationFulfilled"
                 No Active Subscription:
                   $ref: "#/components/examples/errors.Submission.NoActiveSubscription"
+                Accounting Period Under Enquiry:
+                  $ref: "#/components/examples/errors.Submission.AccountingPeriodUnderEnquiry"
         "403":
           description: Forbidden
           content:
@@ -937,6 +939,10 @@ paths:
         <tr>
         <td>063 - Business partner does not have an Active Subscription for this Regime</td>
         <td>The Pillar 2 ID in the request header is not listed as active by HMRC for this regime. Please contact the central support team.</td>
+        </tr>
+        <tr>
+        <td>100 - Accounting period under enquiry</td>
+        <td>A BTN cannot be submitted for this particular accounting period as it is currently subject to an HMRC enquiry.</td>
         </tr>
         </tbody>
         </table>
@@ -2101,6 +2107,11 @@ components:
       value:
         code: '098'
         message: Invalid Total Liability DTT
+    errors.Submission.AccountingPeriodUnderEnquiry:
+      summary: Accounting Period Under Enquiry
+      value:
+        code: 100
+        message: Accounting period under enquiry
     errors.Submission.NoDataFound:
       summary: No data found
       value:

--- a/resources/public/api/conf/1.0/testOnly/application.yaml
+++ b/resources/public/api/conf/1.0/testOnly/application.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.145.0
+  version: 0.150.0
   title: Pillar 2 API
   description: An API for managing and retrieving data in accordance with Pillar 2 tax rules.
 tags: []
@@ -1651,6 +1651,9 @@ components:
         endDate:
           type: string
           format: date
+        underEnquiry:
+          type: boolean
+          nullable: true
       required:
       - startDate
       - endDate

--- a/test/uk/gov/hmrc/pillar2submissionapi/connectors/TestOrganisationConnectorSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/connectors/TestOrganisationConnectorSpec.scala
@@ -207,7 +207,8 @@ class TestOrganisationConnectorSpec extends UnitTestBaseSpec {
     ),
     accountingPeriod = AccountingPeriod(
       startDate = LocalDate.of(2024, 1, 1),
-      endDate = LocalDate.of(2024, 12, 31)
+      endDate = LocalDate.of(2024, 12, 31),
+      None
     ),
     lastUpdated = Instant.parse("2024-01-01T12:00:00Z")
   )

--- a/test/uk/gov/hmrc/pillar2submissionapi/controllers/TestOrganisationControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/controllers/TestOrganisationControllerSpec.scala
@@ -214,7 +214,8 @@ class TestOrganisationControllerSpec extends ControllerBaseSpec {
       ),
       accountingPeriod = AccountingPeriod(
         startDate = LocalDate.of(2024, 1, 1),
-        endDate = LocalDate.of(2024, 12, 31)
+        endDate = LocalDate.of(2024, 12, 31),
+        None
       ),
       lastUpdated = Instant.parse("2024-01-01T12:00:00Z")
     )

--- a/test/uk/gov/hmrc/pillar2submissionapi/services/TestOrganisationServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/services/TestOrganisationServiceSpec.scala
@@ -84,7 +84,8 @@ class TestOrganisationServiceSpec extends UnitTestBaseSpec {
     ),
     accountingPeriod = AccountingPeriod(
       startDate = LocalDate.of(2024, 1, 1),
-      endDate = LocalDate.of(2024, 12, 31)
+      endDate = LocalDate.of(2024, 12, 31),
+      None
     )
   )
 


### PR DESCRIPTION
To better match downstream and be used in validation later

To create a test organisation with an accounting period under enquiry:
```{
  "orgDetails": {
    "domesticOnly": false,
    "organisationName": "Test Organisation Ltd",
    "registrationDate": "2024-01-01"
  },
  "accountingPeriod": {
    "startDate": "2024-01-01",
    "endDate": "2024-12-31",
    "underEnquiry": true
  }
}