### PR TITLE
PIL-2953: Replaced println's with logger

### DIFF
--- a/project/ApiLogger.scala
+++ b/project/ApiLogger.scala
@@ -1,7 +1,0 @@
-import org.slf4j.{Logger, LoggerFactory}
-
-object ApiLogger {
-
-  val log: Logger = LoggerFactory.getLogger("[API Logger]")
-
-}

--- a/project/ApiLogger.scala
+++ b/project/ApiLogger.scala
@@ -1,0 +1,7 @@
+import org.slf4j.{Logger, LoggerFactory}
+
+object ApiLogger {
+
+  val log: Logger = LoggerFactory.getLogger("[API Logger]")
+
+}

--- a/project/PublishTestOnlyOas.scala
+++ b/project/PublishTestOnlyOas.scala
@@ -16,7 +16,7 @@ object PublishTestOnlyOas {
 
       IO.createDirectory(targetDir)
       IO.copyFile(sourceFile, targetFile)
-      println(s"Successfully copied OpenAPI spec to: ${targetFile.getAbsolutePath}")
+      ApiLogger.log.info(s"Successfully copied OpenAPI spec to: ${targetFile.getAbsolutePath}")
     }
   )
 }

--- a/project/PublishTestOnlyOas.scala
+++ b/project/PublishTestOnlyOas.scala
@@ -16,7 +16,7 @@ object PublishTestOnlyOas {
 
       IO.createDirectory(targetDir)
       IO.copyFile(sourceFile, targetFile)
-      ApiLogger.log.info(s"Successfully copied OpenAPI spec to: ${targetFile.getAbsolutePath}")
+      streams.value.log.info(s"Successfully copied OpenAPI spec to: ${targetFile.getAbsolutePath}")
     }
   )
 }


### PR DESCRIPTION
The 3 areas that need to be moved to logger:
pillar2-api-tests (25 printlns)
pillar2-performance-tests (5 printlns)
pillar2-submission-api (1 println)