### PR TITLE
[PIL-2469] - change electionUKGAAP to an optional field and update API Spec

### DIFF
--- a/app/uk/gov/hmrc/pillar2submissionapi/models/uktrsubmissions/UKTRSubmission.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/models/uktrsubmissions/UKTRSubmission.scala
@@ -24,7 +24,7 @@ sealed trait UKTRSubmission {
   val accountingPeriodFrom: LocalDate
   val accountingPeriodTo:   LocalDate
   val obligationMTT:        Boolean
-  val electionUKGAAP:       Boolean
+  val electionUKGAAP:       Option[Boolean]
   val liabilities:          Liability
 }
 
@@ -32,7 +32,7 @@ case class UKTRSubmissionData(
   accountingPeriodFrom: LocalDate,
   accountingPeriodTo:   LocalDate,
   obligationMTT:        Boolean,
-  electionUKGAAP:       Boolean,
+  electionUKGAAP:       Option[Boolean],
   liabilities:          LiabilityData
 ) extends UKTRSubmission
 
@@ -44,7 +44,7 @@ case class UKTRSubmissionNilReturn(
   accountingPeriodFrom: LocalDate,
   accountingPeriodTo:   LocalDate,
   obligationMTT:        Boolean,
-  electionUKGAAP:       Boolean,
+  electionUKGAAP:       Option[Boolean],
   liabilities:          LiabilityNilReturn
 ) extends UKTRSubmission
 

--- a/it/test/uk/gov/hmrc/pillar2submissionapi/controllers/platform/DocumentationControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2submissionapi/controllers/platform/DocumentationControllerISpec.scala
@@ -56,7 +56,7 @@ class DocumentationControllerISpec extends IntegrationSpecBase {
 
     "return API documentation" when {
       "testOnlyOasEnabled is false" in {
-        val url            = s"$baseUrl${routes.DocumentationController.specification("1.0", "public/api/conf/1.0/application.yaml").url}"
+        val url            = s"$baseUrl${routes.DocumentationController.specification("1.0", "application.yaml").url}"
         val apiDoc         = Await.result(client.get(URI.create(url).toURL).execute[HttpResponse], 5.seconds)
         val apiDocStr      = apiDoc.body
         val expectedAPIDoc = Source.fromResource("public/api/conf/1.0/application.yaml").mkString
@@ -70,7 +70,7 @@ class DocumentationControllerISpec extends IntegrationSpecBase {
           .configure("features.testOnlyOasEnabled" -> true)
           .build()
 
-        val request = FakeRequest(GET, routes.DocumentationController.specification("1.0", "public/api/conf/1.0/application.yaml").url)
+        val request = FakeRequest(GET, routes.DocumentationController.specification("1.0", "application.yaml").url)
         val result  = route(app, request).get
 
         val apiDocStr      = contentAsString(result)

--- a/it/test/uk/gov/hmrc/pillar2submissionapi/controllers/platform/DocumentationControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2submissionapi/controllers/platform/DocumentationControllerISpec.scala
@@ -56,7 +56,7 @@ class DocumentationControllerISpec extends IntegrationSpecBase {
 
     "return API documentation" when {
       "testOnlyOasEnabled is false" in {
-        val url            = s"$baseUrl${routes.DocumentationController.specification("1.0", "application.yaml").url}"
+        val url            = s"$baseUrl${routes.DocumentationController.specification("1.0", "public/api/conf/1.0/application.yaml").url}"
         val apiDoc         = Await.result(client.get(URI.create(url).toURL).execute[HttpResponse], 5.seconds)
         val apiDocStr      = apiDoc.body
         val expectedAPIDoc = Source.fromResource("public/api/conf/1.0/application.yaml").mkString
@@ -70,7 +70,7 @@ class DocumentationControllerISpec extends IntegrationSpecBase {
           .configure("features.testOnlyOasEnabled" -> true)
           .build()
 
-        val request = FakeRequest(GET, routes.DocumentationController.specification("1.0", "application.yaml").url)
+        val request = FakeRequest(GET, routes.DocumentationController.specification("1.0", "public/api/conf/1.0/application.yaml").url)
         val result  = route(app, request).get
 
         val apiDocStr      = contentAsString(result)

--- a/resources/public/api/conf/1.0/application.yaml
+++ b/resources/public/api/conf/1.0/application.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.157.0
+  version: 0.151.0
   title: Pillar 2 API
   description: An API for managing and retrieving data in accordance with Pillar 2 tax rules.
 tags: []

--- a/resources/public/api/conf/1.0/application.yaml
+++ b/resources/public/api/conf/1.0/application.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.145.0
+  version: 0.150.0
   title: Pillar 2 API
   description: An API for managing and retrieving data in accordance with Pillar 2 tax rules.
 tags: []
@@ -1504,13 +1504,13 @@ components:
           type: boolean
         electionUKGAAP:
           type: boolean
+          nullable: true
         liabilities:
           $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.LiabilityNilReturn"
       required:
       - accountingPeriodFrom
       - accountingPeriodTo
       - obligationMTT
-      - electionUKGAAP
       - liabilities
     uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.LiableEntity:
       properties:
@@ -1600,13 +1600,13 @@ components:
           type: boolean
         electionUKGAAP:
           type: boolean
+          nullable: true
         liabilities:
           $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.LiabilityData"
       required:
       - accountingPeriodFrom
       - accountingPeriodTo
       - obligationMTT
-      - electionUKGAAP
       - liabilities
     uk.gov.hmrc.pillar2submissionapi.models.globeinformationreturn.GIRSuccess:
       properties:

--- a/resources/public/api/conf/1.0/application.yaml
+++ b/resources/public/api/conf/1.0/application.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.151.0
+  version: 0.157.0
   title: Pillar 2 API
   description: An API for managing and retrieving data in accordance with Pillar 2 tax rules.
 tags: []

--- a/resources/public/api/conf/1.0/testOnly/application.yaml
+++ b/resources/public/api/conf/1.0/testOnly/application.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.157.0
+  version: 0.151.0
   title: Pillar 2 API
   description: An API for managing and retrieving data in accordance with Pillar 2 tax rules.
 tags: []

--- a/resources/public/api/conf/1.0/testOnly/application.yaml
+++ b/resources/public/api/conf/1.0/testOnly/application.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.145.0
+  version: 0.150.0
   title: Pillar 2 API
   description: An API for managing and retrieving data in accordance with Pillar 2 tax rules.
 tags: []
@@ -1504,13 +1504,13 @@ components:
           type: boolean
         electionUKGAAP:
           type: boolean
+          nullable: true
         liabilities:
           $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.LiabilityNilReturn"
       required:
       - accountingPeriodFrom
       - accountingPeriodTo
       - obligationMTT
-      - electionUKGAAP
       - liabilities
     uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.LiableEntity:
       properties:
@@ -1600,13 +1600,13 @@ components:
           type: boolean
         electionUKGAAP:
           type: boolean
+          nullable: true
         liabilities:
           $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.LiabilityData"
       required:
       - accountingPeriodFrom
       - accountingPeriodTo
       - obligationMTT
-      - electionUKGAAP
       - liabilities
     uk.gov.hmrc.pillar2submissionapi.models.globeinformationreturn.GIRSuccess:
       properties:

--- a/resources/public/api/conf/1.0/testOnly/application.yaml
+++ b/resources/public/api/conf/1.0/testOnly/application.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.151.0
+  version: 0.157.0
   title: Pillar 2 API
   description: An API for managing and retrieving data in accordance with Pillar 2 tax rules.
 tags: []

--- a/test/uk/gov/hmrc/pillar2submissionapi/helpers/UKTaxReturnDataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/helpers/UKTaxReturnDataFixture.scala
@@ -18,17 +18,11 @@ package uk.gov.hmrc.pillar2submissionapi.helpers
 
 import cats.data.NonEmptyList
 import play.api.libs.json.{JsObject, JsValue, Json}
-import uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.EntityName
-import uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.IdType
-import uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.IdValue
-import uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.LiableEntities
-import uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.Monetary
 import uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.ReturnType.NIL_RETURN
 import uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions._
 import uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.responses.UKTRSubmitSuccessResponse
 
 import java.time.{LocalDate, ZoneId, ZonedDateTime}
-import scala.math.BigDecimal
 
 trait UKTaxReturnDataFixture {
 
@@ -61,13 +55,13 @@ trait UKTaxReturnDataFixture {
       LiableEntities(NonEmptyList.of(liableEntity))
     )
   val validNilSubmission: UKTRSubmissionData =
-    UKTRSubmissionData(LocalDate.parse("2024-08-14"), LocalDate.parse("2024-12-14"), obligationMTT = true, electionUKGAAP = true, liabilityData)
+    UKTRSubmissionData(LocalDate.parse("2024-08-14"), LocalDate.parse("2024-12-14"), obligationMTT = true, electionUKGAAP = Some(true), liabilityData)
   val validLiabilitySubmission: UKTRSubmissionNilReturn =
     UKTRSubmissionNilReturn(
       LocalDate.parse("2024-08-14"),
       LocalDate.parse("2024-12-14"),
       obligationMTT = true,
-      electionUKGAAP = true,
+      electionUKGAAP = Some(true),
       liabilityNilReturn
     )
 


### PR DESCRIPTION
ETMP does not require the UKGAAP field to be present at all so this change is aligning our database to match their current functionality