### PR TITLE
Pil 2845 - Changes to OAS for currency conversion

### DIFF
--- a/conf/swagger-custom-mappings.yml
+++ b/conf/swagger-custom-mappings.yml
@@ -10,6 +10,7 @@
       minimum: 0
       maximum: 9999999999999.99
       multipleOf: 0.01
+      description: In pound sterling
 - type: java\.time\.LocalDate
   specAsParameter:
     - type: string

--- a/conf/swagger.yml
+++ b/conf/swagger.yml
@@ -1308,7 +1308,7 @@ components:
           type: string
           minLength: 1
           maxLength: 200
-          description: The name of the company that submitted the Overseas Return Notification (ORN).
+          description: The name of the company that submitted the GloBE Information Return (GIR).
         TIN:
           type: string
           minLength: 1
@@ -1348,7 +1348,7 @@ components:
         reportingEntityName:
           description: The name of the company that submitted the Overseas Return Notification (ORN).
         TIN:
-          description: The Tax Identification Number of the entity that submitted the Overseas Return Notification.
+          description: The Tax Identification Number of the entity submitting the GloBE Information Return (GIR).
         issuingCountryTIN:
           description: The country in which the Tax Identification Number was issued.
     uk.gov.hmrc.pillar2submissionapi.models.belowthresholdnotification.BTNSubmission:

--- a/conf/swagger.yml
+++ b/conf/swagger.yml
@@ -13,6 +13,7 @@ paths:
       summary: Submit UK Tax Return
       description: |
         Submits a UK Tax Return for a specified accounting period.
+        ### The MTT and DTT liabilities reported in the UKTR should be stated in pound sterling in accordance with s123(3) F(No. 2)A 2023.
         ### Error Codes
         <p>This table contains a list of 422 error codes returned when a SubmitUKTR or AmendUKTR request is not processed successfully.</p>
         <table>
@@ -162,7 +163,7 @@ paths:
       summary: Amend UK Tax Return
       description: |
         Amends a UK tax return submitted for a specified accounting period.   
-
+        ### The MTT and DTT liabilities reported in the UKTR should be stated in pound sterling in accordance with s123(3) F(No. 2)A 2023.
         ### Error Codes
         <p>AmendUKTR generates the same error codes as Submit UKTR, please use the Error Codes table in the SubmitUKTR section above.</p>
       requestBody:

--- a/resources/public/api/conf/1.0/application.yaml
+++ b/resources/public/api/conf/1.0/application.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.196.0
+  version: 0.198.0
   title: Pillar 2 API
   description: An API for managing and retrieving data in accordance with Pillar 2 tax rules.
 tags: []
@@ -624,6 +624,7 @@ paths:
                   $ref: "#/components/examples/errors.Submission.NoSubscriptionData"
       description: |
         Submits a UK Tax Return for a specified accounting period.
+        ### The MTT and DTT liabilities reported in the UKTR should be stated in pound sterling in accordance with s123(3) F(No. 2)A 2023.
         ### Error Codes
         <p>This table contains a list of 422 error codes returned when a SubmitUKTR or AmendUKTR request is not processed successfully.</p>
         <table>
@@ -809,7 +810,7 @@ paths:
                   $ref: "#/components/examples/errors.Submission.GenericServerError"
                 No Subscription Data:
                   $ref: "#/components/examples/errors.Submission.NoSubscriptionData"
-      description: "Amends a UK tax return submitted for a specified accounting period.   \n\n### Error Codes\n<p>AmendUKTR generates the same error codes as Submit UKTR, please use the Error Codes table in the SubmitUKTR section above.</p>\n"
+      description: "Amends a UK tax return submitted for a specified accounting period.   \n### The MTT and DTT liabilities reported in the UKTR should be stated in pound sterling in accordance with s123(3) F(No. 2)A 2023.\n### Error Codes\n<p>AmendUKTR generates the same error codes as Submit UKTR, please use the Error Codes table in the SubmitUKTR section above.</p>\n"
       security:
       - userRestricted:
         - write:pillar2
@@ -1772,18 +1773,21 @@ components:
           minimum: 0
           maximum: 9.99999999999999E12
           multipleOf: 0.01
+          description: In pound sterling
         amountOwedIIR:
           type: number
           format: double
           minimum: 0
           maximum: 9.99999999999999E12
           multipleOf: 0.01
+          description: In pound sterling
         amountOwedUTPR:
           type: number
           format: double
           minimum: 0
           maximum: 9.99999999999999E12
           multipleOf: 0.01
+          description: In pound sterling
       required:
       - ukChargeableEntityName
       - idType
@@ -1947,7 +1951,7 @@ components:
           description: The name of the company that submitted the Overseas Return Notification (ORN).
         TIN:
           type: string
-          description: The Tax Identification Number of the entity that submitted the Overseas Return Notification.
+          description: The Tax Identification Number of the entity submitting the GloBE Information Return (GIR).
         issuingCountryTIN:
           type: string
           description: The country in which the Tax Identification Number was issued.
@@ -1994,7 +1998,7 @@ components:
           type: string
           minLength: 1
           maxLength: 200
-          description: The name of the company that submitted the Overseas Return Notification (ORN).
+          description: The name of the company that submitted the GloBE Information Return (GIR).
         TIN:
           type: string
           minLength: 1
@@ -2102,24 +2106,28 @@ components:
           minimum: 0
           maximum: 9.99999999999999E12
           multipleOf: 0.01
+          description: In pound sterling
         totalLiabilityDTT:
           type: number
           format: double
           minimum: 0
           maximum: 9.99999999999999E12
           multipleOf: 0.01
+          description: In pound sterling
         totalLiabilityIIR:
           type: number
           format: double
           minimum: 0
           maximum: 9.99999999999999E12
           multipleOf: 0.01
+          description: In pound sterling
         totalLiabilityUTPR:
           type: number
           format: double
           minimum: 0
           maximum: 9.99999999999999E12
           multipleOf: 0.01
+          description: In pound sterling
         liableEntities:
           type: array
           minItems: 1

--- a/resources/public/api/conf/1.0/testOnly/application.yaml
+++ b/resources/public/api/conf/1.0/testOnly/application.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.196.0
+  version: 0.198.0
   title: Pillar 2 API
   description: An API for managing and retrieving data in accordance with Pillar 2 tax rules.
 tags: []
@@ -624,6 +624,7 @@ paths:
                   $ref: "#/components/examples/errors.Submission.NoSubscriptionData"
       description: |
         Submits a UK Tax Return for a specified accounting period.
+        ### The MTT and DTT liabilities reported in the UKTR should be stated in pound sterling in accordance with s123(3) F(No. 2)A 2023.
         ### Error Codes
         <p>This table contains a list of 422 error codes returned when a SubmitUKTR or AmendUKTR request is not processed successfully.</p>
         <table>
@@ -809,7 +810,7 @@ paths:
                   $ref: "#/components/examples/errors.Submission.GenericServerError"
                 No Subscription Data:
                   $ref: "#/components/examples/errors.Submission.NoSubscriptionData"
-      description: "Amends a UK tax return submitted for a specified accounting period.   \n\n### Error Codes\n<p>AmendUKTR generates the same error codes as Submit UKTR, please use the Error Codes table in the SubmitUKTR section above.</p>\n"
+      description: "Amends a UK tax return submitted for a specified accounting period.   \n### The MTT and DTT liabilities reported in the UKTR should be stated in pound sterling in accordance with s123(3) F(No. 2)A 2023.\n### Error Codes\n<p>AmendUKTR generates the same error codes as Submit UKTR, please use the Error Codes table in the SubmitUKTR section above.</p>\n"
       security:
       - userRestricted:
         - write:pillar2
@@ -1772,18 +1773,21 @@ components:
           minimum: 0
           maximum: 9.99999999999999E12
           multipleOf: 0.01
+          description: In pound sterling
         amountOwedIIR:
           type: number
           format: double
           minimum: 0
           maximum: 9.99999999999999E12
           multipleOf: 0.01
+          description: In pound sterling
         amountOwedUTPR:
           type: number
           format: double
           minimum: 0
           maximum: 9.99999999999999E12
           multipleOf: 0.01
+          description: In pound sterling
       required:
       - ukChargeableEntityName
       - idType
@@ -1947,7 +1951,7 @@ components:
           description: The name of the company that submitted the Overseas Return Notification (ORN).
         TIN:
           type: string
-          description: The Tax Identification Number of the entity that submitted the Overseas Return Notification.
+          description: The Tax Identification Number of the entity submitting the GloBE Information Return (GIR).
         issuingCountryTIN:
           type: string
           description: The country in which the Tax Identification Number was issued.
@@ -1994,7 +1998,7 @@ components:
           type: string
           minLength: 1
           maxLength: 200
-          description: The name of the company that submitted the Overseas Return Notification (ORN).
+          description: The name of the company that submitted the GloBE Information Return (GIR).
         TIN:
           type: string
           minLength: 1
@@ -2102,24 +2106,28 @@ components:
           minimum: 0
           maximum: 9.99999999999999E12
           multipleOf: 0.01
+          description: In pound sterling
         totalLiabilityDTT:
           type: number
           format: double
           minimum: 0
           maximum: 9.99999999999999E12
           multipleOf: 0.01
+          description: In pound sterling
         totalLiabilityIIR:
           type: number
           format: double
           minimum: 0
           maximum: 9.99999999999999E12
           multipleOf: 0.01
+          description: In pound sterling
         totalLiabilityUTPR:
           type: number
           format: double
           minimum: 0
           maximum: 9.99999999999999E12
           multipleOf: 0.01
+          description: In pound sterling
         liableEntities:
           type: array
           minItems: 1

--- a/resources/public/api/conf/common/overview.md
+++ b/resources/public/api/conf/common/overview.md
@@ -10,5 +10,5 @@ The *Pillar 2 API* allows developers to
  - retrieve the details of a submitted ORN
 
 
-The [Pillar 2 Service Guide](https://developer.service.hmrc.gov.uk/guides/pillar2-service-guide) contains further information on integrating with the API, including a glossary of terms and acronyms relating to the Pillar 2 API. The [Pillar 2 Roadmap](https://developer.service.hmrc.gov.uk/roadmaps/pillar2-roadmap/) contains information on the Pillar 2 API release schedule. 
+The [Pillar 2 API Service Guide](https://developer.service.hmrc.gov.uk/guides/pillar2-service-guide) contains further information on integrating with the API, including a glossary of terms and acronyms relating to the Pillar 2 API. The [Pillar 2 API Roadmap](https://developer.service.hmrc.gov.uk/roadmaps/pillar2-roadmap/) contains information on the Pillar 2 API release schedule. 
 

--- a/resources/public/api/conf/common/overview.md
+++ b/resources/public/api/conf/common/overview.md
@@ -8,6 +8,7 @@ The *Pillar 2 API* allows developers to
  - submit an Overseas Return Notification (**ORN**)
  - amend a submitted ORN
  - retrieve the details of a submitted ORN
+ - retrieve account activity
 
 
 The [Pillar 2 API Service Guide](https://developer.service.hmrc.gov.uk/guides/pillar2-service-guide) contains further information on integrating with the API, including a glossary of terms and acronyms relating to the Pillar 2 API. The [Pillar 2 API Roadmap](https://developer.service.hmrc.gov.uk/roadmaps/pillar2-roadmap/) contains information on the Pillar 2 API release schedule. 

--- a/resources/public/api/conf/common/testing.md
+++ b/resources/public/api/conf/common/testing.md
@@ -1,4 +1,4 @@
-API testing is performed in the [HMRC developer hub](https://developer.service.hmrc.gov.uk/api-documentation) “sandbox” environment. Once you have [registered for an account](https://developer.service.hmrc.gov.uk/developer/registration), you can conduct your own testing. The Pillar 2 API belongs to the "Corporation Tax" category. 
+API testing is performed in our [sandbox](https://developer.service.hmrc.gov.uk/api-documentation/docs/testing) environment. Once you have [registered for an account](https://developer.service.hmrc.gov.uk/developer/registration), you can conduct your own testing. The Pillar 2 API belongs to the "Corporation Tax" category. 
 
 Work through the instructions on the [getting started](https://developer.service.hmrc.gov.uk/api-documentation/docs/using-the-hub) page to create an application, then locate and subscribe to the Pillar 2 API.
 
@@ -11,7 +11,7 @@ The next steps are outlined on the Open API Specification (**OAS**) page under "
 - Set up a test organisation.
 - Run a *Submit UK Tax Return* request.
 
-The [service guide](https://developer.service.hmrc.gov.uk/guides/pillar2-service-guide/) contains more detailed information on testing for each endpoint.
+The [Pillar 2 API Service Guide](https://developer.service.hmrc.gov.uk/guides/pillar2-service-guide/) contains more detailed information on testing for each endpoint.
 
 If you have a specific testing need that is not supported in the sandbox, please contact our [support team](https://developer.service.hmrc.gov.uk/developer/support).
 

--- a/resources/public/api/definition.json
+++ b/resources/public/api/definition.json
@@ -1,6 +1,6 @@
 {
   "api": {
-    "name": "Pillar 2",
+    "name": "Pillar 2 API",
     "description": "An API for managing and retrieving Pillar 2 data",
     "context": "organisations/pillar-two",
     "categories": ["CORPORATION_TAX"],


### PR DESCRIPTION
modified:   conf/swagger-custom-mappings.yml - added "In pound sterling" message on affected fields
modified:   conf/swagger.yml - added truncated currency conversion notice on affected endpoints (Submit & Amend UKTR)
modified:   resources/public/api/conf/1.0/application.yaml - New OAS
modified:   resources/public/api/conf/1.0/testOnly/application.yaml - New test OAS
modified:   resources/public/api/conf/common/overview.md - placed correct link for sandbox link on overview page