### PR TITLE
NOJIRA enforce scala3 syntax

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -3,6 +3,7 @@ rules = [ExplicitResultTypes, OrganizeImports, RemoveUnused,DisableSyntax]
 OrganizeImports {
   groupedImports = Keep
   coalesceToWildcardImportThreshold = 3
+  targetDialect = Scala3
 }
 
 DisableSyntax {

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -4,6 +4,7 @@ style = defaultWithAlign
 maxColumn = 150
 lineEndings = unix
 importSelectors = singleLine
+rewrite.scala3.convertToNewSyntax = true
 
 project {
   git = true

--- a/app/uk/gov/hmrc/pillar2submissionapi/config/Module.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/config/Module.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.pillar2submissionapi.config
 
 import com.google.inject.AbstractModule
 import uk.gov.hmrc.auth.core.AuthConnector
-import uk.gov.hmrc.pillar2submissionapi.controllers.actions._
+import uk.gov.hmrc.pillar2submissionapi.controllers.actions.*
 import uk.gov.hmrc.play.bootstrap.auth.DefaultAuthConnector
 
 class Module extends AbstractModule {

--- a/app/uk/gov/hmrc/pillar2submissionapi/connectors/GIRConnector.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/connectors/GIRConnector.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.pillar2submissionapi.connectors
 import play.api.Logging
 import play.api.libs.json.Json
 import play.api.libs.ws.JsonBodyWritables.writeableOf_JsValue
-import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.http.HttpReads.Implicits.*
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2submissionapi.config.AppConfig

--- a/app/uk/gov/hmrc/pillar2submissionapi/connectors/ObligationAndSubmissionsConnector.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/connectors/ObligationAndSubmissionsConnector.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.pillar2submissionapi.connectors
 
 import play.api.Logging
-import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.http.HttpReads.Implicits.*
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
 import uk.gov.hmrc.pillar2submissionapi.config.AppConfig

--- a/app/uk/gov/hmrc/pillar2submissionapi/connectors/OverseasReturnNotificationConnector.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/connectors/OverseasReturnNotificationConnector.scala
@@ -20,7 +20,7 @@ import play.api.Logging
 import play.api.libs.json.Format.GenericFormat
 import play.api.libs.json.Json
 import play.api.libs.ws.JsonBodyWritables.writeableOf_JsValue
-import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.http.HttpReads.Implicits.*
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2submissionapi.config.AppConfig

--- a/app/uk/gov/hmrc/pillar2submissionapi/connectors/SubmitBTNConnector.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/connectors/SubmitBTNConnector.scala
@@ -20,7 +20,7 @@ import play.api.Logging
 import play.api.libs.json.Format.GenericFormat
 import play.api.libs.json.Json
 import play.api.libs.ws.JsonBodyWritables.writeableOf_JsValue
-import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.http.HttpReads.Implicits.*
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2submissionapi.config.AppConfig

--- a/app/uk/gov/hmrc/pillar2submissionapi/connectors/SubscriptionConnector.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/connectors/SubscriptionConnector.scala
@@ -20,8 +20,8 @@ import play.api.Logging
 import play.api.libs.json.Json
 import play.api.mvc.Result
 import play.api.mvc.Results.BadRequest
-import uk.gov.hmrc.http.HttpReads.Implicits._
-import uk.gov.hmrc.http._
+import uk.gov.hmrc.http.HttpReads.Implicits.*
+import uk.gov.hmrc.http.*
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.pillar2submissionapi.config.AppConfig
 import uk.gov.hmrc.pillar2submissionapi.models.subscription.{SubscriptionData, SubscriptionSuccess}

--- a/app/uk/gov/hmrc/pillar2submissionapi/connectors/SubscriptionConnector.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/connectors/SubscriptionConnector.scala
@@ -20,8 +20,8 @@ import play.api.Logging
 import play.api.libs.json.Json
 import play.api.mvc.Result
 import play.api.mvc.Results.BadRequest
-import uk.gov.hmrc.http.HttpReads.Implicits.*
 import uk.gov.hmrc.http.*
+import uk.gov.hmrc.http.HttpReads.Implicits.*
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.pillar2submissionapi.config.AppConfig
 import uk.gov.hmrc.pillar2submissionapi.models.subscription.{SubscriptionData, SubscriptionSuccess}

--- a/app/uk/gov/hmrc/pillar2submissionapi/connectors/TestOrganisationConnector.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/connectors/TestOrganisationConnector.scala
@@ -19,11 +19,11 @@ package uk.gov.hmrc.pillar2submissionapi.connectors
 import play.api.Logging
 import play.api.libs.json.Json
 import play.api.libs.ws.JsonBodyWritables.writeableOf_JsValue
-import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.http.HttpReads.Implicits.*
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2submissionapi.config.AppConfig
-import uk.gov.hmrc.pillar2submissionapi.controllers.error._
+import uk.gov.hmrc.pillar2submissionapi.controllers.error.*
 import uk.gov.hmrc.pillar2submissionapi.models.organisation.{TestOrganisation, TestOrganisationWithId}
 
 import java.net.URI

--- a/app/uk/gov/hmrc/pillar2submissionapi/connectors/UKTaxReturnConnector.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/connectors/UKTaxReturnConnector.scala
@@ -20,7 +20,7 @@ import play.api.Logging
 import play.api.libs.json.Format.GenericFormat
 import play.api.libs.json.Json
 import play.api.libs.ws.JsonBodyWritables.writeableOf_JsValue
-import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.http.HttpReads.Implicits.*
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2submissionapi.config.AppConfig

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandler.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandler.scala
@@ -21,7 +21,7 @@ import play.api.http.HttpErrorHandler
 import play.api.libs.json.Json
 import play.api.mvc.Results.Status
 import play.api.mvc.{RequestHeader, Result, Results}
-import uk.gov.hmrc.pillar2submissionapi.controllers.error._
+import uk.gov.hmrc.pillar2submissionapi.controllers.error.*
 import uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse
 
 import scala.concurrent.Future

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/actions/AuthenticatedIdentifierAction.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/actions/AuthenticatedIdentifierAction.scala
@@ -18,9 +18,9 @@ package uk.gov.hmrc.pillar2submissionapi.controllers.actions
 
 import com.google.inject.{Inject, Singleton}
 import play.api.Logging
+import uk.gov.hmrc.auth.core.*
 import uk.gov.hmrc.auth.core.AffinityGroup.{Agent, Organisation}
 import uk.gov.hmrc.auth.core.AuthProvider.GovernmentGateway
-import uk.gov.hmrc.auth.core.*
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
 import uk.gov.hmrc.auth.core.retrieve.~
 import uk.gov.hmrc.http.{HeaderCarrier, HeaderNames}

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/actions/AuthenticatedIdentifierAction.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/actions/AuthenticatedIdentifierAction.scala
@@ -20,12 +20,12 @@ import com.google.inject.{Inject, Singleton}
 import play.api.Logging
 import uk.gov.hmrc.auth.core.AffinityGroup.{Agent, Organisation}
 import uk.gov.hmrc.auth.core.AuthProvider.GovernmentGateway
-import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.auth.core.*
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
 import uk.gov.hmrc.auth.core.retrieve.~
 import uk.gov.hmrc.http.{HeaderCarrier, HeaderNames}
 import uk.gov.hmrc.pillar2submissionapi.config.AppConfig
-import uk.gov.hmrc.pillar2submissionapi.controllers.error._
+import uk.gov.hmrc.pillar2submissionapi.controllers.error.*
 import uk.gov.hmrc.pillar2submissionapi.models.requests.IdentifierRequest
 import uk.gov.hmrc.play.http.HeaderCarrierConverter
 
@@ -40,7 +40,7 @@ class AuthenticatedIdentifierAction @Inject() (
     with AuthorisedFunctions
     with Logging {
 
-  import AuthenticatedIdentifierAction._
+  import AuthenticatedIdentifierAction.*
   private def getPillar2Id(enrolments: Enrolments): Option[String] =
     for {
       pillar2Enrolment <- enrolments.getEnrolment(HMRC_PILLAR2_ORG_KEY)
@@ -57,7 +57,7 @@ class AuthenticatedIdentifierAction @Inject() (
     enrolments
   ) match {
     case Some(pillar2Id) =>
-      if (request.pillar2Id != pillar2Id) throw IncorrectHeaderValue
+      if request.pillar2Id != pillar2Id then throw IncorrectHeaderValue
       else
         Future.successful(
           IdentifierRequest(
@@ -75,7 +75,7 @@ class AuthenticatedIdentifierAction @Inject() (
 
   override protected def transform[A](request: RequestWithPillar2Id[A]): Future[IdentifierRequest[A]] = {
     given hc: HeaderCarrier = HeaderCarrierConverter.fromRequest(request)
-    if (!request.headers.get(HeaderNames.authorisation).exists(_.trim.nonEmpty)) throw MissingCredentials
+    if !request.headers.get(HeaderNames.authorisation).exists(_.trim.nonEmpty) then throw MissingCredentials
     else {
       val retrievals = Retrievals.internalId and Retrievals.groupIdentifier and
         Retrievals.allEnrolments and Retrievals.affinityGroup and

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/actions/IdentifierAction.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/actions/IdentifierAction.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.pillar2submissionapi.controllers.actions
 
-import play.api.mvc._
+import play.api.mvc.*
 import uk.gov.hmrc.pillar2submissionapi.models.requests.IdentifierRequest
 
 trait IdentifierAction extends ActionTransformer[RequestWithPillar2Id, IdentifierRequest]

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/actions/Pillar2IdHeaderAction.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/actions/Pillar2IdHeaderAction.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.pillar2submissionapi.controllers.actions
 
-import play.api.mvc._
+import play.api.mvc.*
 
 trait Pillar2IdHeaderAction
     extends ActionTransformer[Request, RequestWithPillar2Id]

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/obligationsandsubmissions/ObligationsAndSubmissionsController.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/obligationsandsubmissions/ObligationsAndSubmissionsController.scala
@@ -44,7 +44,7 @@ class ObligationsAndSubmissionsController @Inject() (
     Try {
       val accountingPeriod = ObligationsAndSubmissions(fromDate = LocalDate.parse(fromDate), toDate = LocalDate.parse(toDate))
 
-      if (accountingPeriod.validDateRange) {
+      if accountingPeriod.validDateRange then {
         obligationAndSubmissionsService
           .handleData(accountingPeriod.fromDate, accountingPeriod.toDate)
           .map(response => Ok(Json.toJson(response)))

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/platform/DocumentationController.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/platform/DocumentationController.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.pillar2submissionapi.controllers.platform
 
 import controllers.Assets
-import play.api.libs.json._
+import play.api.libs.json.*
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import uk.gov.hmrc.pillar2submissionapi.config.AppConfig
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
@@ -44,7 +44,7 @@ class DocumentationController @Inject() (assets: Assets, cc: ControllerComponent
   }
 
   def specification(version: String, file: String): Action[AnyContent] =
-    if (appConfig.testOnlyOasEnabled) {
+    if appConfig.testOnlyOasEnabled then {
       assets.at(s"/public/api/conf/$version/testOnly", file)
     } else assets.at(s"/public/api/conf/$version", file)
 }

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/submission/OverseasReturnNotificationController.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/submission/OverseasReturnNotificationController.scala
@@ -20,7 +20,7 @@ import play.api.libs.json.{JsError, JsSuccess, Json}
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2submissionapi.controllers.actions.{IdentifierAction, Pillar2IdHeaderAction, SubscriptionDataRetrievalAction}
-import uk.gov.hmrc.pillar2submissionapi.controllers.error._
+import uk.gov.hmrc.pillar2submissionapi.controllers.error.*
 import uk.gov.hmrc.pillar2submissionapi.models.obligationsandsubmissions.ObligationsAndSubmissions
 import uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification.ORNSubmission
 import uk.gov.hmrc.pillar2submissionapi.services.OverseasReturnNotificationService
@@ -79,7 +79,7 @@ class OverseasReturnNotificationController @Inject() (
       Try {
         val accountingPeriod =
           ObligationsAndSubmissions(fromDate = LocalDate.parse(accountingPeriodFrom), toDate = LocalDate.parse(accountingPeriodTo))
-        if (accountingPeriod.validDateRange) {
+        if accountingPeriod.validDateRange then {
           ornService
             .retrieveORN(accountingPeriodFrom, accountingPeriodTo)(using hc)
             .map(response => Ok(Json.toJson(response)))

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/submission/UKTaxReturnController.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/submission/UKTaxReturnController.scala
@@ -22,8 +22,8 @@ import play.api.libs.json.{JsError, JsSuccess, Json}
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2submissionapi.controllers.actions.{IdentifierAction, Pillar2IdHeaderExistsAction, SubscriptionDataRetrievalAction}
-import uk.gov.hmrc.pillar2submissionapi.controllers.error._
-import uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions._
+import uk.gov.hmrc.pillar2submissionapi.controllers.error.*
+import uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.*
 import uk.gov.hmrc.pillar2submissionapi.services.UKTaxReturnService
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import uk.gov.hmrc.play.http.HeaderCarrierConverter

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/test/GIRController.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/test/GIRController.scala
@@ -41,7 +41,7 @@ class GIRController @Inject() (
     extends BackendController(cc) {
 
   private def checkTestEndpointsEnabled[A](block: => Future[A]): Future[A] =
-    if (config.testOrganisationEnabled) block else Future.failed(TestEndpointDisabled)
+    if config.testOrganisationEnabled then block else Future.failed(TestEndpointDisabled)
 
   def createGIR: Action[AnyContent] = (pillar2IdAction andThen identify).async { request =>
     given hc: HeaderCarrier = HeaderCarrierConverter.fromRequest(request).withExtraHeaders("X-Pillar2-Id" -> request.clientPillar2Id)

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/test/TestOrganisationController.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/test/TestOrganisationController.scala
@@ -21,7 +21,7 @@ import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2submissionapi.config.AppConfig
 import uk.gov.hmrc.pillar2submissionapi.controllers.actions.{IdentifierAction, Pillar2IdHeaderExistsAction}
-import uk.gov.hmrc.pillar2submissionapi.controllers.error._
+import uk.gov.hmrc.pillar2submissionapi.controllers.error.*
 import uk.gov.hmrc.pillar2submissionapi.models.organisation.TestOrganisationRequest
 import uk.gov.hmrc.pillar2submissionapi.services.TestOrganisationService
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
@@ -41,7 +41,7 @@ class TestOrganisationController @Inject() (
     extends BackendController(cc) {
 
   private def checkTestEndpointsEnabled[A](block: => Future[A]): Future[A] =
-    if (config.testOrganisationEnabled) block else Future.failed(TestEndpointDisabled)
+    if config.testOrganisationEnabled then block else Future.failed(TestEndpointDisabled)
 
   def createTestOrganisation: Action[AnyContent] = (pillar2IdAction andThen identify).async { request =>
     given HeaderCarrier = HeaderCarrierConverter.fromRequest(request)
@@ -50,7 +50,7 @@ class TestOrganisationController @Inject() (
         case Some(json) =>
           json.validate[TestOrganisationRequest] match {
             case JsSuccess(value, _) =>
-              if (!value.accountingPeriod.endDate.isAfter(value.accountingPeriod.startDate)) Future.failed(InvalidDateRange)
+              if !value.accountingPeriod.endDate.isAfter(value.accountingPeriod.startDate) then Future.failed(InvalidDateRange)
               else
                 testOrganisationService
                   .createTestOrganisation(request.clientPillar2Id, value)
@@ -79,7 +79,7 @@ class TestOrganisationController @Inject() (
         case Some(json) =>
           json.validate[TestOrganisationRequest] match {
             case JsSuccess(value, _) =>
-              if (!value.accountingPeriod.endDate.isAfter(value.accountingPeriod.startDate)) Future.failed(InvalidDateRange)
+              if !value.accountingPeriod.endDate.isAfter(value.accountingPeriod.startDate) then Future.failed(InvalidDateRange)
               else
                 testOrganisationService
                   .updateTestOrganisation(request.clientPillar2Id, value)

--- a/app/uk/gov/hmrc/pillar2submissionapi/models/WrappedValue.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/models/WrappedValue.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.pillar2submissionapi.models
 
-import play.api.libs.json._
+import play.api.libs.json.*
 
 trait WrappedValue[T] {
   def value: T

--- a/app/uk/gov/hmrc/pillar2submissionapi/models/overseasreturnnotification/ORNSubmission.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/models/overseasreturnnotification/ORNSubmission.scala
@@ -16,8 +16,8 @@
 
 package uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification
 
-import play.api.libs.functional.syntax._
-import play.api.libs.json._
+import play.api.libs.functional.syntax.*
+import play.api.libs.json.*
 
 import java.time.LocalDate
 

--- a/app/uk/gov/hmrc/pillar2submissionapi/models/overseasreturnnotification/ORNSuccessResponse.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/models/overseasreturnnotification/ORNSuccessResponse.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification
 
-import play.api.libs.json._
+import play.api.libs.json.*
 
 case class ORNRetrieveSuccessResponse(
   processingDate:       String,
@@ -36,7 +36,7 @@ object ORNRetrieveSuccessResponse {
   given reads: Reads[ORNRetrieveSuccessResponse] = (json: JsValue) => {
     val standardReads = Json.reads[ORNRetrieveSuccessResponse]
     standardReads.reads(json) match {
-      case success: JsSuccess[_] => success.asInstanceOf[JsSuccess[ORNRetrieveSuccessResponse]]
+      case success: JsSuccess[?] => success.asInstanceOf[JsSuccess[ORNRetrieveSuccessResponse]]
       case _ =>
         (json \ "success").validate[ORNRetrieveSuccessResponse](using standardReads)
     }
@@ -51,7 +51,7 @@ object ORNSuccessResponse {
   given reads: Reads[ORNSuccessResponse] = (json: JsValue) => {
     val standardReads = Json.reads[ORNSuccessResponse]
     standardReads.reads(json) match {
-      case success: JsSuccess[_] => success.asInstanceOf[JsSuccess[ORNSuccessResponse]]
+      case success: JsSuccess[?] => success.asInstanceOf[JsSuccess[ORNSuccessResponse]]
       case _ =>
         (json \ "success").validate[ORNSuccessResponse](using standardReads)
     }

--- a/app/uk/gov/hmrc/pillar2submissionapi/models/subscription/UpeDetails.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/models/subscription/UpeDetails.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.pillar2submissionapi.models.subscription
 
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import java.time.LocalDate
 

--- a/app/uk/gov/hmrc/pillar2submissionapi/models/uktrsubmissions/EntityName.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/models/uktrsubmissions/EntityName.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions
 
-import play.api.libs.json._
+import play.api.libs.json.*
 import uk.gov.hmrc.pillar2submissionapi.models.WrappedValue
 
 case class EntityName(value: String) extends WrappedValue[String]

--- a/app/uk/gov/hmrc/pillar2submissionapi/models/uktrsubmissions/IdType.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/models/uktrsubmissions/IdType.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions
 
-import play.api.libs.json._
+import play.api.libs.json.*
 import uk.gov.hmrc.pillar2submissionapi.models.WrappedValue
 
 case class IdType(value: String) extends WrappedValue[String]

--- a/app/uk/gov/hmrc/pillar2submissionapi/models/uktrsubmissions/IdValue.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/models/uktrsubmissions/IdValue.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions
 
-import play.api.libs.json._
+import play.api.libs.json.*
 import uk.gov.hmrc.pillar2submissionapi.models.WrappedValue
 
 case class IdValue(value: String) extends WrappedValue[String]

--- a/app/uk/gov/hmrc/pillar2submissionapi/models/uktrsubmissions/Monetary.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/models/uktrsubmissions/Monetary.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions
 
-import play.api.libs.json._
+import play.api.libs.json.*
 import uk.gov.hmrc.pillar2submissionapi.models.WrappedValue
 
 case class Monetary(value: BigDecimal) extends WrappedValue[BigDecimal]

--- a/app/uk/gov/hmrc/pillar2submissionapi/models/uktrsubmissions/ReturnType.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/models/uktrsubmissions/ReturnType.scala
@@ -16,8 +16,8 @@
 
 package uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions
 
-import enumeratum.EnumEntry.UpperSnakecase
 import enumeratum.*
+import enumeratum.EnumEntry.UpperSnakecase
 
 sealed trait ReturnType extends EnumEntry with UpperSnakecase
 

--- a/app/uk/gov/hmrc/pillar2submissionapi/models/uktrsubmissions/ReturnType.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/models/uktrsubmissions/ReturnType.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions
 
 import enumeratum.EnumEntry.UpperSnakecase
-import enumeratum._
+import enumeratum.*
 
 sealed trait ReturnType extends EnumEntry with UpperSnakecase
 

--- a/app/uk/gov/hmrc/pillar2submissionapi/models/uktrsubmissions/UKTRSubmission.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/models/uktrsubmissions/UKTRSubmission.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions
 
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import java.time.LocalDate
 
@@ -54,7 +54,7 @@ object UKTRSubmissionNilReturn {
 
 object UKTRSubmission {
   given uktrSubmissionReads: Reads[UKTRSubmission] = (json: JsValue) =>
-    if ((json \ "liabilities" \ "returnType").isEmpty) {
+    if (json \ "liabilities" \ "returnType").isEmpty then {
       json.validate[UKTRSubmissionData]
     } else {
       json.validate[UKTRSubmissionNilReturn]

--- a/app/uk/gov/hmrc/pillar2submissionapi/services/OverseasReturnNotificationService.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/services/OverseasReturnNotificationService.scala
@@ -22,7 +22,7 @@ import play.api.libs.json.{JsError, JsSuccess, Json}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2submissionapi.connectors.OverseasReturnNotificationConnector
 import uk.gov.hmrc.pillar2submissionapi.controllers.error.{DownstreamValidationError, ORNNotFoundException, UnexpectedResponse}
-import uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification._
+import uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification.*
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -75,7 +75,7 @@ class OverseasReturnNotificationService @Inject() (connector: OverseasReturnNoti
       case 422 =>
         response.json.validate[ORNErrorResponse] match {
           case JsSuccess(response, _) =>
-            if (response.code == "005" && response.message.contains("No Form Bundle found")) {
+            if response.code == "005" && response.message.contains("No Form Bundle found") then {
               throw ORNNotFoundException
             } else {
               throw DownstreamValidationError(response.code, response.message)

--- a/app/uk/gov/hmrc/pillar2submissionapi/services/UKTaxReturnService.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/services/UKTaxReturnService.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.pillar2submissionapi.services
 import com.google.inject.{Inject, Singleton}
 import play.api.Logging
 import play.api.http.Status.{CREATED, OK, UNPROCESSABLE_ENTITY}
-import play.api.libs.json._
+import play.api.libs.json.*
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2submissionapi.connectors.UKTaxReturnConnector
 import uk.gov.hmrc.pillar2submissionapi.controllers.error.{DownstreamValidationError, UnexpectedResponse}

--- a/project/PublishTestOnlyOas.scala
+++ b/project/PublishTestOnlyOas.scala
@@ -10,7 +10,7 @@ object PublishTestOnlyOas {
       val targetDir  = baseDirectory.value / "resources/public/api/conf/1.0/testOnly"
       val targetFile = targetDir / "application.yaml"
 
-      if (!sourceFile.exists) {
+      if !sourceFile.exists then {
         sys.error(s"Source file not found: ${sourceFile.getAbsolutePath}")
       }
 

--- a/project/PublishTestOnlyOas.scala
+++ b/project/PublishTestOnlyOas.scala
@@ -1,10 +1,10 @@
-import sbt.Keys._
-import sbt._
+import sbt.Keys.*
+import sbt.*
 
 object PublishTestOnlyOas {
   val publishOas = taskKey[Unit]("Copy OpenAPI specification to resources directory")
 
-  def settings: Seq[Setting[_]] = Seq(
+  def settings: Seq[Setting[?]] = Seq(
     publishOas := {
       val sourceFile = baseDirectory.value / "target/swagger/application.yaml"
       val targetDir  = baseDirectory.value / "resources/public/api/conf/1.0/testOnly"

--- a/project/PublishTestOnlyOas.scala
+++ b/project/PublishTestOnlyOas.scala
@@ -10,7 +10,8 @@ object PublishTestOnlyOas {
       val targetDir  = baseDirectory.value / "resources/public/api/conf/1.0/testOnly"
       val targetFile = targetDir / "application.yaml"
 
-      if !sourceFile.exists then {
+      // scalafmt: { rewrite.scala3.newSyntax.control = false }
+      if (!sourceFile.exists) {
         sys.error(s"Source file not found: ${sourceFile.getAbsolutePath}")
       }
 

--- a/project/Validate.scala
+++ b/project/Validate.scala
@@ -12,7 +12,8 @@ object Validate {
       val parser          = new OpenAPIV3Parser()
       val result          = parser.readLocation(openApiFilePath.toString, null, null)
 
-      if !result.getMessages.isEmpty then sys.error(s"Validation failed:\n${result.getMessages.asScala.mkString("\n")}")
+      // scalafmt: { rewrite.scala3.newSyntax.control = false }
+      if (!result.getMessages.isEmpty) sys.error(s"Validation failed:\n${result.getMessages.asScala.mkString("\n")}")
 
     }
   )

--- a/project/Validate.scala
+++ b/project/Validate.scala
@@ -12,7 +12,7 @@ object Validate {
       val parser          = new OpenAPIV3Parser()
       val result          = parser.readLocation(openApiFilePath.toString, null, null)
 
-      if (!result.getMessages.isEmpty) sys.error(s"Validation failed:\n${result.getMessages.asScala.mkString("\n")}")
+      if !result.getMessages.isEmpty then sys.error(s"Validation failed:\n${result.getMessages.asScala.mkString("\n")}")
 
     }
   )

--- a/project/Validate.scala
+++ b/project/Validate.scala
@@ -1,12 +1,12 @@
 import _root_.io.swagger.v3.parser.OpenAPIV3Parser
-import sbt.Keys._
-import sbt._
+import sbt.Keys.*
+import sbt.*
 
 import scala.jdk.CollectionConverters.asScalaBufferConverter
 
 object Validate {
   val validateOas = taskKey[Unit]("Validate OpenAPI specification")
-  def settings: Seq[Setting[_]] = Seq(
+  def settings: Seq[Setting[?]] = Seq(
     validateOas := {
       val openApiFilePath = baseDirectory.value / "target/swagger/application.yaml"
       val parser          = new OpenAPIV3Parser()

--- a/test/uk/gov/hmrc/pillar2submissionapi/base/ControllerBaseSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/base/ControllerBaseSpec.scala
@@ -24,15 +24,15 @@ import org.scalatest.matchers.should.Matchers.shouldEqual
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import play.api.Configuration
-import play.api.mvc._
+import play.api.mvc.*
 import play.api.test.Helpers.stubControllerComponents
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.pillar2submissionapi.config.AppConfig
 import uk.gov.hmrc.pillar2submissionapi.connectors.SubscriptionConnector
-import uk.gov.hmrc.pillar2submissionapi.controllers.actions._
+import uk.gov.hmrc.pillar2submissionapi.controllers.actions.*
 import uk.gov.hmrc.pillar2submissionapi.helpers.{SubscriptionDataFixture, UKTaxReturnDataFixture}
 import uk.gov.hmrc.pillar2submissionapi.models.requests.{IdentifierRequest, SubscriptionDataRequest}
-import uk.gov.hmrc.pillar2submissionapi.services._
+import uk.gov.hmrc.pillar2submissionapi.services.*
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import scala.concurrent.duration.DurationInt

--- a/test/uk/gov/hmrc/pillar2submissionapi/base/UnitTestBaseSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/base/UnitTestBaseSpec.scala
@@ -23,12 +23,12 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Configuration
-import play.api.mvc._
+import play.api.mvc.*
 import play.api.test.Helpers.stubControllerComponents
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.test.HttpClientSupport
-import uk.gov.hmrc.pillar2submissionapi.connectors._
+import uk.gov.hmrc.pillar2submissionapi.connectors.*
 import uk.gov.hmrc.pillar2submissionapi.helpers.{UKTaxReturnDataFixture, WireMockServerHandler}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 

--- a/test/uk/gov/hmrc/pillar2submissionapi/connectors/GIRConnectorSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/connectors/GIRConnectorSpec.scala
@@ -16,9 +16,9 @@
 
 package uk.gov.hmrc.pillar2submissionapi.connectors
 
-import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.client.WireMock.*
 import org.scalatest.matchers.should.Matchers.should
-import play.api.http.Status._
+import play.api.http.Status.*
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.JsObject
 import play.api.libs.json.Json

--- a/test/uk/gov/hmrc/pillar2submissionapi/connectors/OverseasReturnNotificationConnectorSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/connectors/OverseasReturnNotificationConnectorSpec.scala
@@ -16,9 +16,9 @@
 
 package uk.gov.hmrc.pillar2submissionapi.connectors
 
-import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.client.WireMock.*
 import org.scalatest.matchers.should.Matchers.should
-import play.api.http.Status._
+import play.api.http.Status.*
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.JsObject
 import play.api.test.Helpers.{await, defaultAwaitTimeout}

--- a/test/uk/gov/hmrc/pillar2submissionapi/connectors/SubmitBTNConnectorSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/connectors/SubmitBTNConnectorSpec.scala
@@ -16,9 +16,9 @@
 
 package uk.gov.hmrc.pillar2submissionapi.connectors
 
-import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.client.WireMock.*
 import org.scalatest.matchers.should.Matchers.should
-import play.api.http.Status._
+import play.api.http.Status.*
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.JsObject
 import play.api.test.Helpers.{await, defaultAwaitTimeout}

--- a/test/uk/gov/hmrc/pillar2submissionapi/connectors/TestOrganisationConnectorSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/connectors/TestOrganisationConnectorSpec.scala
@@ -17,13 +17,13 @@
 package uk.gov.hmrc.pillar2submissionapi.connectors
 
 import org.scalatest.matchers.should.Matchers.shouldBe
-import play.api.http.Status._
+import play.api.http.Status.*
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsObject, Json}
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import play.api.{Application, Configuration}
 import uk.gov.hmrc.pillar2submissionapi.base.UnitTestBaseSpec
-import uk.gov.hmrc.pillar2submissionapi.controllers.error._
+import uk.gov.hmrc.pillar2submissionapi.controllers.error.*
 import uk.gov.hmrc.pillar2submissionapi.models.organisation.{AccountingPeriod, OrgDetails, TestOrganisation}
 
 import java.time.{Instant, LocalDate}

--- a/test/uk/gov/hmrc/pillar2submissionapi/connectors/UKTaxReturnConnectorSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/connectors/UKTaxReturnConnectorSpec.scala
@@ -16,9 +16,9 @@
 
 package uk.gov.hmrc.pillar2submissionapi.connectors
 
-import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.client.WireMock.*
 import org.scalatest.matchers.should.Matchers.should
-import play.api.http.Status._
+import play.api.http.Status.*
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.JsObject
 import play.api.test.Helpers.{await, defaultAwaitTimeout}

--- a/test/uk/gov/hmrc/pillar2submissionapi/controllers/BTNSubmissionControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/controllers/BTNSubmissionControllerSpec.scala
@@ -25,7 +25,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers.{defaultAwaitTimeout, status}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2submissionapi.base.ControllerBaseSpec
-import uk.gov.hmrc.pillar2submissionapi.controllers.BTNSubmissionControllerSpec._
+import uk.gov.hmrc.pillar2submissionapi.controllers.BTNSubmissionControllerSpec.*
 import uk.gov.hmrc.pillar2submissionapi.controllers.error.{EmptyRequestBody, InvalidJson, MissingHeader}
 import uk.gov.hmrc.pillar2submissionapi.controllers.submission.BTNSubmissionController
 import uk.gov.hmrc.pillar2submissionapi.models.belowthresholdnotification.{BTNSubmission, SubmitBTNSuccessResponse}

--- a/test/uk/gov/hmrc/pillar2submissionapi/controllers/ObligationsAndSubmissionsControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/controllers/ObligationsAndSubmissionsControllerSpec.scala
@@ -20,10 +20,10 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import play.api.mvc.Result
 import play.api.test.FakeRequest
-import play.api.test.Helpers._
+import play.api.test.Helpers.*
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2submissionapi.base.ControllerBaseSpec
-import uk.gov.hmrc.pillar2submissionapi.controllers.error._
+import uk.gov.hmrc.pillar2submissionapi.controllers.error.*
 import uk.gov.hmrc.pillar2submissionapi.controllers.obligationsandsubmissions.ObligationsAndSubmissionsController
 import uk.gov.hmrc.pillar2submissionapi.helpers.ObligationsAndSubmissionsDataFixture
 

--- a/test/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandlerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandlerSpec.scala
@@ -23,7 +23,7 @@ import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{contentAsJson, defaultAwaitTimeout, status}
-import uk.gov.hmrc.pillar2submissionapi.controllers.error._
+import uk.gov.hmrc.pillar2submissionapi.controllers.error.*
 import uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse
 
 class Pillar2ErrorHandlerSpec extends AnyFunSuite with ScalaCheckDrivenPropertyChecks {

--- a/test/uk/gov/hmrc/pillar2submissionapi/controllers/TestOrganisationControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/controllers/TestOrganisationControllerSpec.scala
@@ -16,18 +16,18 @@
 
 package uk.gov.hmrc.pillar2submissionapi.controllers
 
-import org.mockito.ArgumentMatchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq as eqTo}
 import org.mockito.Mockito.when
-import play.api.http.Status._
+import play.api.http.Status.*
 import play.api.libs.json.{JsObject, JsValue, Json}
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{contentAsJson, defaultAwaitTimeout, status}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2submissionapi.base.ControllerBaseSpec
 import uk.gov.hmrc.pillar2submissionapi.config.AppConfig
-import uk.gov.hmrc.pillar2submissionapi.controllers.error._
+import uk.gov.hmrc.pillar2submissionapi.controllers.error.*
 import uk.gov.hmrc.pillar2submissionapi.controllers.test.TestOrganisationController
-import uk.gov.hmrc.pillar2submissionapi.models.organisation._
+import uk.gov.hmrc.pillar2submissionapi.models.organisation.*
 
 import java.time.{Instant, LocalDate}
 import scala.concurrent.Future

--- a/test/uk/gov/hmrc/pillar2submissionapi/controllers/actions/AuthenticatedIdentifierActionSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/controllers/actions/AuthenticatedIdentifierActionSpec.scala
@@ -24,9 +24,9 @@ import play.api.Configuration
 import play.api.mvc.*
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
+import uk.gov.hmrc.auth.core.*
 import uk.gov.hmrc.auth.core.AffinityGroup.{Agent, Individual, Organisation}
 import uk.gov.hmrc.auth.core.AuthProvider.GovernmentGateway
-import uk.gov.hmrc.auth.core.*
 import uk.gov.hmrc.auth.core.authorise.Predicate
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
 import uk.gov.hmrc.auth.core.retrieve.{Credentials, Retrieval, ~}

--- a/test/uk/gov/hmrc/pillar2submissionapi/controllers/actions/AuthenticatedIdentifierActionSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/controllers/actions/AuthenticatedIdentifierActionSpec.scala
@@ -21,22 +21,22 @@ import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import play.api.Configuration
-import play.api.mvc._
+import play.api.mvc.*
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.auth.core.AffinityGroup.{Agent, Individual, Organisation}
 import uk.gov.hmrc.auth.core.AuthProvider.GovernmentGateway
-import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.auth.core.*
 import uk.gov.hmrc.auth.core.authorise.Predicate
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
 import uk.gov.hmrc.auth.core.retrieve.{Credentials, Retrieval, ~}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2submissionapi.base.ActionBaseSpec
 import uk.gov.hmrc.pillar2submissionapi.config.AppConfig
-import uk.gov.hmrc.pillar2submissionapi.controllers.actions.AuthenticatedIdentifierAction._
-import uk.gov.hmrc.pillar2submissionapi.controllers.actions.AuthenticatedIdentifierActionSpec._
-import uk.gov.hmrc.pillar2submissionapi.controllers.error._
-import uk.gov.hmrc.pillar2submissionapi.helpers.TestAuthRetrievals._
+import uk.gov.hmrc.pillar2submissionapi.controllers.actions.AuthenticatedIdentifierAction.*
+import uk.gov.hmrc.pillar2submissionapi.controllers.actions.AuthenticatedIdentifierActionSpec.*
+import uk.gov.hmrc.pillar2submissionapi.controllers.error.*
+import uk.gov.hmrc.pillar2submissionapi.helpers.TestAuthRetrievals.*
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import java.util.UUID

--- a/test/uk/gov/hmrc/pillar2submissionapi/controllers/actions/SubscriptionDataRetrievalActionSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/controllers/actions/SubscriptionDataRetrievalActionSpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.pillar2submissionapi.controllers.actions
 
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito._
+import org.mockito.Mockito.*
 import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
 import play.api.test.FakeRequest
 import uk.gov.hmrc.http.HeaderCarrier

--- a/test/uk/gov/hmrc/pillar2submissionapi/controllers/test/GIRControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/controllers/test/GIRControllerSpec.scala
@@ -16,9 +16,9 @@
 
 package uk.gov.hmrc.pillar2submissionapi.controllers.test
 
-import org.mockito.ArgumentMatchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq as eqTo}
 import org.mockito.Mockito.when
-import play.api.http.Status._
+import play.api.http.Status.*
 import play.api.libs.json.{JsValue, Json}
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{contentAsJson, defaultAwaitTimeout, status}

--- a/test/uk/gov/hmrc/pillar2submissionapi/helpers/ORNDataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/helpers/ORNDataFixture.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.pillar2submissionapi.helpers
 
-import play.api.libs.json._
+import play.api.libs.json.*
 import uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification.{ORNRetrieveSuccessResponse, ORNSubmission, ORNSuccessResponse}
 
 import java.time.LocalDate

--- a/test/uk/gov/hmrc/pillar2submissionapi/helpers/ObligationsAndSubmissionsDataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/helpers/ObligationsAndSubmissionsDataFixture.scala
@@ -16,10 +16,10 @@
 
 package uk.gov.hmrc.pillar2submissionapi.helpers
 
+import uk.gov.hmrc.pillar2submissionapi.models.obligationsandsubmissions.*
 import uk.gov.hmrc.pillar2submissionapi.models.obligationsandsubmissions.ObligationStatus.{Fulfilled, Open}
 import uk.gov.hmrc.pillar2submissionapi.models.obligationsandsubmissions.ObligationType.{GIR, UKTR}
 import uk.gov.hmrc.pillar2submissionapi.models.obligationsandsubmissions.SubmissionType.BTN
-import uk.gov.hmrc.pillar2submissionapi.models.obligationsandsubmissions.*
 
 import java.time.{LocalDate, ZonedDateTime}
 

--- a/test/uk/gov/hmrc/pillar2submissionapi/helpers/ObligationsAndSubmissionsDataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/helpers/ObligationsAndSubmissionsDataFixture.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.pillar2submissionapi.helpers
 import uk.gov.hmrc.pillar2submissionapi.models.obligationsandsubmissions.ObligationStatus.{Fulfilled, Open}
 import uk.gov.hmrc.pillar2submissionapi.models.obligationsandsubmissions.ObligationType.{GIR, UKTR}
 import uk.gov.hmrc.pillar2submissionapi.models.obligationsandsubmissions.SubmissionType.BTN
-import uk.gov.hmrc.pillar2submissionapi.models.obligationsandsubmissions._
+import uk.gov.hmrc.pillar2submissionapi.models.obligationsandsubmissions.*
 
 import java.time.{LocalDate, ZonedDateTime}
 

--- a/test/uk/gov/hmrc/pillar2submissionapi/helpers/SubscriptionDataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/helpers/SubscriptionDataFixture.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.pillar2submissionapi.helpers
 
 import play.api.libs.json.{JsValue, Json}
-import uk.gov.hmrc.pillar2submissionapi.models.subscription._
+import uk.gov.hmrc.pillar2submissionapi.models.subscription.*
 
 import java.time.LocalDate
 

--- a/test/uk/gov/hmrc/pillar2submissionapi/helpers/UKTaxReturnDataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/helpers/UKTaxReturnDataFixture.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.pillar2submissionapi.helpers
 import cats.data.NonEmptyList
 import play.api.libs.json.{JsObject, JsValue, Json}
 import uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.ReturnType.NIL_RETURN
-import uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions._
+import uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.*
 import uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.responses.UKTRSubmitSuccessResponse
 
 import java.time.{LocalDate, ZoneId, ZonedDateTime}

--- a/test/uk/gov/hmrc/pillar2submissionapi/helpers/UKTaxReturnDataFixture.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/helpers/UKTaxReturnDataFixture.scala
@@ -18,8 +18,8 @@ package uk.gov.hmrc.pillar2submissionapi.helpers
 
 import cats.data.NonEmptyList
 import play.api.libs.json.{JsObject, JsValue, Json}
-import uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.ReturnType.NIL_RETURN
 import uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.*
+import uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.ReturnType.NIL_RETURN
 import uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.responses.UKTRSubmitSuccessResponse
 
 import java.time.{LocalDate, ZoneId, ZonedDateTime}

--- a/test/uk/gov/hmrc/pillar2submissionapi/helpers/WireMockServerHandler.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/helpers/WireMockServerHandler.scala
@@ -17,11 +17,11 @@
 package uk.gov.hmrc.pillar2submissionapi.helpers
 
 import com.github.tomakehurst.wiremock.WireMockServer
-import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.client.WireMock.*
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
-import play.api.http.HttpVerbs._
+import play.api.http.HttpVerbs.*
 import play.api.libs.json.JsValue
 import uk.gov.hmrc.http.HeaderCarrier
 

--- a/test/uk/gov/hmrc/pillar2submissionapi/models/WrappedValueSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/models/WrappedValueSpec.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.pillar2submissionapi.models
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import play.api.libs.json._
+import play.api.libs.json.*
 
 class WrappedValueSpec extends AnyWordSpec with Matchers {
 

--- a/test/uk/gov/hmrc/pillar2submissionapi/models/uktrsubmissions/IdTypeSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/models/uktrsubmissions/IdTypeSpec.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import play.api.libs.json._
+import play.api.libs.json.*
 import uk.gov.hmrc.pillar2submissionapi.models.WrappedValue
 
 class IdTypeSpec extends AnyWordSpec with Matchers {

--- a/test/uk/gov/hmrc/pillar2submissionapi/models/uktrsubmissions/IdValueSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/models/uktrsubmissions/IdValueSpec.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import play.api.libs.json._
+import play.api.libs.json.*
 import uk.gov.hmrc.pillar2submissionapi.models.WrappedValue
 
 class IdValueSpec extends AnyWordSpec with Matchers {

--- a/test/uk/gov/hmrc/pillar2submissionapi/models/uktrsubmissions/LiableEntitiesSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/models/uktrsubmissions/LiableEntitiesSpec.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions
 import cats.data.NonEmptyList
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import play.api.libs.json._
+import play.api.libs.json.*
 import uk.gov.hmrc.pillar2submissionapi.models.WrappedValue
 
 import scala.math.BigDecimal

--- a/test/uk/gov/hmrc/pillar2submissionapi/models/uktrsubmissions/MonetarySpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/models/uktrsubmissions/MonetarySpec.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import play.api.libs.json._
+import play.api.libs.json.*
 import uk.gov.hmrc.pillar2submissionapi.models.WrappedValue
 
 import scala.math.BigDecimal

--- a/test/uk/gov/hmrc/pillar2submissionapi/services/GIRServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/services/GIRServiceSpec.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2submissionapi.base.UnitTestBaseSpec
 import uk.gov.hmrc.pillar2submissionapi.connectors.GIRConnector
 import uk.gov.hmrc.pillar2submissionapi.controllers.error.{DownstreamValidationError, UnexpectedResponse}
-import uk.gov.hmrc.pillar2submissionapi.models.globeinformationreturn._
+import uk.gov.hmrc.pillar2submissionapi.models.globeinformationreturn.*
 
 import java.time.LocalDate
 import scala.concurrent.Future

--- a/test/uk/gov/hmrc/pillar2submissionapi/services/ObligationsAndSubmissionsServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/services/ObligationsAndSubmissionsServiceSpec.scala
@@ -20,12 +20,12 @@ import junit.framework.TestCase.assertEquals
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import play.api.libs.json.Json
-import play.api.test.Helpers._
+import play.api.test.Helpers.*
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2submissionapi.base.UnitTestBaseSpec
 import uk.gov.hmrc.pillar2submissionapi.controllers.error.{DownstreamValidationError, UnexpectedResponse}
 import uk.gov.hmrc.pillar2submissionapi.helpers.ObligationsAndSubmissionsDataFixture
-import uk.gov.hmrc.pillar2submissionapi.models.obligationsandsubmissions._
+import uk.gov.hmrc.pillar2submissionapi.models.obligationsandsubmissions.*
 
 import java.time.LocalDate
 import scala.concurrent.{ExecutionContext, Future}

--- a/test/uk/gov/hmrc/pillar2submissionapi/services/OverseasReturnNotificationServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/services/OverseasReturnNotificationServiceSpec.scala
@@ -23,7 +23,7 @@ import play.api.libs.json.Json
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2submissionapi.base.UnitTestBaseSpec
-import uk.gov.hmrc.pillar2submissionapi.controllers.error._
+import uk.gov.hmrc.pillar2submissionapi.controllers.error.*
 import uk.gov.hmrc.pillar2submissionapi.helpers.ORNDataFixture
 import uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification.{ORNErrorResponse, ORNSubmission}
 

--- a/test/uk/gov/hmrc/pillar2submissionapi/services/SubmitBTNServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/services/SubmitBTNServiceSpec.scala
@@ -23,9 +23,9 @@ import play.api.libs.json.Json
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2submissionapi.base.UnitTestBaseSpec
-import uk.gov.hmrc.pillar2submissionapi.controllers.error._
+import uk.gov.hmrc.pillar2submissionapi.controllers.error.*
 import uk.gov.hmrc.pillar2submissionapi.models.belowthresholdnotification.{BTNSubmission, SubmitBTNErrorResponse, SubmitBTNSuccessResponse}
-import uk.gov.hmrc.pillar2submissionapi.services.SubmitBTNServiceSpec._
+import uk.gov.hmrc.pillar2submissionapi.services.SubmitBTNServiceSpec.*
 
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit

--- a/test/uk/gov/hmrc/pillar2submissionapi/services/TestOrganisationServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/services/TestOrganisationServiceSpec.scala
@@ -16,12 +16,12 @@
 
 package uk.gov.hmrc.pillar2submissionapi.services
 
-import org.mockito.ArgumentMatchers.{any, eq => eqTo}
+import org.mockito.ArgumentMatchers.{any, eq as eqTo}
 import org.mockito.Mockito.when
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2submissionapi.base.UnitTestBaseSpec
-import uk.gov.hmrc.pillar2submissionapi.models.organisation._
+import uk.gov.hmrc.pillar2submissionapi.models.organisation.*
 
 import java.time.{Instant, LocalDate}
 import scala.concurrent.Future

--- a/test/uk/gov/hmrc/pillar2submissionapi/services/UKTaxReturnServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/services/UKTaxReturnServiceSpec.scala
@@ -20,14 +20,14 @@ import junit.framework.TestCase.assertEquals
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
-import play.api.http.Status._
+import play.api.http.Status.*
 import play.api.libs.json.Json
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2submissionapi.base.UnitTestBaseSpec
-import uk.gov.hmrc.pillar2submissionapi.controllers.error._
+import uk.gov.hmrc.pillar2submissionapi.controllers.error.*
 import uk.gov.hmrc.pillar2submissionapi.helpers.UKTRErrorCodes.INVALID_RETURN_093
-import uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions._
+import uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.*
 
 import scala.concurrent.Future
 


### PR DESCRIPTION
This PR adds a rewrite flag to scalafmt to ensure we use the Scala 3 syntax going forward. This will avoid a moment in the future where the Scala 2 syntax (e.g. underscore wildcard imports) are removed, and ensure consistency in the style used across the codebase.

We already have this flag in place for the stubs, and it's being added to the frontend and backend as part of the inflight migration work.

There are more granular config options here if we want to retain the scala 2 syntax for any of the specific changes here.