### PR TITLE
Add changes to OAS for MNE vs Domestic-only UKTR submissions

### DIFF
--- a/conf/swagger.yml
+++ b/conf/swagger.yml
@@ -54,15 +54,15 @@ paths:
         </tr>
         <tr>
         <td>097 - Invalid Total Liability IIR</td>
-        <td>The <em>totalLiabilityIIR</em> value does not match the <em>amountIIR value</em> from the <em>liableEntities</em> array. IIR values should only be entered by entities registered as a Multinational Enterprise. Please check the individual totals of each entity and submit the request again.</td>
+        <td>The <em>totalLiabilityIIR</em> value does not match the <em>amountIIR value</em> from the sum of <em>liableEntities</em> array. IIR values should only be entered by entities registered as a Multinational Enterprise. Please check the individual totals of each entity and submit the request again.</td>
         </tr>
         <tr>
         <td>098 - Invalid Total Liability DTT</td>
-        <td>The <em>totalLiabilityDTT</em> value does not match the <em>amountDTT</em> value from the <em>liableEntities</em> array. Please check the value of these fields matches and submit the request again.</td>
+        <td>The <em>totalLiabilityDTT</em> value does not match the <em>amountDTT</em> value from the sum of <em>liableEntities</em> array. Please check the value of these fields matches and submit the request again.</td>
         </tr>
         <tr>
         <td>099 - Invalid Total Liability UTPR</td>
-        <td>The <em>totalLiabilityUTPR</em> value does not match the <em>amountUTPR</em> value from the <em>liableEntities</em> array. UTPR values should only be entered by entities registered as a Multinational Enterprise. Please check the individual totals of each entity and submit the request again.</td>
+        <td>The <em>totalLiabilityUTPR</em> value does not match the <em>amountUTPR</em> value from the sum of <em>liableEntities</em> array. UTPR values should only be entered by entities registered as a Multinational Enterprise. Please check the individual totals of each entity and submit the request again.</td>
         </tr>
         </tbody>
         </table>
@@ -457,7 +457,7 @@ paths:
         </tr>
         <tr>
         <td>044 - Tax Obligation already fulfilled</td>
-        <td>A BTN for the specified period has already been submitted.</td>
+        <td>An ORN for the specified period has already been submitted.</td>
         </tr>
         <tr>
         <td>063 - Business Partner does not have an Active Subscription for this Regime</td>
@@ -995,7 +995,7 @@ paths:
         <tbody>
         <tr>
         <td>UKTR - DTT</td>
-        <td>Amount of Domestic Top-Up Tax payable as reported on the UK Pillar 2 Tax Return, applied to an account marked as domestic only.</td>
+        <td>Amount of Domestic Top-Up Tax payable as reported on the UK Pillar 2 Tax Return. A domestic-only or multinational can be liable for DTT.</td>
         </tr>
         <tr>
         <td>UKTR - MTT (IIR)</td>
@@ -1379,7 +1379,7 @@ components:
         accountingPeriodTo:
           description: The calendar date upon which a business' accounting period ends.
         obligationMTT:
-          description: Specifies whether a multinational group owes IIR or UTPR Pillar 2 tax. In the case where a group is 'domestic only', then the value must be `false`.
+          description: Specifies whether a multinational group owes IIR or UTPR Pillar 2 tax. In the case where a group is 'domestic only', then the value must be `false`. Where a group is 'multinational', the value can be `true` or `false`.
         electionUKGAAP:
           description: A means of calculating tax liability and profit. For domestic-only groups, the value must be `true`. For multinational groups, it must be `false`.
     uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.UKTRSubmissionNilReturn:
@@ -1391,7 +1391,7 @@ components:
         obligationMTT:
           description: Specifies whether a multinational group owes IIR or UTPR Pillar 2 tax. In the case where a group is 'domestic only', then the value must be `false`.
         electionUKGAAP:
-          description: A means of calculating tax liability and profit. For domestic-only groups, the value must be `true`. For multinational groups, it must be `false`.
+          description: A means of calculating tax liability and profit. For domestic-only groups, the value can be `true` or `false`. For multinational groups, it must always be `false`.
     uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.LiabilityNilReturn:
       description: |
         A liability is a return for UKTR per accounting period which needs to be submitted (unless a BTN has been submitted). This is to be returned annually, and certain groups will need to submit this, whereas others will not.

--- a/resources/public/api/conf/1.0/application.yaml
+++ b/resources/public/api/conf/1.0/application.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.205.0
+  version: 0.208.0
   title: Pillar 2 API
   description: An API for managing and retrieving data in accordance with Pillar 2 tax rules.
 tags: []
@@ -665,15 +665,15 @@ paths:
         </tr>
         <tr>
         <td>097 - Invalid Total Liability IIR</td>
-        <td>The <em>totalLiabilityIIR</em> value does not match the <em>amountIIR value</em> from the <em>liableEntities</em> array. IIR values should only be entered by entities registered as a Multinational Enterprise. Please check the individual totals of each entity and submit the request again.</td>
+        <td>The <em>totalLiabilityIIR</em> value does not match the <em>amountIIR value</em> from the sum of <em>liableEntities</em> array. IIR values should only be entered by entities registered as a Multinational Enterprise. Please check the individual totals of each entity and submit the request again.</td>
         </tr>
         <tr>
         <td>098 - Invalid Total Liability DTT</td>
-        <td>The <em>totalLiabilityDTT</em> value does not match the <em>amountDTT</em> value from the <em>liableEntities</em> array. Please check the value of these fields matches and submit the request again.</td>
+        <td>The <em>totalLiabilityDTT</em> value does not match the <em>amountDTT</em> value from the sum of <em>liableEntities</em> array. Please check the value of these fields matches and submit the request again.</td>
         </tr>
         <tr>
         <td>099 - Invalid Total Liability UTPR</td>
-        <td>The <em>totalLiabilityUTPR</em> value does not match the <em>amountUTPR</em> value from the <em>liableEntities</em> array. UTPR values should only be entered by entities registered as a Multinational Enterprise. Please check the individual totals of each entity and submit the request again.</td>
+        <td>The <em>totalLiabilityUTPR</em> value does not match the <em>amountUTPR</em> value from the sum of <em>liableEntities</em> array. UTPR values should only be entered by entities registered as a Multinational Enterprise. Please check the individual totals of each entity and submit the request again.</td>
         </tr>
         </tbody>
         </table>
@@ -1148,7 +1148,7 @@ paths:
                   $ref: "#/components/examples/errors.Submission.GenericServerError"
                 No Subscription Data:
                   $ref: "#/components/examples/errors.Submission.NoSubscriptionData"
-      description: "Submits an Overseas Return Notification for an accounting period.\n### Error Codes\n<p>This table contains a list of 422 error codes returned when a Submit Overseas Return Notification request is not processed successfully.</p> \n<table>\n<thead>\n<tr>\n<th>Error Message</th>\n<th>Next Steps</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>003 - Request could not be processed</td>\n<td>The message could not be processed due to locking. Please make the following checks. Confirm if there is currently an open enquiry on your tax account. The <em>accountingPeriodFrom</em> and <em>accountingPeriodTo</em> date range should match the period defined in your test organisation. The <em>filedDateGIR</em> date should not be in the future. The <em>countryGIR</em> and <em>issuingCountryTIN</em> fields must conform to the ISO-3166 standard for country codes. In the organisation’s settings, the <em>accountStatus</em> should have the <em>inactive</em> flag set to “false\".\n</td>\n</tr>\n<tr>\n<td>044 - Tax Obligation already fulfilled</td>\n<td>A BTN for the specified period has already been submitted.</td>\n</tr>\n<tr>\n<td>063 - Business Partner does not have an Active Subscription for this Regime</td>\n<td>The Pillar 2 ID in the request header is not listed as active by HMRC for this regime. Please contact the central support team.</td>\n</tr>\n<tr>\n<td>093 - Invalid Return</td>\n<td>There is an error with the return you’ve submitted in the request.</td>\n</tr>\n</tbody>\n</table>\n"
+      description: "Submits an Overseas Return Notification for an accounting period.\n### Error Codes\n<p>This table contains a list of 422 error codes returned when a Submit Overseas Return Notification request is not processed successfully.</p> \n<table>\n<thead>\n<tr>\n<th>Error Message</th>\n<th>Next Steps</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>003 - Request could not be processed</td>\n<td>The message could not be processed due to locking. Please make the following checks. Confirm if there is currently an open enquiry on your tax account. The <em>accountingPeriodFrom</em> and <em>accountingPeriodTo</em> date range should match the period defined in your test organisation. The <em>filedDateGIR</em> date should not be in the future. The <em>countryGIR</em> and <em>issuingCountryTIN</em> fields must conform to the ISO-3166 standard for country codes. In the organisation’s settings, the <em>accountStatus</em> should have the <em>inactive</em> flag set to “false\".\n</td>\n</tr>\n<tr>\n<td>044 - Tax Obligation already fulfilled</td>\n<td>An ORN for the specified period has already been submitted.</td>\n</tr>\n<tr>\n<td>063 - Business Partner does not have an Active Subscription for this Regime</td>\n<td>The Pillar 2 ID in the request header is not listed as active by HMRC for this regime. Please contact the central support team.</td>\n</tr>\n<tr>\n<td>093 - Invalid Return</td>\n<td>There is an error with the return you’ve submitted in the request.</td>\n</tr>\n</tbody>\n</table>\n"
       security:
       - userRestricted:
         - write:pillar2
@@ -1548,7 +1548,7 @@ paths:
         <tbody>
         <tr>
         <td>UKTR - DTT</td>
-        <td>Amount of Domestic Top-Up Tax payable as reported on the UK Pillar 2 Tax Return, applied to an account marked as domestic only.</td>
+        <td>Amount of Domestic Top-Up Tax payable as reported on the UK Pillar 2 Tax Return. A domestic-only or multinational can be liable for DTT.</td>
         </tr>
         <tr>
         <td>UKTR - MTT (IIR)</td>
@@ -2081,7 +2081,7 @@ components:
           description: "Specifies whether a multinational group owes IIR or UTPR Pillar 2 tax. In the case where a group is 'domestic only', then the value must be `false`."
         electionUKGAAP:
           type: boolean
-          description: "A means of calculating tax liability and profit. For domestic-only groups, the value must be `true`. For multinational groups, it must be `false`."
+          description: "A means of calculating tax liability and profit. For domestic-only groups, the value can be `true` or `false`. For multinational groups, it must always be `false`."
         liabilities:
           $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.LiabilityNilReturn"
       required:
@@ -2161,7 +2161,7 @@ components:
           description: The calendar date upon which a business' accounting period ends.
         obligationMTT:
           type: boolean
-          description: "Specifies whether a multinational group owes IIR or UTPR Pillar 2 tax. In the case where a group is 'domestic only', then the value must be `false`."
+          description: "Specifies whether a multinational group owes IIR or UTPR Pillar 2 tax. In the case where a group is 'domestic only', then the value must be `false`. Where a group is 'multinational', the value can be `true` or `false`."
         electionUKGAAP:
           type: boolean
           description: "A means of calculating tax liability and profit. For domestic-only groups, the value must be `true`. For multinational groups, it must be `false`."

--- a/resources/public/api/conf/1.0/testOnly/application.yaml
+++ b/resources/public/api/conf/1.0/testOnly/application.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.205.0
+  version: 0.208.0
   title: Pillar 2 API
   description: An API for managing and retrieving data in accordance with Pillar 2 tax rules.
 tags: []
@@ -665,15 +665,15 @@ paths:
         </tr>
         <tr>
         <td>097 - Invalid Total Liability IIR</td>
-        <td>The <em>totalLiabilityIIR</em> value does not match the <em>amountIIR value</em> from the <em>liableEntities</em> array. IIR values should only be entered by entities registered as a Multinational Enterprise. Please check the individual totals of each entity and submit the request again.</td>
+        <td>The <em>totalLiabilityIIR</em> value does not match the <em>amountIIR value</em> from the sum of <em>liableEntities</em> array. IIR values should only be entered by entities registered as a Multinational Enterprise. Please check the individual totals of each entity and submit the request again.</td>
         </tr>
         <tr>
         <td>098 - Invalid Total Liability DTT</td>
-        <td>The <em>totalLiabilityDTT</em> value does not match the <em>amountDTT</em> value from the <em>liableEntities</em> array. Please check the value of these fields matches and submit the request again.</td>
+        <td>The <em>totalLiabilityDTT</em> value does not match the <em>amountDTT</em> value from the sum of <em>liableEntities</em> array. Please check the value of these fields matches and submit the request again.</td>
         </tr>
         <tr>
         <td>099 - Invalid Total Liability UTPR</td>
-        <td>The <em>totalLiabilityUTPR</em> value does not match the <em>amountUTPR</em> value from the <em>liableEntities</em> array. UTPR values should only be entered by entities registered as a Multinational Enterprise. Please check the individual totals of each entity and submit the request again.</td>
+        <td>The <em>totalLiabilityUTPR</em> value does not match the <em>amountUTPR</em> value from the sum of <em>liableEntities</em> array. UTPR values should only be entered by entities registered as a Multinational Enterprise. Please check the individual totals of each entity and submit the request again.</td>
         </tr>
         </tbody>
         </table>
@@ -1148,7 +1148,7 @@ paths:
                   $ref: "#/components/examples/errors.Submission.GenericServerError"
                 No Subscription Data:
                   $ref: "#/components/examples/errors.Submission.NoSubscriptionData"
-      description: "Submits an Overseas Return Notification for an accounting period.\n### Error Codes\n<p>This table contains a list of 422 error codes returned when a Submit Overseas Return Notification request is not processed successfully.</p> \n<table>\n<thead>\n<tr>\n<th>Error Message</th>\n<th>Next Steps</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>003 - Request could not be processed</td>\n<td>The message could not be processed due to locking. Please make the following checks. Confirm if there is currently an open enquiry on your tax account. The <em>accountingPeriodFrom</em> and <em>accountingPeriodTo</em> date range should match the period defined in your test organisation. The <em>filedDateGIR</em> date should not be in the future. The <em>countryGIR</em> and <em>issuingCountryTIN</em> fields must conform to the ISO-3166 standard for country codes. In the organisation’s settings, the <em>accountStatus</em> should have the <em>inactive</em> flag set to “false\".\n</td>\n</tr>\n<tr>\n<td>044 - Tax Obligation already fulfilled</td>\n<td>A BTN for the specified period has already been submitted.</td>\n</tr>\n<tr>\n<td>063 - Business Partner does not have an Active Subscription for this Regime</td>\n<td>The Pillar 2 ID in the request header is not listed as active by HMRC for this regime. Please contact the central support team.</td>\n</tr>\n<tr>\n<td>093 - Invalid Return</td>\n<td>There is an error with the return you’ve submitted in the request.</td>\n</tr>\n</tbody>\n</table>\n"
+      description: "Submits an Overseas Return Notification for an accounting period.\n### Error Codes\n<p>This table contains a list of 422 error codes returned when a Submit Overseas Return Notification request is not processed successfully.</p> \n<table>\n<thead>\n<tr>\n<th>Error Message</th>\n<th>Next Steps</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>003 - Request could not be processed</td>\n<td>The message could not be processed due to locking. Please make the following checks. Confirm if there is currently an open enquiry on your tax account. The <em>accountingPeriodFrom</em> and <em>accountingPeriodTo</em> date range should match the period defined in your test organisation. The <em>filedDateGIR</em> date should not be in the future. The <em>countryGIR</em> and <em>issuingCountryTIN</em> fields must conform to the ISO-3166 standard for country codes. In the organisation’s settings, the <em>accountStatus</em> should have the <em>inactive</em> flag set to “false\".\n</td>\n</tr>\n<tr>\n<td>044 - Tax Obligation already fulfilled</td>\n<td>An ORN for the specified period has already been submitted.</td>\n</tr>\n<tr>\n<td>063 - Business Partner does not have an Active Subscription for this Regime</td>\n<td>The Pillar 2 ID in the request header is not listed as active by HMRC for this regime. Please contact the central support team.</td>\n</tr>\n<tr>\n<td>093 - Invalid Return</td>\n<td>There is an error with the return you’ve submitted in the request.</td>\n</tr>\n</tbody>\n</table>\n"
       security:
       - userRestricted:
         - write:pillar2
@@ -1548,7 +1548,7 @@ paths:
         <tbody>
         <tr>
         <td>UKTR - DTT</td>
-        <td>Amount of Domestic Top-Up Tax payable as reported on the UK Pillar 2 Tax Return, applied to an account marked as domestic only.</td>
+        <td>Amount of Domestic Top-Up Tax payable as reported on the UK Pillar 2 Tax Return. A domestic-only or multinational can be liable for DTT.</td>
         </tr>
         <tr>
         <td>UKTR - MTT (IIR)</td>
@@ -2081,7 +2081,7 @@ components:
           description: "Specifies whether a multinational group owes IIR or UTPR Pillar 2 tax. In the case where a group is 'domestic only', then the value must be `false`."
         electionUKGAAP:
           type: boolean
-          description: "A means of calculating tax liability and profit. For domestic-only groups, the value must be `true`. For multinational groups, it must be `false`."
+          description: "A means of calculating tax liability and profit. For domestic-only groups, the value can be `true` or `false`. For multinational groups, it must always be `false`."
         liabilities:
           $ref: "#/components/schemas/uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.LiabilityNilReturn"
       required:
@@ -2161,7 +2161,7 @@ components:
           description: The calendar date upon which a business' accounting period ends.
         obligationMTT:
           type: boolean
-          description: "Specifies whether a multinational group owes IIR or UTPR Pillar 2 tax. In the case where a group is 'domestic only', then the value must be `false`."
+          description: "Specifies whether a multinational group owes IIR or UTPR Pillar 2 tax. In the case where a group is 'domestic only', then the value must be `false`. Where a group is 'multinational', the value can be `true` or `false`."
         electionUKGAAP:
           type: boolean
           description: "A means of calculating tax liability and profit. For domestic-only groups, the value must be `true`. For multinational groups, it must be `false`."


### PR DESCRIPTION
Added to or replaced definitions that exist within the OAS, specifically around errors within the submit UKTR endpoint, and the differences between the MNE submissions and Domestic-only.