### PR TITLE
NOJIRA - Reverting API name - pipeline issue

### DIFF
--- a/it/test/uk/gov/hmrc/pillar2submissionapi/controllers/platform/DocumentationControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2submissionapi/controllers/platform/DocumentationControllerISpec.scala
@@ -41,7 +41,7 @@ class DocumentationControllerISpec extends IntegrationSpecBase {
       val url        = s"$baseUrl${routes.DocumentationController.definition().url}"
       val definition = Await.result(client.get(URI.create(url).toURL).execute[HttpResponse], 5.seconds)
       val json       = definition.json
-      (json \ "api" \ "name").as[String] mustEqual "Pillar 2"
+      (json \ "api" \ "name").as[String] mustEqual "Pillar 2 API"
       (json \ "api" \ "description").as[String] mustEqual "An API for managing and retrieving Pillar 2 data"
       (json \ "api" \ "context").as[String] mustEqual "organisations/pillar-two"
       (json \ "api" \ "categories").as[List[String]] must have size 1

--- a/resources/public/api/definition.json
+++ b/resources/public/api/definition.json
@@ -1,6 +1,6 @@
 {
   "api": {
-    "name": "Pillar 2",
+    "name": "Pillar 2 API",
     "description": "An API for managing and retrieving Pillar 2 data",
     "context": "organisations/pillar-two",
     "categories": ["CORPORATION_TAX"],


### PR DESCRIPTION
Reverting temporarily to unblock pipeline.

Issue:
```
Field 'name' cannot change from the previously published Pillar 2 API
```