### PR TITLE
Replace unmaintained java-json-tools JSON schema validator with netwo…

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,7 +6,6 @@ object AppDependencies {
 
   val compile = Seq(
     "uk.gov.hmrc"                  %% "bootstrap-backend-play-30" % bootstrapVersion,
-    "com.github.java-json-tools"    % "json-schema-validator"     % "2.2.14",
     "com.fasterxml.jackson.module" %% "jackson-module-scala"      % "2.20.0",
     "org.typelevel"                %% "cats-core"                 % "2.13.0",
     "com.beachape"                 %% "enumeratum-play-json"      % "1.9.0"
@@ -19,7 +18,8 @@ object AppDependencies {
     "org.mockito"             % "mockito-core"           % "5.20.0"         % "test,it",
     "org.scalatestplus"      %% "mockito-4-11"           % "3.2.18.0"       % "test, it",
     "org.scalatestplus.play" %% "scalatestplus-play"     % "7.0.2"          % "test, it",
-    "org.scalatestplus"      %% "scalacheck-1-18"        % "3.2.19.0"       % "test"
+    "org.scalatestplus"      %% "scalacheck-1-18"        % "3.2.19.0"       % "test",
+    "com.networknt"           % "json-schema-validator"  % "1.5.7"          % Test
   )
 
   val it: Seq[ModuleID] = Seq(

--- a/test/uk/gov/hmrc/pillar2submissionapi/resources/DefinitionSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/resources/DefinitionSpec.scala
@@ -16,13 +16,12 @@
 
 package uk.gov.hmrc.pillar2submissionapi.resources
 
-import com.github.fge.jackson.JsonLoader
-import com.github.fge.jsonschema.core.report.LogLevel
-import com.github.fge.jsonschema.main.JsonSchemaFactory
-import play.twirl.api.TwirlHelperImports.twirlJavaCollectionToScala
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.networknt.schema.{JsonSchemaFactory, SpecVersion}
 import uk.gov.hmrc.pillar2submissionapi.base.UnitTestBaseSpec
 
 import scala.io.Source
+import scala.jdk.CollectionConverters.*
 
 class DefinitionSpec extends UnitTestBaseSpec {
 
@@ -30,20 +29,17 @@ class DefinitionSpec extends UnitTestBaseSpec {
 
   "API Definition" should {
     "conform to api-publisher schema" in {
+      val mapper     = new ObjectMapper()
       val source     = Source.fromURL(schemaUrl)
       val schemaJson =
         try source.mkString
         finally source.close()
-      val schema     = JsonLoader.fromString(schemaJson)
-      val definition = JsonLoader.fromResource("/public/api/definition.json")
-      val validator  = JsonSchemaFactory.byDefault().getJsonSchema(schema)
+      val schemaNode     = mapper.readTree(schemaJson)
+      val definitionNode = mapper.readTree(getClass.getResourceAsStream("/public/api/definition.json"))
+      val factory        = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7)
+      val schema         = factory.getSchema(schemaNode)
 
-      val report = validator.validate(definition)
-
-      val errors = report
-        .filter(_.getLogLevel == LogLevel.ERROR)
-        .map(error => s"${error.asJson().get("instance")}: ${error.getMessage}")
-        .toList
+      val errors = schema.validate(definitionNode).asScala.map(_.getMessage).toList
 
       errors mustEqual List.empty
     }

--- a/test/uk/gov/hmrc/pillar2submissionapi/resources/DefinitionSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/resources/DefinitionSpec.scala
@@ -21,7 +21,7 @@ import com.networknt.schema.{JsonSchemaFactory, SpecVersion}
 import uk.gov.hmrc.pillar2submissionapi.base.UnitTestBaseSpec
 
 import scala.io.Source
-import scala.jdk.CollectionConverters.*
+import scala.jdk.CollectionConverters._
 
 class DefinitionSpec extends UnitTestBaseSpec {
 


### PR DESCRIPTION
Replaces the `com.github.java-json-tools:json-schema-validator` dependency with `com.networknt:json-schema-validator:1.5.7`.

## Why

The `java-json-tools/json-schema-validator` library is unmaintained and has fallen behind on security updates for its transitive dependencies. The `networknt` library is actively maintained (latest release March 2026), supports JSON Schema drafts V4 through V2020-12, and uses Jackson under the hood — which is already a direct dependency of this service.

## Changes

- **`project/AppDependencies.scala`**: Removes `com.github.java-json-tools:json-schema-validator:2.2.14` from the `compile` scope. Adds `com.networknt:json-schema-validator:1.5.7` to `test` scope only, as it is only used in tests.
- **`test/.../resources/DefinitionSpec.scala`**: Rewrites the `DefinitionSpec` test to use the `networknt` API. The test behaviour is unchanged — it validates `definition.json` against the HMRC `api-publisher` JSON Schema (draft-07). Uses `SpecVersion.VersionFlag.V7` to explicitly match the draft version of the schema. Replaces the Twirl Java-collection import with standard `scala.jdk.CollectionConverters`.

## Notes

- No production code is affected. The old library was incorrectly declared in `compile` scope despite having no production usages; this is corrected by moving the replacement to `test` scope.
- The `networknt` 1.x line (Jackson 2 compatible) is used rather than 3.x, which requires Jackson 3 and JDK 17.