### PR TITLE
PIL-3079 Logging & Error Handling improvements

### DIFF
--- a/app/uk/gov/hmrc/pillar2submissionapi/connectors/TestOrganisationConnector.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/connectors/TestOrganisationConnector.scala
@@ -48,11 +48,11 @@ class TestOrganisationConnector @Inject() (
       .map { response =>
         response.status match {
           case 201 => Json.parse(response.body).as[TestOrganisationWithId]
-          case 409 => throw OrganisationAlreadyExists(pillar2Id)
+          case 409 => throw OrganisationAlreadyExistsError(pillar2Id)
           case 500 => throw DatabaseError("create")
           case _   =>
             logger.warn(s"Unexpected response from create organisation with status: ${response.status}")
-            throw UnexpectedResponse
+            throw UnexpectedResponseError
         }
       }
   }
@@ -67,10 +67,10 @@ class TestOrganisationConnector @Inject() (
       .map { response =>
         response.status match {
           case 200 => Json.parse(response.body).as[TestOrganisationWithId]
-          case 404 => throw OrganisationNotFound(pillar2Id)
+          case 404 => throw OrganisationNotFoundError(pillar2Id)
           case _   =>
             logger.warn(s"Unexpected response from get organisation with status: ${response.status}")
-            throw UnexpectedResponse
+            throw UnexpectedResponseError
         }
       }
   }
@@ -86,11 +86,11 @@ class TestOrganisationConnector @Inject() (
       .map { response =>
         response.status match {
           case 200 => Json.parse(response.body).as[TestOrganisationWithId]
-          case 404 => throw OrganisationNotFound(pillar2Id)
+          case 404 => throw OrganisationNotFoundError(pillar2Id)
           case 500 => throw DatabaseError("update")
           case _   =>
             logger.warn(s"Unexpected response from update organisation with status: ${response.status}")
-            throw UnexpectedResponse
+            throw UnexpectedResponseError
         }
       }
   }
@@ -105,11 +105,11 @@ class TestOrganisationConnector @Inject() (
       .map { response =>
         response.status match {
           case 204 => ()
-          case 404 => throw OrganisationNotFound(pillar2Id)
+          case 404 => throw OrganisationNotFoundError(pillar2Id)
           case 500 => throw DatabaseError("Failed to delete organisation and submission data")
           case _   =>
             logger.warn(s"Unexpected response from delete organisation with status: ${response.status}")
-            throw UnexpectedResponse
+            throw UnexpectedResponseError
         }
       }
   }

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandler.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandler.scala
@@ -43,15 +43,16 @@ class Pillar2ErrorHandler extends HttpErrorHandler with Logging {
     exception match {
       case e: Pillar2Error =>
         val ret = e match {
-          case InvalidDateRange | InvalidDateFormat | InvalidJson | EmptyRequestBody | MissingHeader(_) | IncorrectHeaderValue =>
+          case InvalidDateRangeError | InvalidDateFormatError | InvalidJsonError | EmptyRequestBodyError | MissingHeaderError(_) |
+              IncorrectHeaderValueError =>
             Results.BadRequest(Pillar2ErrorResponse(e.code, e.message))
-          case MissingCredentials | InvalidCredentials                       => Results.Unauthorized(Pillar2ErrorResponse(e.code, e.message))
-          case ForbiddenError | InvalidEnrolment | TestEndpointDisabled      => Results.Forbidden(Pillar2ErrorResponse(e.code, e.message))
-          case OrganisationNotFound(_) | ORNNotFoundException                => Results.NotFound(Pillar2ErrorResponse(e.code, e.message))
-          case OrganisationAlreadyExists(_)                                  => Results.Conflict(Pillar2ErrorResponse(e.code, e.message))
-          case DownstreamValidationError(_, _)                               => Results.UnprocessableEntity(Pillar2ErrorResponse(e.code, e.message))
-          case AccountActivityNotAvailable                                   => Results.NotImplemented(Pillar2ErrorResponse(e.code, e.message))
-          case DatabaseError(_) | UnexpectedResponse | NoSubscriptionData(_) =>
+          case MissingCredentialsError | InvalidCredentialsError                  => Results.Unauthorized(Pillar2ErrorResponse(e.code, e.message))
+          case ForbiddenError | InvalidEnrolmentError | TestEndpointDisabledError => Results.Forbidden(Pillar2ErrorResponse(e.code, e.message))
+          case OrganisationNotFoundError(_) | ORNNotFoundError                    => Results.NotFound(Pillar2ErrorResponse(e.code, e.message))
+          case OrganisationAlreadyExistsError(_)                                  => Results.Conflict(Pillar2ErrorResponse(e.code, e.message))
+          case DownstreamValidationError(_, _)  => Results.UnprocessableEntity(Pillar2ErrorResponse(e.code, e.message))
+          case AccountActivityNotAvailableError => Results.NotImplemented(Pillar2ErrorResponse(e.code, e.message))
+          case DatabaseError(_) | UnexpectedResponseError | NoSubscriptionDataError(_) =>
             Results.InternalServerError(Pillar2ErrorResponse(e.code, e.message))
         }
         logger.warn(s"Caught Pillar2Error. Returning ${ret.header.status} status code", exception)

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/accountactivity/AccountActivityController.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/accountactivity/AccountActivityController.scala
@@ -22,7 +22,7 @@ import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2submissionapi.config.AppConfig
 import uk.gov.hmrc.pillar2submissionapi.controllers.actions.{IdentifierAction, Pillar2IdHeaderExistsAction}
-import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{AccountActivityNotAvailable, InvalidDateFormat, InvalidDateRange}
+import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{AccountActivityNotAvailableError, InvalidDateFormatError, InvalidDateRangeError}
 import uk.gov.hmrc.pillar2submissionapi.services.AccountActivityService
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
@@ -42,7 +42,7 @@ class AccountActivityController @Inject() (
     with Logging {
 
   private def checkAccountActivityEnabled[A](block: => Future[A]): Future[A] =
-    if (config.accountActivityEnabled) block else Future.failed(AccountActivityNotAvailable)
+    if (config.accountActivityEnabled) block else Future.failed(AccountActivityNotAvailableError)
 
   def retrieveAccountActivity(fromDate: String, toDate: String): Action[AnyContent] =
     (pillar2IdAction andThen identify).async { request =>
@@ -52,9 +52,9 @@ class AccountActivityController @Inject() (
         Try(LocalDate.parse(fromDate))
           .flatMap(from => Try(LocalDate.parse(toDate)).map(to => (from, to)))
           .fold(
-            _ => Future.failed(InvalidDateFormat),
+            _ => Future.failed(InvalidDateFormatError),
             (from, to) =>
-              if from.isAfter(to) then Future.failed(InvalidDateRange)
+              if from.isAfter(to) then Future.failed(InvalidDateRangeError)
               else {
                 accountActivityService
                   .retrieveAccountActivity(fromDate = from, toDate = to)

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/actions/AuthenticatedIdentifierAction.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/actions/AuthenticatedIdentifierAction.scala
@@ -57,7 +57,7 @@ class AuthenticatedIdentifierAction @Inject() (
     enrolments
   ) match {
     case Some(pillar2Id) =>
-      if (request.pillar2Id != pillar2Id) throw IncorrectHeaderValue
+      if (request.pillar2Id != pillar2Id) throw IncorrectHeaderValueError
       else
         Future.successful(
           IdentifierRequest(
@@ -70,12 +70,12 @@ class AuthenticatedIdentifierAction @Inject() (
         )
     case None =>
       logger.warn(s"Invalid Pillar2 enrolment - userId: $internalId")
-      Future.failed(InvalidEnrolment)
+      Future.failed(InvalidEnrolmentError)
   }
 
   override protected def transform[A](request: RequestWithPillar2Id[A]): Future[IdentifierRequest[A]] = {
     given hc: HeaderCarrier = HeaderCarrierConverter.fromRequest(request)
-    if (!request.headers.get(HeaderNames.authorisation).exists(_.trim.nonEmpty)) throw MissingCredentials
+    if (!request.headers.get(HeaderNames.authorisation).exists(_.trim.nonEmpty)) throw MissingCredentialsError
     else {
       val retrievals = Retrievals.internalId and Retrievals.groupIdentifier and
         Retrievals.allEnrolments and Retrievals.affinityGroup and
@@ -96,7 +96,7 @@ class AuthenticatedIdentifierAction @Inject() (
             Future.failed(ForbiddenError)
         } recoverWith { case e: AuthorisationException =>
         logger.warn(s"Authorization failed", e)
-        Future.failed(InvalidCredentials)
+        Future.failed(InvalidCredentialsError)
       }
     }
   }

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/actions/Pillar2IdHeaderExistsAction.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/actions/Pillar2IdHeaderExistsAction.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.pillar2submissionapi.controllers.actions
 
 import com.google.inject.Inject
 import play.api.mvc.{BodyParsers, Request}
-import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.MissingHeader.MissingPillar2Id
+import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.MissingHeaderError
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -32,7 +32,7 @@ case class Pillar2IdHeaderExistsAction @Inject() (
       .get("X-Pillar2-Id")
       .fold(
         Future.failed[RequestWithPillar2Id[A]](
-          MissingPillar2Id
+          MissingHeaderError("X-Pillar2-Id")
         )
       )(pillar2Id => Future.successful(RequestWithPillar2Id(pillar2Id = pillar2Id, request = request)))
 

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/actions/SubscriptionDataRetrievalAction.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/actions/SubscriptionDataRetrievalAction.scala
@@ -20,7 +20,7 @@ import play.api.Logging
 import play.api.mvc.ActionTransformer
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2submissionapi.connectors.SubscriptionConnector
-import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.NoSubscriptionData
+import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.NoSubscriptionDataError
 import uk.gov.hmrc.pillar2submissionapi.models.requests.{IdentifierRequest, SubscriptionDataRequest}
 import uk.gov.hmrc.play.http.HeaderCarrierConverter
 
@@ -39,7 +39,7 @@ class SubscriptionDataRetrievalActionImpl @Inject() (
     subscriptionConnector.readSubscription(request.clientPillar2Id).flatMap {
       case Left(result) =>
         logger.warn(s"Cannot find subscription with result: ${result.header.headers} and ${result.body}")
-        Future.failed(NoSubscriptionData(request.clientPillar2Id))
+        Future.failed(NoSubscriptionDataError(request.clientPillar2Id))
       case Right(subscriptionData) =>
         Future.successful(
           SubscriptionDataRequest(

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/obligationsandsubmissions/ObligationsAndSubmissionsController.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/obligationsandsubmissions/ObligationsAndSubmissionsController.scala
@@ -20,7 +20,7 @@ import play.api.libs.json.Json
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2submissionapi.controllers.actions.{IdentifierAction, Pillar2IdHeaderExistsAction}
-import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{InvalidDateFormat, InvalidDateRange}
+import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{InvalidDateFormatError, InvalidDateRangeError}
 import uk.gov.hmrc.pillar2submissionapi.models.obligationsandsubmissions.ObligationsAndSubmissions
 import uk.gov.hmrc.pillar2submissionapi.services.ObligationsAndSubmissionsService
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
@@ -48,7 +48,7 @@ class ObligationsAndSubmissionsController @Inject() (
         obligationAndSubmissionsService
           .handleData(accountingPeriod.fromDate, accountingPeriod.toDate)
           .map(response => Ok(Json.toJson(response)))
-      } else { Future.failed(InvalidDateRange) }
-    }.getOrElse(Future.failed(InvalidDateFormat))
+      } else { Future.failed(InvalidDateRangeError) }
+    }.getOrElse(Future.failed(InvalidDateFormatError))
   }
 }

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/submission/BTNSubmissionController.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/submission/BTNSubmissionController.scala
@@ -21,7 +21,7 @@ import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2submissionapi.controllers.actions.{IdentifierAction, Pillar2IdHeaderExistsAction, SubscriptionDataRetrievalAction}
 import uk.gov.hmrc.pillar2submissionapi.models.belowthresholdnotification.BTNSubmission
-import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{EmptyRequestBody, InvalidJson}
+import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{EmptyRequestBodyError, InvalidJsonError}
 import uk.gov.hmrc.pillar2submissionapi.services.SubmitBTNService
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import uk.gov.hmrc.play.http.HeaderCarrierConverter
@@ -48,9 +48,9 @@ class BTNSubmissionController @Inject() (
             submitBTNService
               .submitBTN(value)
               .map(response => Created(Json.toJson(response)))
-          case JsError(_) => Future.failed(InvalidJson)
+          case JsError(_) => Future.failed(InvalidJsonError)
         }
-      case None => Future.failed(EmptyRequestBody)
+      case None => Future.failed(EmptyRequestBodyError)
     }
   }
 }

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/submission/OverseasReturnNotificationController.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/submission/OverseasReturnNotificationController.scala
@@ -51,9 +51,9 @@ class OverseasReturnNotificationController @Inject() (
             ornService
               .submitORN(value)
               .map(response => Created(Json.toJson(response)))
-          case JsError(_) => Future.failed(InvalidJson)
+          case JsError(_) => Future.failed(InvalidJsonError)
         }
-      case None => Future.failed(EmptyRequestBody)
+      case None => Future.failed(EmptyRequestBodyError)
     }
   }
 
@@ -66,9 +66,9 @@ class OverseasReturnNotificationController @Inject() (
             ornService
               .amendORN(value)
               .map(response => Ok(Json.toJson(response)))
-          case JsError(_) => Future.failed(InvalidJson)
+          case JsError(_) => Future.failed(InvalidJsonError)
         }
-      case None => Future.failed(EmptyRequestBody)
+      case None => Future.failed(EmptyRequestBodyError)
     }
   }
 
@@ -83,7 +83,7 @@ class OverseasReturnNotificationController @Inject() (
           ornService
             .retrieveORN(accountingPeriodFrom, accountingPeriodTo)(using hc)
             .map(response => Ok(Json.toJson(response)))
-        } else { Future.failed(InvalidDateRange) }
-      }.getOrElse(Future.failed(InvalidDateFormat))
+        } else { Future.failed(InvalidDateRangeError) }
+      }.getOrElse(Future.failed(InvalidDateFormatError))
     }
 }

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/submission/UKTaxReturnController.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/submission/UKTaxReturnController.scala
@@ -53,9 +53,9 @@ class UKTaxReturnController @Inject() (
             ukTaxReturnService
               .submitUKTR(value)
               .map(response => Created(Json.toJson(response)))
-          case JsError(_) => Future.failed(InvalidJson)
+          case JsError(_) => Future.failed(InvalidJsonError)
         }
-      case None => Future.failed(EmptyRequestBody)
+      case None => Future.failed(EmptyRequestBodyError)
     }
   }
 
@@ -71,9 +71,9 @@ class UKTaxReturnController @Inject() (
             ukTaxReturnService
               .amendUKTR(value)
               .map(response => Ok(Json.toJson(response)))
-          case JsError(_) => Future.failed(InvalidJson)
+          case JsError(_) => Future.failed(InvalidJsonError)
         }
-      case None => Future.failed(EmptyRequestBody)
+      case None => Future.failed(EmptyRequestBodyError)
     }
   }
 }

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/test/GIRController.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/test/GIRController.scala
@@ -21,7 +21,7 @@ import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2submissionapi.config.AppConfig
 import uk.gov.hmrc.pillar2submissionapi.controllers.actions.{IdentifierAction, Pillar2IdHeaderExistsAction}
-import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{EmptyRequestBody, InvalidJson, TestEndpointDisabled}
+import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{EmptyRequestBodyError, InvalidJsonError, TestEndpointDisabledError}
 import uk.gov.hmrc.pillar2submissionapi.models.globeinformationreturn.GIRSubmission
 import uk.gov.hmrc.pillar2submissionapi.services.GIRService
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
@@ -41,7 +41,7 @@ class GIRController @Inject() (
     extends BackendController(cc) {
 
   private def checkTestEndpointsEnabled[A](block: => Future[A]): Future[A] =
-    if (config.testOrganisationEnabled) block else Future.failed(TestEndpointDisabled)
+    if (config.testOrganisationEnabled) block else Future.failed(TestEndpointDisabledError)
 
   def createGIR: Action[AnyContent] = (pillar2IdAction andThen identify).async { request =>
     given hc: HeaderCarrier = HeaderCarrierConverter.fromRequest(request).withExtraHeaders("X-Pillar2-Id" -> request.clientPillar2Id)
@@ -54,9 +54,9 @@ class GIRController @Inject() (
               girService
                 .createGIR(value)
                 .map(response => Created(Json.toJson(response)))
-            case JsError(_) => Future.failed(InvalidJson)
+            case JsError(_) => Future.failed(InvalidJsonError)
           }
-        case None => Future.failed(EmptyRequestBody)
+        case None => Future.failed(EmptyRequestBodyError)
       }
     }
   }
@@ -72,9 +72,9 @@ class GIRController @Inject() (
               girService
                 .amendGIR(value)
                 .map(response => Ok(Json.toJson(response)))
-            case JsError(_) => Future.failed(InvalidJson)
+            case JsError(_) => Future.failed(InvalidJsonError)
           }
-        case None => Future.failed(EmptyRequestBody)
+        case None => Future.failed(EmptyRequestBodyError)
       }
     }
   }
@@ -90,9 +90,9 @@ class GIRController @Inject() (
               girService
                 .deleteGIR(value)
                 .map(response => Ok(Json.toJson(response)))
-            case JsError(_) => Future.failed(InvalidJson)
+            case JsError(_) => Future.failed(InvalidJsonError)
           }
-        case None => Future.failed(EmptyRequestBody)
+        case None => Future.failed(EmptyRequestBodyError)
       }
     }
   }

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/test/TestOrganisationController.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/test/TestOrganisationController.scala
@@ -41,7 +41,7 @@ class TestOrganisationController @Inject() (
     extends BackendController(cc) {
 
   private def checkTestEndpointsEnabled[A](block: => Future[A]): Future[A] =
-    if (config.testOrganisationEnabled) block else Future.failed(TestEndpointDisabled)
+    if (config.testOrganisationEnabled) block else Future.failed(TestEndpointDisabledError)
 
   def createTestOrganisation: Action[AnyContent] = (pillar2IdAction andThen identify).async { request =>
     given HeaderCarrier = HeaderCarrierConverter.fromRequest(request)
@@ -50,15 +50,15 @@ class TestOrganisationController @Inject() (
         case Some(json) =>
           json.validate[TestOrganisationRequest] match {
             case JsSuccess(value, _) =>
-              if (!value.accountingPeriod.endDate.isAfter(value.accountingPeriod.startDate)) Future.failed(InvalidDateRange)
+              if (!value.accountingPeriod.endDate.isAfter(value.accountingPeriod.startDate)) Future.failed(InvalidDateRangeError)
               else
                 testOrganisationService
                   .createTestOrganisation(request.clientPillar2Id, value)
                   .map(response => Created(Json.toJson(response)))
 
-            case JsError(_) => Future.failed(InvalidJson)
+            case JsError(_) => Future.failed(InvalidJsonError)
           }
-        case None => Future.failed(EmptyRequestBody)
+        case None => Future.failed(EmptyRequestBodyError)
       }
     }
   }
@@ -79,14 +79,14 @@ class TestOrganisationController @Inject() (
         case Some(json) =>
           json.validate[TestOrganisationRequest] match {
             case JsSuccess(value, _) =>
-              if (!value.accountingPeriod.endDate.isAfter(value.accountingPeriod.startDate)) Future.failed(InvalidDateRange)
+              if (!value.accountingPeriod.endDate.isAfter(value.accountingPeriod.startDate)) Future.failed(InvalidDateRangeError)
               else
                 testOrganisationService
                   .updateTestOrganisation(request.clientPillar2Id, value)
                   .map(response => Ok(Json.toJson(response)))
-            case JsError(_) => Future.failed(InvalidJson)
+            case JsError(_) => Future.failed(InvalidJsonError)
           }
-        case None => Future.failed(EmptyRequestBody)
+        case None => Future.failed(EmptyRequestBodyError)
       }
     }
   }

--- a/app/uk/gov/hmrc/pillar2submissionapi/models/error/Pillar2Error.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/models/error/Pillar2Error.scala
@@ -17,107 +17,104 @@
 package uk.gov.hmrc.pillar2submissionapi.models.error
 
 sealed trait Pillar2Error extends Exception {
-  val code:    String
-  val message: String
+  def code:    String
+  def message: String
+
+  override def getMessage: String = s"Code: '$code' Message: '$message'"
 }
 
 object Pillar2Error {
 
-  case object InvalidDateRange extends Pillar2Error {
-    val code    = "INVALID_DATE_RANGE"
-    val message = "Invalid date range"
+  case object InvalidDateRangeError extends Pillar2Error {
+    val code:    String = "INVALID_DATE_RANGE"
+    val message: String = "Invalid date range"
   }
 
-  case object InvalidDateFormat extends Pillar2Error {
-    val code    = "INVALID_DATE_FORMAT"
-    val message = "Invalid date format"
+  case object InvalidDateFormatError extends Pillar2Error {
+    val code:    String = "INVALID_DATE_FORMAT"
+    val message: String = "Invalid date format"
   }
 
-  case object InvalidJson extends Pillar2Error {
-    val code    = "INVALID_JSON"
-    val message = "Invalid JSON payload"
+  case object InvalidJsonError extends Pillar2Error {
+    val code:    String = "INVALID_JSON"
+    val message: String = "Invalid JSON payload"
   }
 
-  case object EmptyRequestBody extends Pillar2Error {
-    val code    = "EMPTY_REQUEST_BODY"
-    val message = "Empty request body"
+  case object EmptyRequestBodyError extends Pillar2Error {
+    val code:    String = "EMPTY_REQUEST_BODY"
+    val message: String = "Empty request body"
   }
 
-  case object UnexpectedResponse extends Pillar2Error {
+  case object MissingCredentialsError extends Pillar2Error {
+    val code:    String = "MISSING_CREDENTIALS"
+    val message: String = "Authentication information is not provided"
+  }
+
+  case object InvalidCredentialsError extends Pillar2Error {
+    val code:    String = "INVALID_CREDENTIALS"
+    val message: String = "Invalid Authentication information provided"
+  }
+
+  final case class MissingHeaderError(headerName: String) extends Pillar2Error {
+    val code:    String = "MISSING_HEADER"
+    val message: String = s"Please provide the $headerName header"
+  }
+
+  case object ForbiddenError extends Pillar2Error {
+    val code:    String = "FORBIDDEN"
+    val message: String = "Access to the requested resource is forbidden"
+  }
+
+  case object IncorrectHeaderValueError extends Pillar2Error {
+    val code:    String = "INCORRECT_HEADER_VALUE"
+    val message: String = "X-Pillar2-Id Header value does not match the bearer token"
+  }
+
+  case object InvalidEnrolmentError extends Pillar2Error {
+    val code:    String = "INVALID_ENROLMENT"
+    val message: String = "Invalid Pillar 2 enrolment"
+  }
+
+  case object TestEndpointDisabledError extends Pillar2Error {
+    val code:    String = "TEST_ENDPOINT_DISABLED"
+    val message: String = "Test endpoints are not available in this environment"
+  }
+
+  case object ORNNotFoundError extends Pillar2Error {
+    val code:    String = "NOT_FOUND"
+    val message: String = "The requested ORN could not be found"
+  }
+
+  case object AccountActivityNotAvailableError extends Pillar2Error {
+    val code:    String = "NOT_IMPLEMENTED"
+    val message: String = "Account activity is not available in this environment"
+  }
+
+  final case class NoSubscriptionDataError(pillar2Id: String) extends Pillar2Error {
+    val code:    String = "004"
+    val message: String = s"No Pillar2 subscription found for $pillar2Id"
+  }
+
+  final case class OrganisationNotFoundError(pillar2Id: String) extends Pillar2Error {
+    val code:    String = "404"
+    val message: String = s"Organisation not found for pillar2Id: $pillar2Id"
+  }
+
+  final case class OrganisationAlreadyExistsError(pillar2Id: String) extends Pillar2Error {
+    val code:    String = "409"
+    val message: String = s"Organisation with pillar2Id: $pillar2Id already exists"
+  }
+
+  final case class DatabaseError(operation: String) extends Pillar2Error {
+    val code:    String = "500"
+    val message: String = s"Failed to $operation organisation due to database error"
+  }
+
+  case object UnexpectedResponseError extends Pillar2Error {
     val code:    String = "500"
     val message: String = "Internal Server Error"
   }
 
-  case object MissingCredentials extends Pillar2Error {
-    val code = "MISSING_CREDENTIALS"
-    val message: String = "Authentication information is not provided"
-  }
-
-  case object InvalidCredentials extends Pillar2Error {
-    val code = "INVALID_CREDENTIALS"
-    val message: String = "Invalid Authentication information provided"
-  }
-
-  case class NoSubscriptionData(pillar2Id: String) extends Pillar2Error {
-    val code = "004"
-    val message: String = s"No Pillar2 subscription found for $pillar2Id"
-  }
-
-  case class MissingHeader(message: String) extends Pillar2Error {
-    val code = "MISSING_HEADER"
-  }
-
-  object MissingHeader {
-    val MissingPillar2Id: MissingHeader = MissingHeader(
-      "Please provide the X-Pillar2-Id header"
-    )
-  }
-
-  case object ForbiddenError extends Pillar2Error {
-    val code    = "FORBIDDEN"
-    val message = "Access to the requested resource is forbidden"
-  }
-
-  case object IncorrectHeaderValue extends Pillar2Error {
-    val code    = "INCORRECT_HEADER_VALUE"
-    val message = "X-Pillar2-Id Header value does not match the bearer token"
-  }
-
-  case object InvalidEnrolment extends Pillar2Error {
-    val code    = "INVALID_ENROLMENT"
-    val message = "Invalid Pillar 2 enrolment"
-  }
-
-  case class DownstreamValidationError(code: String, message: String) extends Pillar2Error
-
-  case class OrganisationAlreadyExists(pillar2Id: String) extends Pillar2Error {
-    override val code:    String = "409"
-    override val message: String = s"Organisation with pillar2Id: $pillar2Id already exists"
-  }
-
-  case class OrganisationNotFound(pillar2Id: String) extends Pillar2Error {
-    override val code:    String = "404"
-    override val message: String = s"Organisation not found for pillar2Id: $pillar2Id"
-  }
-
-  case class DatabaseError(operation: String) extends Pillar2Error {
-    override val code:    String = "500"
-    override val message: String = s"Failed to $operation organisation due to database error"
-  }
-
-  case object TestEndpointDisabled extends Pillar2Error {
-    override val code:    String = "TEST_ENDPOINT_DISABLED"
-    override val message: String = "Test endpoints are not available in this environment"
-  }
-
-  case object ORNNotFoundException extends Pillar2Error {
-    override val code:    String = "NOT_FOUND"
-    override val message: String = "The requested ORN could not be found"
-  }
-
-  case object AccountActivityNotAvailable extends Pillar2Error {
-    override val code:    String = "NOT_IMPLEMENTED"
-    override val message: String = "Account activity is not available in this environment"
-  }
+  final case class DownstreamValidationError(code: String, message: String) extends Pillar2Error
 
 }

--- a/app/uk/gov/hmrc/pillar2submissionapi/services/AccountActivityService.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/services/AccountActivityService.scala
@@ -24,7 +24,7 @@ import play.api.libs.json.{JsError, JsSuccess}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2submissionapi.connectors.AccountActivityConnector
 import uk.gov.hmrc.pillar2submissionapi.models.accountactivity.{AccountActivityErrorResponse, AccountActivitySuccessResponse}
-import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{DownstreamValidationError, UnexpectedResponse}
+import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{DownstreamValidationError, UnexpectedResponseError}
 import uk.gov.hmrc.pillar2submissionapi.models.error._
 
 import java.time.LocalDate
@@ -47,36 +47,36 @@ class AccountActivityService @Inject() (accountActivityConnector: AccountActivit
       Try(response.json.validate[AccountActivitySuccessResponse]).fold(
         error =>
           logger.error(s"Exception reading json body from 200: $error")
-          UnexpectedResponse.asLeft
+          UnexpectedResponseError.asLeft
         ,
         {
           case JsError(errors) =>
             logger.error(s"Failed to parse json in 200: $errors")
-            UnexpectedResponse.asLeft
+            UnexpectedResponseError.asLeft
           case JsSuccess(parsed, _) => parsed.asRight
         }
       )
 
     case BAD_REQUEST | UNAUTHORIZED | INTERNAL_SERVER_ERROR =>
       logger.warn(s"Hit error status ${response.status}, but mapping to 500.")
-      UnexpectedResponse.asLeft
+      UnexpectedResponseError.asLeft
 
     case UNPROCESSABLE_ENTITY =>
       Try(response.json.validate[AccountActivityErrorResponse]).fold(
         error =>
           logger.error(s"Failed to parse unprocessable entity body from 422: $error")
-          UnexpectedResponse.asLeft
+          UnexpectedResponseError.asLeft
         ,
         {
           case JsSuccess(response, _) => DownstreamValidationError(code = response.code, message = response.message).asLeft
           case JsError(errors)        =>
             logger.error(s"Failed to parse unprocessable entity body from 422: $errors")
-            UnexpectedResponse.asLeft
+            UnexpectedResponseError.asLeft
         }
       )
 
     case unexpectedStatus =>
       logger.error(s"Unexpected status $unexpectedStatus from account activity")
-      UnexpectedResponse.asLeft
+      UnexpectedResponseError.asLeft
   }
 }

--- a/app/uk/gov/hmrc/pillar2submissionapi/services/GIRService.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/services/GIRService.scala
@@ -21,7 +21,7 @@ import play.api.libs.json.{JsError, JsSuccess}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.HttpResponse
 import uk.gov.hmrc.pillar2submissionapi.connectors.GIRConnector
-import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{DownstreamValidationError, UnexpectedResponse}
+import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{DownstreamValidationError, UnexpectedResponseError}
 import uk.gov.hmrc.pillar2submissionapi.models.globeinformationreturn.GIRSubmission
 import uk.gov.hmrc.pillar2submissionapi.models.globeinformationreturn.SubmitGIRErrorResponse
 import uk.gov.hmrc.pillar2submissionapi.models.globeinformationreturn.SubmitGIRSuccessResponse
@@ -54,17 +54,17 @@ class GIRService @Inject() (
           case JsSuccess(success, _) => success
           case JsError(e)            =>
             logger.error(s"Error while parsing the backend response" + response.body + e)
-            throw UnexpectedResponse
+            throw UnexpectedResponseError
         }
       case 422 =>
         response.json.validate[SubmitGIRErrorResponse] match {
           case JsSuccess(response, _) => throw DownstreamValidationError(response.errors.code, response.errors.text)
           case JsError(e)             =>
             logger.error(s"Error while unprocessable entity response" + response.body + e)
-            throw UnexpectedResponse
+            throw UnexpectedResponseError
         }
       case status =>
         logger.error(s"Error while calling pillar2 backend. Got status: $status")
-        throw UnexpectedResponse
+        throw UnexpectedResponseError
     }
 }

--- a/app/uk/gov/hmrc/pillar2submissionapi/services/ObligationsAndSubmissionsService.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/services/ObligationsAndSubmissionsService.scala
@@ -21,7 +21,7 @@ import play.api.libs.json.Format.GenericFormat
 import play.api.libs.json.{JsError, JsSuccess}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2submissionapi.connectors.ObligationAndSubmissionsConnector
-import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{DownstreamValidationError, UnexpectedResponse}
+import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{DownstreamValidationError, UnexpectedResponseError}
 import uk.gov.hmrc.pillar2submissionapi.models.obligationsandsubmissions.{ObligationsAndSubmissionsErrorResponse, ObligationsAndSubmissionsSuccessResponse}
 
 import java.time.LocalDate
@@ -43,17 +43,17 @@ class ObligationsAndSubmissionsService @Inject() (
           case JsSuccess(success, _) => success
           case JsError(_)            =>
             logger.error("Failed to parse success response")
-            throw UnexpectedResponse
+            throw UnexpectedResponseError
         }
       case 422 =>
         response.json.validate[ObligationsAndSubmissionsErrorResponse] match {
           case JsSuccess(response, _) => throw DownstreamValidationError(response.code, response.message)
           case JsError(_)             =>
             logger.error("Failed to parse unprocessible entity response")
-            throw UnexpectedResponse
+            throw UnexpectedResponseError
         }
       case status =>
         logger.error(s"Error calling pillar2 backend. Got response: $status")
-        throw UnexpectedResponse
+        throw UnexpectedResponseError
     }
 }

--- a/app/uk/gov/hmrc/pillar2submissionapi/services/OverseasReturnNotificationService.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/services/OverseasReturnNotificationService.scala
@@ -21,7 +21,7 @@ import play.api.Logging
 import play.api.libs.json.{JsError, JsSuccess, Json}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2submissionapi.connectors.OverseasReturnNotificationConnector
-import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{DownstreamValidationError, ORNNotFoundException, UnexpectedResponse}
+import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{DownstreamValidationError, ORNNotFoundError, UnexpectedResponseError}
 import uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -45,18 +45,18 @@ class OverseasReturnNotificationService @Inject() (connector: OverseasReturnNoti
           case JsSuccess(success, _) => success
           case JsError(errors)       =>
             logger.error(s"Failed to parse success response. Errors: ${errors.toString()}")
-            throw UnexpectedResponse
+            throw UnexpectedResponseError
         }
       case 422 =>
         response.json.validate[ORNErrorResponse] match {
           case JsSuccess(response, _) => throw DownstreamValidationError(response.code, response.message)
           case JsError(_)             =>
             logger.error("Failed to parse unprocessible entity response")
-            throw UnexpectedResponse
+            throw UnexpectedResponseError
         }
       case status =>
         logger.error(s"Error calling pillar2 backend. Got response: $status")
-        throw UnexpectedResponse
+        throw UnexpectedResponseError
     }
 
   private def convertToRetrieveResult(response: HttpResponse): ORNRetrieveSuccessResponse =
@@ -70,22 +70,22 @@ class OverseasReturnNotificationService @Inject() (connector: OverseasReturnNoti
           case JsError(errors) =>
             logger.error(s"Failed to parse success response. Errors: ${errors.toString()}")
             logger.error(s"JSON structure: ${Json.prettyPrint(response.json)}")
-            throw UnexpectedResponse
+            throw UnexpectedResponseError
         }
       case 422 =>
         response.json.validate[ORNErrorResponse] match {
           case JsSuccess(response, _) =>
             if (response.code == "005" && response.message.contains("No Form Bundle found")) {
-              throw ORNNotFoundException
+              throw ORNNotFoundError
             } else {
               throw DownstreamValidationError(response.code, response.message)
             }
           case JsError(_) =>
             logger.error("Failed to parse unprocessible entity response")
-            throw UnexpectedResponse
+            throw UnexpectedResponseError
         }
       case status =>
         logger.error(s"Error calling pillar2 backend. Got response: $status")
-        throw UnexpectedResponse
+        throw UnexpectedResponseError
     }
 }

--- a/app/uk/gov/hmrc/pillar2submissionapi/services/SubmitBTNService.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/services/SubmitBTNService.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2submissionapi.connectors.SubmitBTNConnector
 import uk.gov.hmrc.pillar2submissionapi.models.belowthresholdnotification.{BTNSubmission, SubmitBTNSuccessResponse}
 import uk.gov.hmrc.pillar2submissionapi.models.btn.BTNSuccessResponse
-import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{DownstreamValidationError, UnexpectedResponse}
+import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{DownstreamValidationError, UnexpectedResponseError}
 import uk.gov.hmrc.pillar2submissionapi.models.hip.ApiFailureResponse
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -41,17 +41,17 @@ class SubmitBTNService @Inject() (submitBTNConnector: SubmitBTNConnector)(using 
           case JsSuccess(wrapper, _) => SubmitBTNSuccessResponse(wrapper.success.processingDate.toString)
           case JsError(_)            =>
             logger.error("Failed to parse success response")
-            throw UnexpectedResponse
+            throw UnexpectedResponseError
         }
       case 422 =>
         response.json.validate[ApiFailureResponse] match {
           case JsSuccess(apiFailure, _) => throw DownstreamValidationError(apiFailure.errors.code, apiFailure.errors.text)
           case JsError(_)               =>
             logger.error("Failed to parse unprocessible entity response")
-            throw UnexpectedResponse
+            throw UnexpectedResponseError
         }
       case status =>
         logger.error(s"Error calling pillar2 backend. Got response: $status")
-        throw UnexpectedResponse
+        throw UnexpectedResponseError
     }
 }

--- a/app/uk/gov/hmrc/pillar2submissionapi/services/UKTaxReturnService.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/services/UKTaxReturnService.scala
@@ -22,7 +22,7 @@ import play.api.http.Status.{CREATED, OK, UNPROCESSABLE_ENTITY}
 import play.api.libs.json._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2submissionapi.connectors.UKTaxReturnConnector
-import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{DownstreamValidationError, UnexpectedResponse}
+import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{DownstreamValidationError, UnexpectedResponseError}
 import uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.UKTRSubmission
 import uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.responses.UKTRSubmitSuccessResponse
 
@@ -44,17 +44,17 @@ class UKTaxReturnService @Inject() (ukTaxReturnConnector: UKTaxReturnConnector)(
           case JsSuccess(success, _) => success
           case JsError(_)            =>
             logger.error(s"Error while parsing the backend response")
-            throw UnexpectedResponse
+            throw UnexpectedResponseError
         }
       case UNPROCESSABLE_ENTITY =>
         response.json.validate[UKTRSubmitErrorResponse] match {
           case JsSuccess(response, _) => throw DownstreamValidationError(response.code, response.message)
           case JsError(_)             =>
             logger.error(s"Error while unprocessable entity response")
-            throw UnexpectedResponse
+            throw UnexpectedResponseError
         }
       case status =>
         logger.error(s"Error while calling pillar2 backend. Got status: $status")
-        throw UnexpectedResponse
+        throw UnexpectedResponseError
     }
 }

--- a/it/test/uk/gov/hmrc/pillar2submissionapi/AccountActivityISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2submissionapi/AccountActivityISpec.scala
@@ -28,7 +28,7 @@ import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
 import uk.gov.hmrc.http.HttpReads.Implicits.readRaw
 import uk.gov.hmrc.pillar2submissionapi.base.IntegrationSpecBase
 import uk.gov.hmrc.pillar2submissionapi.controllers.accountactivity.routes
-import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{InvalidDateFormat, InvalidDateRange, UnexpectedResponse}
+import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{InvalidDateFormatError, InvalidDateRangeError, UnexpectedResponseError}
 import uk.gov.hmrc.pillar2submissionapi.helpers.{AccountActivityDataFixture, WireMockServerHandler}
 import uk.gov.hmrc.pillar2submissionapi.models.accountactivity.AccountActivitySuccessResponse
 import uk.gov.hmrc.pillar2submissionapi.models.response.Pillar2ErrorResponse
@@ -81,14 +81,14 @@ class AccountActivityISpec
       val result = request("not-a-date", toDate).execute[HttpResponse].futureValue
 
       result.status mustBe BAD_REQUEST
-      result.json mustBe Json.toJson(Pillar2ErrorResponse(InvalidDateFormat.code, InvalidDateFormat.message))
+      result.json mustBe Json.toJson(Pillar2ErrorResponse(InvalidDateFormatError.code, InvalidDateFormatError.message))
     }
 
     "return bad request on an invalid date range" in {
       val result = request(localDateFrom.toString, localDateFrom.minusDays(1).toString).execute[HttpResponse].futureValue
 
       result.status mustBe BAD_REQUEST
-      result.json mustBe Json.toJson(Pillar2ErrorResponse(InvalidDateRange.code, InvalidDateRange.message))
+      result.json mustBe Json.toJson(Pillar2ErrorResponse(InvalidDateRangeError.code, InvalidDateRangeError.message))
     }
 
     "return unprocessable entity when the backend does" in {
@@ -122,7 +122,7 @@ class AccountActivityISpec
       val result = request(fromDate, toDate).execute[HttpResponse].futureValue
 
       result.status mustBe INTERNAL_SERVER_ERROR
-      result.json mustBe Json.toJson(Pillar2ErrorResponse(UnexpectedResponse.code, UnexpectedResponse.message))
+      result.json mustBe Json.toJson(Pillar2ErrorResponse(UnexpectedResponseError.code, UnexpectedResponseError.message))
 
       server.verify(
         getRequestedFor(urlEqualTo(backendEndpoint(fromDate, toDate))).withHeader("X-Pillar2-Id", equalTo(plrReference))
@@ -140,7 +140,7 @@ class AccountActivityISpec
       val result = request(fromDate, toDate).execute[HttpResponse].futureValue
 
       result.status mustBe INTERNAL_SERVER_ERROR
-      result.json mustBe Json.toJson(Pillar2ErrorResponse(UnexpectedResponse.code, UnexpectedResponse.message))
+      result.json mustBe Json.toJson(Pillar2ErrorResponse(UnexpectedResponseError.code, UnexpectedResponseError.message))
 
       server.verify(
         getRequestedFor(urlEqualTo(backendEndpoint(fromDate, toDate))).withHeader("X-Pillar2-Id", equalTo(plrReference))

--- a/test/uk/gov/hmrc/pillar2submissionapi/connectors/TestOrganisationConnectorSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/connectors/TestOrganisationConnectorSpec.scala
@@ -56,7 +56,7 @@ class TestOrganisationConnectorSpec extends UnitTestBaseSpec {
         )
         stubRequest("POST", url(pillar2Id), CONFLICT, errorResponse)
 
-        intercept[OrganisationAlreadyExists] {
+        intercept[OrganisationAlreadyExistsError] {
           await(connector.createTestOrganisation(pillar2Id, validOrganisationDetails)(using hc))
         }
       }
@@ -76,7 +76,7 @@ class TestOrganisationConnectorSpec extends UnitTestBaseSpec {
       "return UnexpectedResponse for any other status code" in {
         stubRequest("POST", url(pillar2Id), BAD_REQUEST, Json.obj())
 
-        intercept[UnexpectedResponse.type] {
+        intercept[UnexpectedResponseError.type] {
           await(connector.createTestOrganisation(pillar2Id, validOrganisationDetails)(using hc))
         }
       }
@@ -99,7 +99,7 @@ class TestOrganisationConnectorSpec extends UnitTestBaseSpec {
         )
         stubRequest("GET", url(pillar2Id), NOT_FOUND, errorResponse)
 
-        intercept[OrganisationNotFound] {
+        intercept[OrganisationNotFoundError] {
           await(connector.getTestOrganisation(pillar2Id)(using hc))
         }
       }
@@ -107,7 +107,7 @@ class TestOrganisationConnectorSpec extends UnitTestBaseSpec {
       "return UnexpectedResponse for any other status code" in {
         stubRequest("GET", url(pillar2Id), BAD_REQUEST, Json.obj())
 
-        intercept[UnexpectedResponse.type] {
+        intercept[UnexpectedResponseError.type] {
           await(connector.getTestOrganisation(pillar2Id)(using hc))
         }
       }
@@ -130,7 +130,7 @@ class TestOrganisationConnectorSpec extends UnitTestBaseSpec {
         )
         stubRequest("PUT", url(pillar2Id), NOT_FOUND, errorResponse)
 
-        intercept[OrganisationNotFound] {
+        intercept[OrganisationNotFoundError] {
           await(connector.updateTestOrganisation(pillar2Id, validOrganisationDetails)(using hc))
         }
       }
@@ -150,7 +150,7 @@ class TestOrganisationConnectorSpec extends UnitTestBaseSpec {
       "return UnexpectedResponse for any other status code" in {
         stubRequest("PUT", url(pillar2Id), BAD_REQUEST, Json.obj())
 
-        intercept[UnexpectedResponse.type] {
+        intercept[UnexpectedResponseError.type] {
           await(connector.updateTestOrganisation(pillar2Id, validOrganisationDetails)(using hc))
         }
       }
@@ -172,7 +172,7 @@ class TestOrganisationConnectorSpec extends UnitTestBaseSpec {
         )
         stubRequest("DELETE", url(pillar2Id), NOT_FOUND, errorResponse)
 
-        intercept[OrganisationNotFound] {
+        intercept[OrganisationNotFoundError] {
           await(connector.deleteTestOrganisation(pillar2Id)(using hc))
         }
       }
@@ -192,7 +192,7 @@ class TestOrganisationConnectorSpec extends UnitTestBaseSpec {
       "return UnexpectedResponse for any other status code" in {
         stubRequest("DELETE", url(pillar2Id), BAD_REQUEST, Json.obj())
 
-        intercept[UnexpectedResponse.type] {
+        intercept[UnexpectedResponseError.type] {
           await(connector.deleteTestOrganisation(pillar2Id)(using hc))
         }
       }

--- a/test/uk/gov/hmrc/pillar2submissionapi/controllers/AccountActivityControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/controllers/AccountActivityControllerSpec.scala
@@ -69,35 +69,35 @@ class AccountActivityControllerSpec extends ControllerBaseSpec with AccountActiv
         val badFirstDate:  Future[Result] = controllerUnderTest.retrieveAccountActivity("not-a-date", toDate)(request)
         val badSecondDate: Future[Result] = controllerUnderTest.retrieveAccountActivity(fromDate, "not-a-date")(request)
 
-        badFirstDate.shouldFailWith(InvalidDateFormat)
-        badSecondDate.shouldFailWith(InvalidDateFormat)
+        badFirstDate.shouldFailWith(InvalidDateFormatError)
+        badSecondDate.shouldFailWith(InvalidDateFormatError)
       }
 
       "fail with InvalidDateRange when from is after to" in new TestCase(accountActivityJsonParsed.asRight) {
         controllerUnderTest
           .retrieveAccountActivity(localDateFrom.toString, localDateFrom.minusDays(1).toString)(request)
-          .shouldFailWith(InvalidDateRange)
+          .shouldFailWith(InvalidDateRangeError)
       }
 
       "return MissingHeader when X-Pillar2-Id header not provided" in new TestCase(accountActivityJsonParsed.asRight) {
         controllerUnderTest
           .retrieveAccountActivity(fromDate, toDate)(FakeRequest())
-          .shouldFailWith(MissingHeader.MissingPillar2Id)
+          .shouldFailWith(MissingHeaderError("X-Pillar2-Id"))
       }
 
       "return the cause when an upstream layer fails in the Future's error channel" in new TestCase(accountActivityJsonParsed.asRight) {
         when(mockAccountActivityService.retrieveAccountActivity(eqTo(localDateFrom), eqTo(localDateTo))(using any[HeaderCarrier]))
-          .thenReturn(EitherT.liftF(Future.failed(UnexpectedResponse)))
+          .thenReturn(EitherT.liftF(Future.failed(UnexpectedResponseError)))
 
         controllerUnderTest
           .retrieveAccountActivity(fromDate, toDate)(request)
-          .shouldFailWith(UnexpectedResponse)
+          .shouldFailWith(UnexpectedResponseError)
       }
 
-      "return the cause when an upstream layer fails in the Either error channel" in new TestCase(UnexpectedResponse.asLeft) {
+      "return the cause when an upstream layer fails in the Either error channel" in new TestCase(UnexpectedResponseError.asLeft) {
         controllerUnderTest
           .retrieveAccountActivity(fromDate, toDate)(request)
-          .shouldFailWith(UnexpectedResponse)
+          .shouldFailWith(UnexpectedResponseError)
       }
     }
 
@@ -105,7 +105,7 @@ class AccountActivityControllerSpec extends ControllerBaseSpec with AccountActiv
       "return AccountActivityNotAvailable (501 Not Implemented)" in new TestCase(accountActivityJsonParsed.asRight, accountActivityEnabled = false) {
         controllerUnderTest
           .retrieveAccountActivity(fromDate, toDate)(request)
-          .shouldFailWith(AccountActivityNotAvailable)
+          .shouldFailWith(AccountActivityNotAvailableError)
       }
     }
   }

--- a/test/uk/gov/hmrc/pillar2submissionapi/controllers/BTNSubmissionControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/controllers/BTNSubmissionControllerSpec.scala
@@ -28,7 +28,7 @@ import uk.gov.hmrc.pillar2submissionapi.base.ControllerBaseSpec
 import uk.gov.hmrc.pillar2submissionapi.controllers.BTNSubmissionControllerSpec._
 import uk.gov.hmrc.pillar2submissionapi.controllers.submission.BTNSubmissionController
 import uk.gov.hmrc.pillar2submissionapi.models.belowthresholdnotification.{BTNSubmission, SubmitBTNSuccessResponse}
-import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{EmptyRequestBody, InvalidJson, MissingHeader}
+import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{EmptyRequestBodyError, InvalidJsonError, MissingHeaderError}
 
 import scala.concurrent.Future
 
@@ -60,17 +60,17 @@ class BTNSubmissionControllerSpec extends ControllerBaseSpec {
 
     "submitBTN() called with an invalid request" should {
       "return InvalidJson response" in
-        result(invalidRequestJson_data).shouldFailWith(InvalidJson)
+        result(invalidRequestJson_data).shouldFailWith(InvalidJsonError)
     }
 
     "submitBTN called with an invalid json request" should {
       "return InvalidJson response" in
-        result(invalidRequest_Json).shouldFailWith(InvalidJson)
+        result(invalidRequest_Json).shouldFailWith(InvalidJsonError)
     }
 
     "submitBTN called with an empty json object" should {
       "return InvalidJson response" in
-        result(invalidRequest_emptyBody).shouldFailWith(InvalidJson)
+        result(invalidRequest_emptyBody).shouldFailWith(InvalidJsonError)
     }
 
     "submitBTN called with an non-json request" should {
@@ -80,7 +80,7 @@ class BTNSubmissionControllerSpec extends ControllerBaseSpec {
             .withHeaders("X-Pillar2-Id" -> pillar2Id)
             .withTextBody(invalidRequest_wrongType)
         )
-        result.shouldFailWith(EmptyRequestBody)
+        result.shouldFailWith(EmptyRequestBodyError)
       }
     }
 
@@ -89,7 +89,7 @@ class BTNSubmissionControllerSpec extends ControllerBaseSpec {
         val result: Future[Result] = BTNSubmissionController.submitBTN(
           FakeRequest().withHeaders("X-Pillar2-Id" -> pillar2Id)
         )
-        result.shouldFailWith(EmptyRequestBody)
+        result.shouldFailWith(EmptyRequestBodyError)
       }
     }
 
@@ -98,7 +98,7 @@ class BTNSubmissionControllerSpec extends ControllerBaseSpec {
         val result: Future[Result] = BTNSubmissionController.submitBTN(
           FakeRequest()
         )
-        result.shouldFailWith(MissingHeader.MissingPillar2Id)
+        result.shouldFailWith(MissingHeaderError("X-Pillar2-Id"))
       }
     }
 

--- a/test/uk/gov/hmrc/pillar2submissionapi/controllers/ObligationsAndSubmissionsControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/controllers/ObligationsAndSubmissionsControllerSpec.scala
@@ -52,27 +52,27 @@ class ObligationsAndSubmissionsControllerSpec extends ControllerBaseSpec with Ob
   "return InvalidDateFormat when date format is invalid" in {
     val result = request("invalid-date", toDate)
 
-    result.shouldFailWith(InvalidDateFormat)
+    result.shouldFailWith(InvalidDateFormatError)
   }
 
   "return MissingHeader when X-Pillar2-Id header not provided" in {
     val result = obligationsAndSubmissionsController.retrieveData(fromDate, toDate)(FakeRequest())
 
-    result.shouldFailWith(MissingHeader.MissingPillar2Id)
+    result.shouldFailWith(MissingHeaderError("X-Pillar2-Id"))
   }
 
   "return InvalidDateRange when date range is invalid" in {
     val result = request(toDate, fromDate)
 
-    result.shouldFailWith(InvalidDateRange)
+    result.shouldFailWith(InvalidDateRangeError)
   }
 
   "return InternalServerError when service call fails" in {
     when(mockObligationsAndSubmissionsService.handleData(any[LocalDate], any[LocalDate])(using any[HeaderCarrier]))
-      .thenReturn(Future.failed(UnexpectedResponse))
+      .thenReturn(Future.failed(UnexpectedResponseError))
 
     val result = request(fromDate, toDate)
 
-    result.shouldFailWith(UnexpectedResponse)
+    result.shouldFailWith(UnexpectedResponseError)
   }
 }

--- a/test/uk/gov/hmrc/pillar2submissionapi/controllers/OverseasReturnNotificationControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/controllers/OverseasReturnNotificationControllerSpec.scala
@@ -27,7 +27,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2submissionapi.base.ControllerBaseSpec
 import uk.gov.hmrc.pillar2submissionapi.controllers.submission.OverseasReturnNotificationController
 import uk.gov.hmrc.pillar2submissionapi.helpers.ORNDataFixture
-import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{EmptyRequestBody, InvalidJson, MissingHeader}
+import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{EmptyRequestBodyError, InvalidJsonError, MissingHeaderError}
 import uk.gov.hmrc.pillar2submissionapi.models.overseasreturnnotification.ORNSubmission
 
 import scala.concurrent.Future
@@ -72,17 +72,17 @@ class OverseasReturnNotificationControllerSpec extends ControllerBaseSpec with O
 
     "submitORN called with an invalid request" should {
       "return InvalidJson response" in
-        callWithBody(invalidRequestJson_data).shouldFailWith(InvalidJson)
+        callWithBody(invalidRequestJson_data).shouldFailWith(InvalidJsonError)
     }
 
     "submitORN called with an invalid json request" should {
       "return InvalidJson response" in
-        callWithBody(invalidRequest_Json).shouldFailWith(InvalidJson)
+        callWithBody(invalidRequest_Json).shouldFailWith(InvalidJsonError)
     }
 
     "submitORN called with an empty json object" should {
       "return InvalidJson response" in
-        callWithBody(invalidRequest_emptyBody).shouldFailWith(InvalidJson)
+        callWithBody(invalidRequest_emptyBody).shouldFailWith(InvalidJsonError)
     }
 
     "submitORN called without X-Pillar2-Id" should {
@@ -91,7 +91,7 @@ class OverseasReturnNotificationControllerSpec extends ControllerBaseSpec with O
           .submitORN(
             FakeRequest()
           )
-          .shouldFailWith(MissingHeader.MissingPillar2Id)
+          .shouldFailWith(MissingHeaderError("X-Pillar2-Id"))
     }
 
     "submitORN called with an non-json request" should {
@@ -101,7 +101,7 @@ class OverseasReturnNotificationControllerSpec extends ControllerBaseSpec with O
             .withTextBody(invalidRequest_wrongType)
             .withHeaders("X-Pillar2-Id" -> pillar2Id)
         )
-        result.shouldFailWith(EmptyRequestBody)
+        result.shouldFailWith(EmptyRequestBodyError)
       }
     }
 
@@ -110,7 +110,7 @@ class OverseasReturnNotificationControllerSpec extends ControllerBaseSpec with O
         val result: Future[Result] = ornController.submitORN(
           FakeRequest().withHeaders("X-Pillar2-Id" -> pillar2Id)
         )
-        result.shouldFailWith(EmptyRequestBody)
+        result.shouldFailWith(EmptyRequestBodyError)
       }
     }
 
@@ -129,22 +129,22 @@ class OverseasReturnNotificationControllerSpec extends ControllerBaseSpec with O
     "submitORN called with invalid field lengths" should {
 
       "return InvalidJson response when countryGIR is longer than 2 characters" in
-        callWithBody(invalidCountryGIRJson).shouldFailWith(InvalidJson)
+        callWithBody(invalidCountryGIRJson).shouldFailWith(InvalidJsonError)
 
       "return InvalidJson response when issuingCountryTIN is longer than 2 characters" in
-        callWithBody(invalidIssuingCountryTINJson).shouldFailWith(InvalidJson)
+        callWithBody(invalidIssuingCountryTINJson).shouldFailWith(InvalidJsonError)
 
       "return InvalidJson response when reportingEntityName is empty" in
-        callWithBody(invalidReportingEntityNameJson).shouldFailWith(InvalidJson)
+        callWithBody(invalidReportingEntityNameJson).shouldFailWith(InvalidJsonError)
 
       "return InvalidJson response when TIN is empty" in
-        callWithBody(invalidTinJson).shouldFailWith(InvalidJson)
+        callWithBody(invalidTinJson).shouldFailWith(InvalidJsonError)
 
       "return InvalidJson response when reportingEntityName exceeds 200 characters" in
-        callWithBody(invalidLongReportingEntityJson).shouldFailWith(InvalidJson)
+        callWithBody(invalidLongReportingEntityJson).shouldFailWith(InvalidJsonError)
 
       "return InvalidJson response when TIN exceeds 200 characters" in
-        callWithBody(invalidLongTinJson).shouldFailWith(InvalidJson)
+        callWithBody(invalidLongTinJson).shouldFailWith(InvalidJsonError)
     }
 
     "amendORN() called with a valid request" should {
@@ -162,17 +162,17 @@ class OverseasReturnNotificationControllerSpec extends ControllerBaseSpec with O
 
     "amendORN called with an invalid request" should {
       "return InvalidJson response" in
-        callAmendWithBody(invalidRequestJson_data).shouldFailWith(InvalidJson)
+        callAmendWithBody(invalidRequestJson_data).shouldFailWith(InvalidJsonError)
     }
 
     "amendORN called with an invalid json request" should {
       "return InvalidJson response" in
-        callAmendWithBody(invalidRequest_Json).shouldFailWith(InvalidJson)
+        callAmendWithBody(invalidRequest_Json).shouldFailWith(InvalidJsonError)
     }
 
     "amendORN called with an empty json object" should {
       "return InvalidJson response" in
-        callAmendWithBody(invalidRequest_emptyBody).shouldFailWith(InvalidJson)
+        callAmendWithBody(invalidRequest_emptyBody).shouldFailWith(InvalidJsonError)
     }
 
     "amendORN called without X-Pillar2-Id" should {
@@ -181,7 +181,7 @@ class OverseasReturnNotificationControllerSpec extends ControllerBaseSpec with O
           .amendORN(
             FakeRequest()
           )
-          .shouldFailWith(MissingHeader.MissingPillar2Id)
+          .shouldFailWith(MissingHeaderError("X-Pillar2-Id"))
     }
 
     "amendORN called with an non-json request" should {
@@ -191,7 +191,7 @@ class OverseasReturnNotificationControllerSpec extends ControllerBaseSpec with O
             .withTextBody(invalidRequest_wrongType)
             .withHeaders("X-Pillar2-Id" -> pillar2Id)
         )
-        result.shouldFailWith(EmptyRequestBody)
+        result.shouldFailWith(EmptyRequestBodyError)
       }
     }
 
@@ -200,7 +200,7 @@ class OverseasReturnNotificationControllerSpec extends ControllerBaseSpec with O
         val result: Future[Result] = ornController.amendORN(
           FakeRequest().withHeaders("X-Pillar2-Id" -> pillar2Id)
         )
-        result.shouldFailWith(EmptyRequestBody)
+        result.shouldFailWith(EmptyRequestBodyError)
       }
     }
 
@@ -219,22 +219,22 @@ class OverseasReturnNotificationControllerSpec extends ControllerBaseSpec with O
     "amendORN called with invalid field lengths" should {
 
       "return InvalidJson response when countryGIR is longer than 2 characters" in
-        callAmendWithBody(invalidCountryGIRJson).shouldFailWith(InvalidJson)
+        callAmendWithBody(invalidCountryGIRJson).shouldFailWith(InvalidJsonError)
 
       "return InvalidJson response when issuingCountryTIN is longer than 2 characters" in
-        callAmendWithBody(invalidIssuingCountryTINJson).shouldFailWith(InvalidJson)
+        callAmendWithBody(invalidIssuingCountryTINJson).shouldFailWith(InvalidJsonError)
 
       "return InvalidJson response when reportingEntityName is empty" in
-        callAmendWithBody(invalidReportingEntityNameJson).shouldFailWith(InvalidJson)
+        callAmendWithBody(invalidReportingEntityNameJson).shouldFailWith(InvalidJsonError)
 
       "return InvalidJson response when TIN is empty" in
-        callAmendWithBody(invalidTinJson).shouldFailWith(InvalidJson)
+        callAmendWithBody(invalidTinJson).shouldFailWith(InvalidJsonError)
 
       "return InvalidJson response when reportingEntityName exceeds 200 characters" in
-        callAmendWithBody(invalidLongReportingEntityJson).shouldFailWith(InvalidJson)
+        callAmendWithBody(invalidLongReportingEntityJson).shouldFailWith(InvalidJsonError)
 
       "return InvalidJson response when TIN exceeds 200 characters" in
-        callAmendWithBody(invalidLongTinJson).shouldFailWith(InvalidJson)
+        callAmendWithBody(invalidLongTinJson).shouldFailWith(InvalidJsonError)
     }
   }
 }

--- a/test/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandlerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandlerSpec.scala
@@ -101,7 +101,7 @@ class Pillar2ErrorHandlerSpec extends AnyFunSuite with ScalaCheckDrivenPropertyC
   }
 
   test("EmptyRequestBody error response") {
-    val response = classUnderTest.onServerError(dummyRequest, EmptyRequestBody)
+    val response = classUnderTest.onServerError(dummyRequest, EmptyRequestBodyError)
     status(response) mustEqual 400
     val result = contentAsJson(response).as[Pillar2ErrorResponse]
     result.code mustEqual "EMPTY_REQUEST_BODY"
@@ -109,7 +109,7 @@ class Pillar2ErrorHandlerSpec extends AnyFunSuite with ScalaCheckDrivenPropertyC
   }
 
   test("InvalidDateFormat error response") {
-    val response = classUnderTest.onServerError(dummyRequest, InvalidDateFormat)
+    val response = classUnderTest.onServerError(dummyRequest, InvalidDateFormatError)
     status(response) mustEqual 400
     val result = contentAsJson(response).as[Pillar2ErrorResponse]
     result.code mustEqual "INVALID_DATE_FORMAT"
@@ -117,7 +117,7 @@ class Pillar2ErrorHandlerSpec extends AnyFunSuite with ScalaCheckDrivenPropertyC
   }
 
   test("InvalidDateRange error response") {
-    val response = classUnderTest.onServerError(dummyRequest, InvalidDateRange)
+    val response = classUnderTest.onServerError(dummyRequest, InvalidDateRangeError)
     status(response) mustEqual 400
     val result = contentAsJson(response).as[Pillar2ErrorResponse]
     result.code mustEqual "INVALID_DATE_RANGE"
@@ -125,15 +125,15 @@ class Pillar2ErrorHandlerSpec extends AnyFunSuite with ScalaCheckDrivenPropertyC
   }
 
   test("MissingHeader error response") {
-    val response = classUnderTest.onServerError(dummyRequest, MissingHeader("Missing Header"))
+    val response = classUnderTest.onServerError(dummyRequest, MissingHeaderError("X-Test-Header"))
     status(response) mustEqual 400
     val result = contentAsJson(response).as[Pillar2ErrorResponse]
     result.code mustEqual "MISSING_HEADER"
-    result.message mustEqual "Missing Header"
+    result.message mustEqual "Please provide the X-Test-Header header"
   }
 
   test("InvalidJson error response") {
-    val response = classUnderTest.onServerError(dummyRequest, InvalidJson)
+    val response = classUnderTest.onServerError(dummyRequest, InvalidJsonError)
     status(response) mustEqual 400
     val result = contentAsJson(response).as[Pillar2ErrorResponse]
     result.code mustEqual "INVALID_JSON"
@@ -141,7 +141,7 @@ class Pillar2ErrorHandlerSpec extends AnyFunSuite with ScalaCheckDrivenPropertyC
   }
 
   test("IncorrectHeaderValue error response") {
-    val response = classUnderTest.onServerError(dummyRequest, IncorrectHeaderValue)
+    val response = classUnderTest.onServerError(dummyRequest, IncorrectHeaderValueError)
     status(response) mustEqual 400
     val result = contentAsJson(response).as[Pillar2ErrorResponse]
     result.code mustEqual "INCORRECT_HEADER_VALUE"
@@ -149,7 +149,7 @@ class Pillar2ErrorHandlerSpec extends AnyFunSuite with ScalaCheckDrivenPropertyC
   }
 
   test("MissingCredentials error response") {
-    val response = classUnderTest.onServerError(dummyRequest, MissingCredentials)
+    val response = classUnderTest.onServerError(dummyRequest, MissingCredentialsError)
     status(response) mustEqual 401
     val result = contentAsJson(response).as[Pillar2ErrorResponse]
     result.code mustEqual "MISSING_CREDENTIALS"
@@ -157,7 +157,7 @@ class Pillar2ErrorHandlerSpec extends AnyFunSuite with ScalaCheckDrivenPropertyC
   }
 
   test("InvalidCredentials error response") {
-    val response = classUnderTest.onServerError(dummyRequest, InvalidCredentials)
+    val response = classUnderTest.onServerError(dummyRequest, InvalidCredentialsError)
     status(response) mustEqual 401
     val result = contentAsJson(response).as[Pillar2ErrorResponse]
     result.code mustEqual "INVALID_CREDENTIALS"
@@ -173,7 +173,7 @@ class Pillar2ErrorHandlerSpec extends AnyFunSuite with ScalaCheckDrivenPropertyC
   }
 
   test("InvalidEnrolment error response") {
-    val response = classUnderTest.onServerError(dummyRequest, InvalidEnrolment)
+    val response = classUnderTest.onServerError(dummyRequest, InvalidEnrolmentError)
     status(response) mustEqual 403
     val result = contentAsJson(response).as[Pillar2ErrorResponse]
     result.code mustEqual "INVALID_ENROLMENT"
@@ -181,7 +181,7 @@ class Pillar2ErrorHandlerSpec extends AnyFunSuite with ScalaCheckDrivenPropertyC
   }
 
   test("NoSubscriptionData error response") {
-    val response = classUnderTest.onServerError(dummyRequest, NoSubscriptionData("XTC01234123412"))
+    val response = classUnderTest.onServerError(dummyRequest, NoSubscriptionDataError("XTC01234123412"))
     status(response) mustEqual 500
     val result = contentAsJson(response).as[Pillar2ErrorResponse]
     result.code mustEqual "004"
@@ -197,7 +197,7 @@ class Pillar2ErrorHandlerSpec extends AnyFunSuite with ScalaCheckDrivenPropertyC
   }
 
   test("TestEndpointDisabled response") {
-    val response = classUnderTest.onServerError(dummyRequest, TestEndpointDisabled)
+    val response = classUnderTest.onServerError(dummyRequest, TestEndpointDisabledError)
     status(response) mustEqual 403
     val result = contentAsJson(response).as[Pillar2ErrorResponse]
     result.code mustEqual "TEST_ENDPOINT_DISABLED"
@@ -213,7 +213,7 @@ class Pillar2ErrorHandlerSpec extends AnyFunSuite with ScalaCheckDrivenPropertyC
   }
 
   test("UnexpectedResponse error response") {
-    val response = classUnderTest.onServerError(dummyRequest, UnexpectedResponse)
+    val response = classUnderTest.onServerError(dummyRequest, UnexpectedResponseError)
     status(response) mustEqual 500
     val result = contentAsJson(response).as[Pillar2ErrorResponse]
     result.code mustEqual "500"

--- a/test/uk/gov/hmrc/pillar2submissionapi/controllers/TestOrganisationControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/controllers/TestOrganisationControllerSpec.scala
@@ -57,20 +57,20 @@ class TestOrganisationControllerSpec extends ControllerBaseSpec {
         "return InvalidJson for invalid request" in {
           val result = controller().createTestOrganisation(FakeRequest().withHeaders("X-Pillar2-Id" -> pillar2Id).withJsonBody(invalidRequestJson))
 
-          result.shouldFailWith(InvalidJson)
+          result.shouldFailWith(InvalidJsonError)
         }
 
         "return EmptyRequestBody for missing body" in {
           val result = controller().createTestOrganisation(FakeRequest().withHeaders("X-Pillar2-Id" -> pillar2Id))
 
-          result.shouldFailWith(EmptyRequestBody)
+          result.shouldFailWith(EmptyRequestBodyError)
         }
 
         "return InvalidDateRange for invalid accounting period" in {
           val result =
             controller().createTestOrganisation(FakeRequest().withHeaders("X-Pillar2-Id" -> pillar2Id).withJsonBody(invalidAccountingPeriodJson))
 
-          result.shouldFailWith(InvalidDateRange)
+          result.shouldFailWith(InvalidDateRangeError)
         }
       }
 
@@ -100,20 +100,20 @@ class TestOrganisationControllerSpec extends ControllerBaseSpec {
         "return InvalidJson for invalid request" in {
           val result = controller().updateTestOrganisation(FakeRequest().withHeaders("X-Pillar2-Id" -> pillar2Id).withJsonBody(invalidRequestJson))
 
-          result.shouldFailWith(InvalidJson)
+          result.shouldFailWith(InvalidJsonError)
         }
 
         "return EmptyRequestBody for missing body" in {
           val result = controller().updateTestOrganisation(FakeRequest().withHeaders("X-Pillar2-Id" -> pillar2Id))
 
-          result.shouldFailWith(EmptyRequestBody)
+          result.shouldFailWith(EmptyRequestBodyError)
         }
 
         "return InvalidDateRange for invalid accounting period" in {
           val result =
             controller().updateTestOrganisation(FakeRequest().withHeaders("X-Pillar2-Id" -> pillar2Id).withJsonBody(invalidAccountingPeriodJson))
 
-          result.shouldFailWith(InvalidDateRange)
+          result.shouldFailWith(InvalidDateRangeError)
         }
       }
 
@@ -136,7 +136,7 @@ class TestOrganisationControllerSpec extends ControllerBaseSpec {
             FakeRequest().withHeaders("X-Pillar2-Id" -> pillar2Id).withJsonBody(validRequestJson)
           )
 
-          result.shouldFailWith(TestEndpointDisabled)
+          result.shouldFailWith(TestEndpointDisabledError)
         }
       }
 
@@ -144,7 +144,7 @@ class TestOrganisationControllerSpec extends ControllerBaseSpec {
         "return 403 FORBIDDEN" in {
           val result = controller(testEndpointsEnabled = false).getTestOrganisation(FakeRequest().withHeaders("X-Pillar2-Id" -> pillar2Id))
 
-          result.shouldFailWith(TestEndpointDisabled)
+          result.shouldFailWith(TestEndpointDisabledError)
         }
       }
 
@@ -154,7 +154,7 @@ class TestOrganisationControllerSpec extends ControllerBaseSpec {
             FakeRequest().withHeaders("X-Pillar2-Id" -> pillar2Id).withJsonBody(validRequestJson)
           )
 
-          result.shouldFailWith(TestEndpointDisabled)
+          result.shouldFailWith(TestEndpointDisabledError)
         }
       }
 
@@ -162,7 +162,7 @@ class TestOrganisationControllerSpec extends ControllerBaseSpec {
         "return 403 FORBIDDEN" in {
           val result = controller(testEndpointsEnabled = false).deleteTestOrganisation(FakeRequest().withHeaders("X-Pillar2-Id" -> pillar2Id))
 
-          result.shouldFailWith(TestEndpointDisabled)
+          result.shouldFailWith(TestEndpointDisabledError)
         }
       }
     }

--- a/test/uk/gov/hmrc/pillar2submissionapi/controllers/UKTaxReturnControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/controllers/UKTaxReturnControllerSpec.scala
@@ -27,7 +27,7 @@ import play.api.test.Helpers.{OK, defaultAwaitTimeout, status}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2submissionapi.base.ControllerBaseSpec
 import uk.gov.hmrc.pillar2submissionapi.controllers.submission.UKTaxReturnController
-import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{EmptyRequestBody, InvalidJson, MissingHeader}
+import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{EmptyRequestBodyError, InvalidJsonError, MissingHeaderError}
 import uk.gov.hmrc.pillar2submissionapi.models.uktrsubmissions.UKTRSubmissionData
 
 import scala.concurrent.Future
@@ -81,44 +81,44 @@ class UKTaxReturnControllerSpec extends ControllerBaseSpec {
 
     "submitUKTR() called with an invalid request" should {
       "return 400 BAD_REQUEST response" in
-        callWithBody(liabilityReturnInvalidLiabilities).shouldFailWith(InvalidJson)
+        callWithBody(liabilityReturnInvalidLiabilities).shouldFailWith(InvalidJsonError)
     }
 
     "submitUKTR() called with an invalid nil return request" should {
       "return 400 BAD_REQUEST response" in
-        callWithBody(nilReturnInvalidReturnType).shouldFailWith(InvalidJson)
+        callWithBody(nilReturnInvalidReturnType).shouldFailWith(InvalidJsonError)
     }
 
     "submitUKTR() called with an invalid json request" should {
       "return 400 BAD_REQUEST response" in
-        callWithBody(invalidBody).shouldFailWith(InvalidJson)
+        callWithBody(invalidBody).shouldFailWith(InvalidJsonError)
     }
 
     "submitUKTR() called with request that only contains a valid return type" should {
       "return 400 BAD_REQUEST response" in
-        callWithBody(invalidRequest_nilReturn_onlyContainsLiabilities).shouldFailWith(InvalidJson)
+        callWithBody(invalidRequest_nilReturn_onlyContainsLiabilities).shouldFailWith(InvalidJsonError)
     }
 
     "submitUKTR() called with request that only contains an invalid return type" should {
       "return 400 BAD_REQUEST response" in
-        callWithBody(invalidRequest_nilReturn_onlyLiabilitiesButInvalidReturnType).shouldFailWith(InvalidJson)
+        callWithBody(invalidRequest_nilReturn_onlyLiabilitiesButInvalidReturnType).shouldFailWith(InvalidJsonError)
     }
 
     "submitUKTR() called with request that is missing liabilities" should {
       "return 400 BAD_REQUEST response" in
-        callWithBody(invalidRequest_noLiabilities).shouldFailWith(InvalidJson)
+        callWithBody(invalidRequest_noLiabilities).shouldFailWith(InvalidJsonError)
     }
 
     "submitUKTR() called with an empty json object" should {
       "return 400 BAD_REQUEST response" in
-        callWithBody(emptyBody).shouldFailWith(InvalidJson)
+        callWithBody(emptyBody).shouldFailWith(InvalidJsonError)
     }
 
     "submitUKTR() called with an non-json request" should {
       "return 400 BAD_REQUEST response" in {
         val result = uktrSubmissionController.submitUKTR()(FakeRequest().withHeaders("X-Pillar2-Id" -> pillar2Id).withTextBody(stringBody))
 
-        result.shouldFailWith(EmptyRequestBody)
+        result.shouldFailWith(EmptyRequestBodyError)
       }
     }
 
@@ -126,7 +126,7 @@ class UKTaxReturnControllerSpec extends ControllerBaseSpec {
       "return 400 BAD_REQUEST response" in {
         val result = uktrSubmissionController.submitUKTR()(FakeRequest().withHeaders("X-Pillar2-Id" -> pillar2Id))
 
-        result.shouldFailWith(EmptyRequestBody)
+        result.shouldFailWith(EmptyRequestBodyError)
       }
     }
 
@@ -134,7 +134,7 @@ class UKTaxReturnControllerSpec extends ControllerBaseSpec {
       "return MissingHeader response" in {
         val result = uktrSubmissionController.submitUKTR()(FakeRequest())
 
-        result.shouldFailWith(MissingHeader.MissingPillar2Id)
+        result.shouldFailWith(MissingHeaderError("X-Pillar2-Id"))
       }
     }
 
@@ -158,27 +158,27 @@ class UKTaxReturnControllerSpec extends ControllerBaseSpec {
 
     "submitUKTR() called with a monetary value exceeding the maximum allowed" should {
       "return 400 BAD_REQUEST response with InvalidJson" in
-        callWithBody(liabilityReturnMonetaryExceedsLimit).shouldFailWith(InvalidJson)
+        callWithBody(liabilityReturnMonetaryExceedsLimit).shouldFailWith(InvalidJsonError)
     }
 
     "submitUKTR() called with a monetary value having too many decimal places" should {
       "return 400 BAD_REQUEST response with InvalidJson" in
-        callWithBody(liabilityReturnMonetaryDecimalPrecision).shouldFailWith(InvalidJson)
+        callWithBody(liabilityReturnMonetaryDecimalPrecision).shouldFailWith(InvalidJsonError)
     }
 
     "submitUKTR() called with an invalid monetary value in liableEntity amountOwedDTT" should {
       "return 400 BAD_REQUEST response with InvalidJson" in
-        callWithBody(liabilityReturnEntityMonetaryExceedsLimit).shouldFailWith(InvalidJson)
+        callWithBody(liabilityReturnEntityMonetaryExceedsLimit).shouldFailWith(InvalidJsonError)
     }
 
     "submitUKTR() called with a monetary value with too many decimal places in liableEntity amountOwedIIR" should {
       "return 400 BAD_REQUEST response with InvalidJson" in
-        callWithBody(liabilityReturnEntityMonetaryDecimalPrecision).shouldFailWith(InvalidJson)
+        callWithBody(liabilityReturnEntityMonetaryDecimalPrecision).shouldFailWith(InvalidJsonError)
     }
 
     "submitUKTR() called with a negative monetary value" should {
       "return 400 BAD_REQUEST response with InvalidJson" in
-        callWithBody(liabilityReturnNegativeValue).shouldFailWith(InvalidJson)
+        callWithBody(liabilityReturnNegativeValue).shouldFailWith(InvalidJsonError)
     }
 
     "submitUKTR() called with a monetary value at the minimum limit (0)" should {
@@ -228,44 +228,44 @@ class UKTaxReturnControllerSpec extends ControllerBaseSpec {
 
     "amendUKTR() called with an invalid request" should {
       "return 400 BAD_REQUEST response" in
-        callAmendWithBody(liabilityReturnInvalidLiabilities).shouldFailWith(InvalidJson)
+        callAmendWithBody(liabilityReturnInvalidLiabilities).shouldFailWith(InvalidJsonError)
     }
 
     "amendUKTR() called with an invalid nil return request" should {
       "return 400 BAD_REQUEST response" in
-        callAmendWithBody(nilReturnInvalidReturnType).shouldFailWith(InvalidJson)
+        callAmendWithBody(nilReturnInvalidReturnType).shouldFailWith(InvalidJsonError)
     }
 
     "amendUKTR() called with an invalid json request" should {
       "return 400 BAD_REQUEST response" in
-        callAmendWithBody(invalidBody).shouldFailWith(InvalidJson)
+        callAmendWithBody(invalidBody).shouldFailWith(InvalidJsonError)
     }
 
     "amendUKTR() called with request that only contains a valid return type" should {
       "return 400 BAD_REQUEST response" in
-        callAmendWithBody(invalidRequest_nilReturn_onlyContainsLiabilities).shouldFailWith(InvalidJson)
+        callAmendWithBody(invalidRequest_nilReturn_onlyContainsLiabilities).shouldFailWith(InvalidJsonError)
     }
 
     "amendUKTR() called with request that only contains an invalid return type" should {
       "return 400 BAD_REQUEST response" in
-        callAmendWithBody(invalidRequest_nilReturn_onlyLiabilitiesButInvalidReturnType).shouldFailWith(InvalidJson)
+        callAmendWithBody(invalidRequest_nilReturn_onlyLiabilitiesButInvalidReturnType).shouldFailWith(InvalidJsonError)
     }
 
     "amendUKTR() called with request that is missing liabilities" should {
       "return 400 BAD_REQUEST response" in
-        callAmendWithBody(invalidRequest_noLiabilities).shouldFailWith(InvalidJson)
+        callAmendWithBody(invalidRequest_noLiabilities).shouldFailWith(InvalidJsonError)
     }
 
     "amendUKTR() called with an empty json object" should {
       "return 400 BAD_REQUEST response" in
-        callAmendWithBody(emptyBody).shouldFailWith(InvalidJson)
+        callAmendWithBody(emptyBody).shouldFailWith(InvalidJsonError)
     }
 
     "amendUKTR() called with an non-json request" should {
       "return 400 BAD_REQUEST response" in {
         val result = uktrSubmissionController.amendUKTR()(FakeRequest().withHeaders("X-Pillar2-Id" -> pillar2Id).withTextBody(stringBody))
 
-        result.shouldFailWith(EmptyRequestBody)
+        result.shouldFailWith(EmptyRequestBodyError)
       }
     }
 
@@ -273,7 +273,7 @@ class UKTaxReturnControllerSpec extends ControllerBaseSpec {
       "return 400 BAD_REQUEST response" in {
         val result = uktrSubmissionController.amendUKTR()(FakeRequest().withHeaders("X-Pillar2-Id" -> pillar2Id))
 
-        result.shouldFailWith(EmptyRequestBody)
+        result.shouldFailWith(EmptyRequestBodyError)
       }
     }
 
@@ -281,7 +281,7 @@ class UKTaxReturnControllerSpec extends ControllerBaseSpec {
       "return MissingHeader response" in {
         val result = uktrSubmissionController.amendUKTR()(FakeRequest())
 
-        result.shouldFailWith(MissingHeader.MissingPillar2Id)
+        result.shouldFailWith(MissingHeaderError("X-Pillar2-Id"))
       }
     }
 
@@ -305,22 +305,22 @@ class UKTaxReturnControllerSpec extends ControllerBaseSpec {
 
     "amendUKTR() called with a monetary value exceeding the maximum allowed" should {
       "return 400 BAD_REQUEST response with InvalidJson" in
-        callAmendWithBody(liabilityReturnMonetaryExceedsLimit).shouldFailWith(InvalidJson)
+        callAmendWithBody(liabilityReturnMonetaryExceedsLimit).shouldFailWith(InvalidJsonError)
     }
 
     "amendUKTR() called with a monetary value having too many decimal places" should {
       "return 400 BAD_REQUEST response with InvalidJson" in
-        callAmendWithBody(liabilityReturnMonetaryDecimalPrecision).shouldFailWith(InvalidJson)
+        callAmendWithBody(liabilityReturnMonetaryDecimalPrecision).shouldFailWith(InvalidJsonError)
     }
 
     "amendUKTR() called with an invalid monetary value in liableEntity amountOwedDTT" should {
       "return 400 BAD_REQUEST response with InvalidJson" in
-        callAmendWithBody(liabilityReturnEntityMonetaryExceedsLimit).shouldFailWith(InvalidJson)
+        callAmendWithBody(liabilityReturnEntityMonetaryExceedsLimit).shouldFailWith(InvalidJsonError)
     }
 
     "amendUKTR() called with a monetary value with too many decimal places in liableEntity amountOwedIIR" should {
       "return 400 BAD_REQUEST response with InvalidJson" in
-        callAmendWithBody(liabilityReturnEntityMonetaryDecimalPrecision).shouldFailWith(InvalidJson)
+        callAmendWithBody(liabilityReturnEntityMonetaryDecimalPrecision).shouldFailWith(InvalidJsonError)
     }
 
     "amendUKTR() called with a negative monetary value at the minimum limit" should {

--- a/test/uk/gov/hmrc/pillar2submissionapi/controllers/actions/AuthenticatedIdentifierActionSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/controllers/actions/AuthenticatedIdentifierActionSpec.scala
@@ -189,26 +189,26 @@ class AuthenticatedIdentifierActionSpec extends ActionBaseSpec {
           )
             .thenThrow(FailedRelationship("NO_RELATIONSHIP;HMRC-PILLAR2-ORG"))
 
-          val result = intercept[InvalidCredentials.type](await(identifierAction.refine(fakeRequestWithPillar2Id)))
+          val result = intercept[InvalidCredentialsError.type](await(identifierAction.refine(fakeRequestWithPillar2Id)))
 
           result.message mustEqual "Invalid Authentication information provided"
         }
 
         "Authorization is missing" when {
           "Authorization header is missing" in {
-            val result = intercept[MissingCredentials.type](await(identifierAction.refine(requestMissingAuthorization)))
+            val result = intercept[MissingCredentialsError.type](await(identifierAction.refine(requestMissingAuthorization)))
 
             result.message mustEqual "Authentication information is not provided"
           }
 
           "Authorization header exists but is empty" in {
-            val result = intercept[MissingCredentials.type](await(identifierAction.refine(requestEmptyAuthorization)))
+            val result = intercept[MissingCredentialsError.type](await(identifierAction.refine(requestEmptyAuthorization)))
 
             result.message mustEqual "Authentication information is not provided"
           }
 
           "Authorization header exists but has space characters only" in {
-            val result = intercept[MissingCredentials.type](await(identifierAction.refine(requestSpacesOnlyAuthorization)))
+            val result = intercept[MissingCredentialsError.type](await(identifierAction.refine(requestSpacesOnlyAuthorization)))
 
             result.message mustEqual "Authentication information is not provided"
           }
@@ -361,7 +361,7 @@ class AuthenticatedIdentifierActionSpec extends ActionBaseSpec {
             )
           )
 
-        val result = intercept[InvalidEnrolment.type](await(identifierAction.refine(fakeRequestWithPillar2Id)))
+        val result = intercept[InvalidEnrolmentError.type](await(identifierAction.refine(fakeRequestWithPillar2Id)))
 
         result.message mustEqual "Invalid Pillar 2 enrolment"
       }
@@ -379,7 +379,7 @@ class AuthenticatedIdentifierActionSpec extends ActionBaseSpec {
             )
           )
 
-        val result = intercept[IncorrectHeaderValue.type](await(identifierAction.refine(fakeRequestWithDifferentPillar2Id)))
+        val result = intercept[IncorrectHeaderValueError.type](await(identifierAction.refine(fakeRequestWithDifferentPillar2Id)))
 
         result.message mustEqual "X-Pillar2-Id Header value does not match the bearer token"
       }
@@ -394,12 +394,12 @@ class AuthenticatedIdentifierActionSpec extends ActionBaseSpec {
           emptyAppConfig
         )(using ec)
 
-        val result = intercept[InvalidCredentials.type](await(identifierAction.refine(fakeRequestWithPillar2Id)))
+        val result = intercept[InvalidCredentialsError.type](await(identifierAction.refine(fakeRequestWithPillar2Id)))
 
         result.message mustEqual "Invalid Authentication information provided"
       }
       "user is unauthorized for providing no credentials" in {
-        val result = intercept[MissingCredentials.type](await(identifierAction.refine(requestMissingAuthorization)))
+        val result = intercept[MissingCredentialsError.type](await(identifierAction.refine(requestMissingAuthorization)))
 
         result.message mustEqual "Authentication information is not provided"
       }

--- a/test/uk/gov/hmrc/pillar2submissionapi/controllers/actions/SubscriptionDataRetrievalActionSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/controllers/actions/SubscriptionDataRetrievalActionSpec.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2submissionapi.base.ActionBaseSpec
 import uk.gov.hmrc.pillar2submissionapi.connectors.SubscriptionConnector
 import uk.gov.hmrc.pillar2submissionapi.helpers.SubscriptionDataFixture
-import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.NoSubscriptionData
+import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.NoSubscriptionDataError
 import uk.gov.hmrc.pillar2submissionapi.models.requests.{IdentifierRequest, SubscriptionDataRequest}
 
 import scala.concurrent.duration.DurationInt
@@ -66,7 +66,7 @@ class SubscriptionDataRetrievalActionSpec extends ActionBaseSpec with Subscripti
       val result = action
         .callTransform(IdentifierRequest(FakeRequest(), "id", Some("groupID"), userIdForEnrolment = "userId", clientPillar2Id = "pillar2Id"))
 
-      intercept[NoSubscriptionData] {
+      intercept[NoSubscriptionDataError] {
         Await.result(result, 5.seconds)
       }
     }

--- a/test/uk/gov/hmrc/pillar2submissionapi/controllers/test/GIRControllerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/controllers/test/GIRControllerSpec.scala
@@ -25,7 +25,7 @@ import play.api.test.Helpers.{contentAsJson, defaultAwaitTimeout, status}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.pillar2submissionapi.base.ControllerBaseSpec
 import uk.gov.hmrc.pillar2submissionapi.config.AppConfig
-import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{EmptyRequestBody, InvalidJson, TestEndpointDisabled}
+import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{EmptyRequestBodyError, InvalidJsonError, TestEndpointDisabledError}
 import uk.gov.hmrc.pillar2submissionapi.models.globeinformationreturn.{GIRSubmission, GIRSuccess, SubmitGIRSuccessResponse}
 import uk.gov.hmrc.pillar2submissionapi.services.GIRService
 
@@ -66,11 +66,11 @@ class GIRControllerSpec extends ControllerBaseSpec {
         "return InvalidJson for invalid request" in {
           val invalidJson = Json.obj("badField" -> "badValue")
           val result      = controller().createGIR(FakeRequest().withHeaders("X-Pillar2-Id" -> pillar2Id).withJsonBody(invalidJson))
-          result.shouldFailWith(InvalidJson)
+          result.shouldFailWith(InvalidJsonError)
         }
         "return EmptyRequestBody for missing body" in {
           val result = controller().createGIR(FakeRequest().withHeaders("X-Pillar2-Id" -> pillar2Id))
-          result.shouldFailWith(EmptyRequestBody)
+          result.shouldFailWith(EmptyRequestBodyError)
         }
       }
 
@@ -86,11 +86,11 @@ class GIRControllerSpec extends ControllerBaseSpec {
         }
         "return InvalidJson for invalid request" in {
           val result = controller().amendGIR(FakeRequest().withHeaders("X-Pillar2-Id" -> pillar2Id).withJsonBody(Json.obj("badField" -> "badValue")))
-          result.shouldFailWith(InvalidJson)
+          result.shouldFailWith(InvalidJsonError)
         }
         "return EmptyRequestBody for missing body" in {
           val result = controller().amendGIR(FakeRequest().withHeaders("X-Pillar2-Id" -> pillar2Id))
-          result.shouldFailWith(EmptyRequestBody)
+          result.shouldFailWith(EmptyRequestBodyError)
         }
       }
 
@@ -106,11 +106,11 @@ class GIRControllerSpec extends ControllerBaseSpec {
         }
         "return InvalidJson for invalid request" in {
           val result = controller().deleteGIR(FakeRequest().withHeaders("X-Pillar2-Id" -> pillar2Id).withJsonBody(Json.obj("badField" -> "badValue")))
-          result.shouldFailWith(InvalidJson)
+          result.shouldFailWith(InvalidJsonError)
         }
         "return EmptyRequestBody for missing body" in {
           val result = controller().deleteGIR(FakeRequest().withHeaders("X-Pillar2-Id" -> pillar2Id))
-          result.shouldFailWith(EmptyRequestBody)
+          result.shouldFailWith(EmptyRequestBodyError)
         }
       }
     }
@@ -121,7 +121,7 @@ class GIRControllerSpec extends ControllerBaseSpec {
           val result = controller(testEndpointsEnabled = false).createGIR(
             FakeRequest().withHeaders("X-Pillar2-Id" -> pillar2Id).withJsonBody(validRequestJson)
           )
-          result.shouldFailWith(TestEndpointDisabled)
+          result.shouldFailWith(TestEndpointDisabledError)
         }
       }
 
@@ -130,7 +130,7 @@ class GIRControllerSpec extends ControllerBaseSpec {
           val result = controller(testEndpointsEnabled = false).amendGIR(
             FakeRequest().withHeaders("X-Pillar2-Id" -> pillar2Id).withJsonBody(validRequestJson)
           )
-          result.shouldFailWith(TestEndpointDisabled)
+          result.shouldFailWith(TestEndpointDisabledError)
         }
       }
 
@@ -139,7 +139,7 @@ class GIRControllerSpec extends ControllerBaseSpec {
           val result = controller(testEndpointsEnabled = false).deleteGIR(
             FakeRequest().withHeaders("X-Pillar2-Id" -> pillar2Id).withJsonBody(validRequestJson)
           )
-          result.shouldFailWith(TestEndpointDisabled)
+          result.shouldFailWith(TestEndpointDisabledError)
         }
       }
     }

--- a/test/uk/gov/hmrc/pillar2submissionapi/models/error/Pillar2ErrorSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/models/error/Pillar2ErrorSpec.scala
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.pillar2submissionapi.models.error
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers
+import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error._
+
+class Pillar2ErrorSpec extends AnyFreeSpec with Matchers {
+
+  "Pillar2Error.getMessage must override the Throwable.getMessage and" - {
+
+    "return the custom detail message for InvalidDateRangeError" in {
+      val error = InvalidDateRangeError
+      error.getMessage mustBe "Code: 'INVALID_DATE_RANGE' Message: 'Invalid date range'"
+    }
+
+    "return the custom detail message for InvalidDateFormatError" in {
+      val error = InvalidDateFormatError
+      error.getMessage mustBe "Code: 'INVALID_DATE_FORMAT' Message: 'Invalid date format'"
+    }
+
+    "return the custom detail message for InvalidJsonError" in {
+      val error = InvalidJsonError
+      error.getMessage mustBe "Code: 'INVALID_JSON' Message: 'Invalid JSON payload'"
+    }
+
+    "return the custom detail message for EmptyRequestBodyError" in {
+      val error = EmptyRequestBodyError
+      error.getMessage mustBe "Code: 'EMPTY_REQUEST_BODY' Message: 'Empty request body'"
+    }
+
+    "return the custom detail message for MissingCredentialsError" in {
+      val error = MissingCredentialsError
+      error.getMessage mustBe "Code: 'MISSING_CREDENTIALS' Message: 'Authentication information is not provided'"
+    }
+
+    "return the custom detail message for InvalidCredentialsError" in {
+      val error = InvalidCredentialsError
+      error.getMessage mustBe "Code: 'INVALID_CREDENTIALS' Message: 'Invalid Authentication information provided'"
+    }
+
+    "return the custom detail message for MissingHeaderError" in {
+      val error = MissingHeaderError("X-Test-Header")
+      error.getMessage mustBe "Code: 'MISSING_HEADER' Message: 'Please provide the X-Test-Header header'"
+    }
+
+    "return the custom detail message for ForbiddenError" in {
+      val error = ForbiddenError
+      error.getMessage mustBe "Code: 'FORBIDDEN' Message: 'Access to the requested resource is forbidden'"
+    }
+
+    "return the custom detail message for IncorrectHeaderValueError" in {
+      val error = IncorrectHeaderValueError
+      error.getMessage mustBe "Code: 'INCORRECT_HEADER_VALUE' Message: 'X-Pillar2-Id Header value does not match the bearer token'"
+    }
+
+    "return the custom detail message for InvalidEnrolmentError" in {
+      val error = InvalidEnrolmentError
+      error.getMessage mustBe "Code: 'INVALID_ENROLMENT' Message: 'Invalid Pillar 2 enrolment'"
+    }
+
+    "return the custom detail message for TestEndpointDisabledError" in {
+      val error = TestEndpointDisabledError
+      error.getMessage mustBe "Code: 'TEST_ENDPOINT_DISABLED' Message: 'Test endpoints are not available in this environment'"
+    }
+
+    "return the custom detail message for ORNNotFoundError" in {
+      val error = ORNNotFoundError
+      error.getMessage mustBe "Code: 'NOT_FOUND' Message: 'The requested ORN could not be found'"
+    }
+
+    "return the custom detail message for AccountActivityNotAvailableError" in {
+      val error = AccountActivityNotAvailableError
+      error.getMessage mustBe "Code: 'NOT_IMPLEMENTED' Message: 'Account activity is not available in this environment'"
+    }
+
+    "return the custom detail message for NoSubscriptionDataError" in {
+      val error = NoSubscriptionDataError(pillar2Id = "XAPLR1234567890")
+      error.getMessage mustBe "Code: '004' Message: 'No Pillar2 subscription found for XAPLR1234567890'"
+    }
+
+    "return the custom detail message for OrganisationNotFoundError" in {
+      val error = OrganisationNotFoundError(pillar2Id = "XAPLR1234567890")
+      error.getMessage mustBe "Code: '404' Message: 'Organisation not found for pillar2Id: XAPLR1234567890'"
+    }
+
+    "return the custom detail message for OrganisationAlreadyExistsError" in {
+      val error = OrganisationAlreadyExistsError(pillar2Id = "XAPLR1234567890")
+      error.getMessage mustBe "Code: '409' Message: 'Organisation with pillar2Id: XAPLR1234567890 already exists'"
+    }
+
+    "return the custom detail message for DatabaseError" in {
+      val error = DatabaseError(operation = "delete")
+      error.getMessage mustBe "Code: '500' Message: 'Failed to delete organisation due to database error'"
+    }
+
+    "return the custom detail message for UnexpectedResponseError" in {
+      val error = UnexpectedResponseError
+      error.getMessage mustBe "Code: '500' Message: 'Internal Server Error'"
+    }
+
+    "return the custom detail message for DownstreamValidationError" in {
+      val error = DownstreamValidationError(code = "422", message = "Test downstream validation error")
+      error.getMessage mustBe "Code: '422' Message: 'Test downstream validation error'"
+    }
+
+  }
+}

--- a/test/uk/gov/hmrc/pillar2submissionapi/services/AccountActivityServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/services/AccountActivityServiceSpec.scala
@@ -29,7 +29,7 @@ import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2submissionapi.base.UnitTestBaseSpec
 import uk.gov.hmrc.pillar2submissionapi.connectors.AccountActivityConnector
 import uk.gov.hmrc.pillar2submissionapi.helpers.AccountActivityDataFixture
-import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{DownstreamValidationError, UnexpectedResponse}
+import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{DownstreamValidationError, UnexpectedResponseError}
 
 import scala.concurrent.Future
 
@@ -63,7 +63,7 @@ class AccountActivityServiceSpec
             .value
             .futureValue
             .left
-            .value mustBe UnexpectedResponse
+            .value mustBe UnexpectedResponseError
         }
       }
 
@@ -74,7 +74,7 @@ class AccountActivityServiceSpec
             .value
             .futureValue
             .left
-            .value mustBe UnexpectedResponse
+            .value mustBe UnexpectedResponseError
         }
       }
 
@@ -98,7 +98,7 @@ class AccountActivityServiceSpec
             .value
             .futureValue
             .left
-            .value mustBe UnexpectedResponse
+            .value mustBe UnexpectedResponseError
         }
       }
     }
@@ -111,7 +111,7 @@ class AccountActivityServiceSpec
             .value
             .futureValue
             .left
-            .value mustBe UnexpectedResponse
+            .value mustBe UnexpectedResponseError
         }
       }
       "the body is valid json but not in the expected shape" must {
@@ -121,7 +121,7 @@ class AccountActivityServiceSpec
             .value
             .futureValue
             .left
-            .value mustBe UnexpectedResponse
+            .value mustBe UnexpectedResponseError
         }
       }
       "error body meets spec" must {
@@ -143,7 +143,7 @@ class AccountActivityServiceSpec
           .value
           .futureValue
           .left
-          .value mustBe UnexpectedResponse
+          .value mustBe UnexpectedResponseError
       }
     }
   }

--- a/test/uk/gov/hmrc/pillar2submissionapi/services/GIRServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/services/GIRServiceSpec.scala
@@ -23,7 +23,7 @@ import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2submissionapi.base.UnitTestBaseSpec
 import uk.gov.hmrc.pillar2submissionapi.connectors.GIRConnector
-import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{DownstreamValidationError, UnexpectedResponse}
+import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{DownstreamValidationError, UnexpectedResponseError}
 import uk.gov.hmrc.pillar2submissionapi.models.globeinformationreturn._
 
 import java.time.LocalDate
@@ -61,7 +61,7 @@ class GIRServiceSpec extends UnitTestBaseSpec {
         when(mockGIRConnector.createGIR(any[GIRSubmission])(using any[HeaderCarrier]))
           .thenReturn(Future.successful(HttpResponse.apply(201, Json.toJson("unexpected success response"), Map.empty)))
 
-        intercept[UnexpectedResponse.type](await(service.createGIR(validSubmission)))
+        intercept[UnexpectedResponseError.type](await(service.createGIR(validSubmission)))
       }
     }
     "createGIR() unexpected 422 response back" should {
@@ -69,7 +69,7 @@ class GIRServiceSpec extends UnitTestBaseSpec {
         when(mockGIRConnector.createGIR(any[GIRSubmission])(using any[HeaderCarrier]))
           .thenReturn(Future.successful(HttpResponse.apply(422, Json.toJson("unexpected error response"), Map.empty)))
 
-        intercept[UnexpectedResponse.type](await(service.createGIR(validSubmission)))
+        intercept[UnexpectedResponseError.type](await(service.createGIR(validSubmission)))
       }
     }
     "createGIR() 500 response back" should {
@@ -77,7 +77,7 @@ class GIRServiceSpec extends UnitTestBaseSpec {
         when(mockGIRConnector.createGIR(any[GIRSubmission])(using any[HeaderCarrier]))
           .thenReturn(Future.successful(HttpResponse.apply(500, Json.toJson("InternalServerError"), Map.empty)))
 
-        intercept[UnexpectedResponse.type](await(service.createGIR(validSubmission)))
+        intercept[UnexpectedResponseError.type](await(service.createGIR(validSubmission)))
       }
     }
 
@@ -103,7 +103,7 @@ class GIRServiceSpec extends UnitTestBaseSpec {
         when(mockGIRConnector.amendGIR(any[GIRSubmission])(using any[HeaderCarrier]))
           .thenReturn(Future.successful(HttpResponse.apply(200, Json.toJson("unexpected"), Map.empty)))
 
-        intercept[UnexpectedResponse.type](await(service.amendGIR(validSubmission)))
+        intercept[UnexpectedResponseError.type](await(service.amendGIR(validSubmission)))
       }
     }
     "amendGIR() unexpected 422 response back" should {
@@ -111,7 +111,7 @@ class GIRServiceSpec extends UnitTestBaseSpec {
         when(mockGIRConnector.amendGIR(any[GIRSubmission])(using any[HeaderCarrier]))
           .thenReturn(Future.successful(HttpResponse.apply(422, Json.toJson("unexpected"), Map.empty)))
 
-        intercept[UnexpectedResponse.type](await(service.amendGIR(validSubmission)))
+        intercept[UnexpectedResponseError.type](await(service.amendGIR(validSubmission)))
       }
     }
     "amendGIR() 500 response back" should {
@@ -119,7 +119,7 @@ class GIRServiceSpec extends UnitTestBaseSpec {
         when(mockGIRConnector.amendGIR(any[GIRSubmission])(using any[HeaderCarrier]))
           .thenReturn(Future.successful(HttpResponse.apply(500, Json.toJson("InternalServerError"), Map.empty)))
 
-        intercept[UnexpectedResponse.type](await(service.amendGIR(validSubmission)))
+        intercept[UnexpectedResponseError.type](await(service.amendGIR(validSubmission)))
       }
     }
 
@@ -145,7 +145,7 @@ class GIRServiceSpec extends UnitTestBaseSpec {
         when(mockGIRConnector.deleteGIR(any[GIRSubmission])(using any[HeaderCarrier]))
           .thenReturn(Future.successful(HttpResponse.apply(200, Json.toJson("unexpected"), Map.empty)))
 
-        intercept[UnexpectedResponse.type](await(service.deleteGIR(validSubmission)))
+        intercept[UnexpectedResponseError.type](await(service.deleteGIR(validSubmission)))
       }
     }
     "deleteGIR() unexpected 422 response back" should {
@@ -153,7 +153,7 @@ class GIRServiceSpec extends UnitTestBaseSpec {
         when(mockGIRConnector.deleteGIR(any[GIRSubmission])(using any[HeaderCarrier]))
           .thenReturn(Future.successful(HttpResponse.apply(422, Json.toJson("unexpected"), Map.empty)))
 
-        intercept[UnexpectedResponse.type](await(service.deleteGIR(validSubmission)))
+        intercept[UnexpectedResponseError.type](await(service.deleteGIR(validSubmission)))
       }
     }
     "deleteGIR() 500 response back" should {
@@ -161,7 +161,7 @@ class GIRServiceSpec extends UnitTestBaseSpec {
         when(mockGIRConnector.deleteGIR(any[GIRSubmission])(using any[HeaderCarrier]))
           .thenReturn(Future.successful(HttpResponse.apply(500, Json.toJson("InternalServerError"), Map.empty)))
 
-        intercept[UnexpectedResponse.type](await(service.deleteGIR(validSubmission)))
+        intercept[UnexpectedResponseError.type](await(service.deleteGIR(validSubmission)))
       }
     }
   }

--- a/test/uk/gov/hmrc/pillar2submissionapi/services/ObligationsAndSubmissionsServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/services/ObligationsAndSubmissionsServiceSpec.scala
@@ -24,7 +24,7 @@ import play.api.test.Helpers._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.pillar2submissionapi.base.UnitTestBaseSpec
 import uk.gov.hmrc.pillar2submissionapi.helpers.ObligationsAndSubmissionsDataFixture
-import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{DownstreamValidationError, UnexpectedResponse}
+import uk.gov.hmrc.pillar2submissionapi.models.error.Pillar2Error.{DownstreamValidationError, UnexpectedResponseError}
 import uk.gov.hmrc.pillar2submissionapi.models.obligationsandsubmissions._
 
 import java.time.LocalDate
@@ -52,7 +52,7 @@ class ObligationsAndSubmissionsServiceSpec extends UnitTestBaseSpec with Obligat
       when(mockObligationAndSubmissionsConnector.getData(any[LocalDate], any[LocalDate])(using any[HeaderCarrier], any[ExecutionContext]))
         .thenReturn(Future.successful(HttpResponse.apply(200, Json.toJson("unexpected success response"), Map.empty)))
 
-      intercept[UnexpectedResponse.type](await(obligationAndSubmissionsService.handleData(localDateFrom, localDateTo)))
+      intercept[UnexpectedResponseError.type](await(obligationAndSubmissionsService.handleData(localDateFrom, localDateTo)))
     }
   }
 
@@ -72,7 +72,7 @@ class ObligationsAndSubmissionsServiceSpec extends UnitTestBaseSpec with Obligat
       when(mockObligationAndSubmissionsConnector.getData(any[LocalDate], any[LocalDate])(using any[HeaderCarrier], any[ExecutionContext]))
         .thenReturn(Future.successful(HttpResponse.apply(422, Json.toJson("unexpected error response"), Map.empty)))
 
-      intercept[UnexpectedResponse.type](await(obligationAndSubmissionsService.handleData(localDateFrom, localDateTo)))
+      intercept[UnexpectedResponseError.type](await(obligationAndSubmissionsService.handleData(localDateFrom, localDateTo)))
     }
   }
 
@@ -81,7 +81,7 @@ class ObligationsAndSubmissionsServiceSpec extends UnitTestBaseSpec with Obligat
       when(mockObligationAndSubmissionsConnector.getData(any[LocalDate], any[LocalDate])(using any[HeaderCarrier], any[ExecutionContext]))
         .thenReturn(Future.successful(HttpResponse.apply(500, Json.toJson(InternalServerError.toString()), Map.empty)))
 
-      intercept[UnexpectedResponse.type](await(obligationAndSubmissionsService.handleData(localDateFrom, localDateTo)))
+      intercept[UnexpectedResponseError.type](await(obligationAndSubmissionsService.handleData(localDateFrom, localDateTo)))
     }
   }
 }

--- a/test/uk/gov/hmrc/pillar2submissionapi/services/OverseasReturnNotificationServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/services/OverseasReturnNotificationServiceSpec.scala
@@ -53,7 +53,7 @@ class OverseasReturnNotificationServiceSpec extends UnitTestBaseSpec with ORNDat
       when(mockOverseasReturnNotificationConnector.submitORN(any[ORNSubmission])(using any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse.apply(201, Json.toJson("unexpected success response"), Map.empty)))
 
-      intercept[UnexpectedResponse.type](await(ornService.submitORN(ornRequestFixture)))
+      intercept[UnexpectedResponseError.type](await(ornService.submitORN(ornRequestFixture)))
     }
   }
 
@@ -73,7 +73,7 @@ class OverseasReturnNotificationServiceSpec extends UnitTestBaseSpec with ORNDat
       when(mockOverseasReturnNotificationConnector.submitORN(any[ORNSubmission])(using any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse.apply(422, Json.toJson("unexpected error response"), Map.empty)))
 
-      intercept[UnexpectedResponse.type](await(ornService.submitORN(ornRequestFixture)))
+      intercept[UnexpectedResponseError.type](await(ornService.submitORN(ornRequestFixture)))
     }
   }
 
@@ -83,7 +83,7 @@ class OverseasReturnNotificationServiceSpec extends UnitTestBaseSpec with ORNDat
       when(mockOverseasReturnNotificationConnector.submitORN(any[ORNSubmission])(using any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse.apply(500, Json.toJson(InternalServerError.toString()), Map.empty)))
 
-      intercept[UnexpectedResponse.type](await(ornService.submitORN(ornRequestFixture)))
+      intercept[UnexpectedResponseError.type](await(ornService.submitORN(ornRequestFixture)))
     }
   }
 
@@ -107,7 +107,7 @@ class OverseasReturnNotificationServiceSpec extends UnitTestBaseSpec with ORNDat
       when(mockOverseasReturnNotificationConnector.amendORN(any[ORNSubmission])(using any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse.apply(200, Json.toJson("unexpected success response"), Map.empty)))
 
-      intercept[UnexpectedResponse.type](await(ornService.amendORN(ornRequestFixture)))
+      intercept[UnexpectedResponseError.type](await(ornService.amendORN(ornRequestFixture)))
     }
   }
 
@@ -127,7 +127,7 @@ class OverseasReturnNotificationServiceSpec extends UnitTestBaseSpec with ORNDat
       when(mockOverseasReturnNotificationConnector.amendORN(any[ORNSubmission])(using any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse.apply(422, Json.toJson("unexpected error response"), Map.empty)))
 
-      intercept[UnexpectedResponse.type](await(ornService.amendORN(ornRequestFixture)))
+      intercept[UnexpectedResponseError.type](await(ornService.amendORN(ornRequestFixture)))
     }
   }
 
@@ -137,7 +137,7 @@ class OverseasReturnNotificationServiceSpec extends UnitTestBaseSpec with ORNDat
       when(mockOverseasReturnNotificationConnector.amendORN(any[ORNSubmission])(using any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse.apply(500, Json.toJson(InternalServerError.toString()), Map.empty)))
 
-      intercept[UnexpectedResponse.type](await(ornService.amendORN(ornRequestFixture)))
+      intercept[UnexpectedResponseError.type](await(ornService.amendORN(ornRequestFixture)))
     }
   }
 
@@ -159,7 +159,7 @@ class OverseasReturnNotificationServiceSpec extends UnitTestBaseSpec with ORNDat
       when(mockOverseasReturnNotificationConnector.retrieveORN(any[String], any[String])(using any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse.apply(200, Json.toJson("unexpected success response"), Map.empty)))
 
-      intercept[UnexpectedResponse.type](await(ornService.retrieveORN("2024-01-01", "2024-12-31")))
+      intercept[UnexpectedResponseError.type](await(ornService.retrieveORN("2024-01-01", "2024-12-31")))
     }
   }
 
@@ -168,7 +168,7 @@ class OverseasReturnNotificationServiceSpec extends UnitTestBaseSpec with ORNDat
       when(mockOverseasReturnNotificationConnector.retrieveORN(any[String], any[String])(using any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse.apply(404, Json.toJson("Not Found"), Map.empty)))
 
-      intercept[UnexpectedResponse.type](await(ornService.retrieveORN("2024-01-01", "2024-12-31")))
+      intercept[UnexpectedResponseError.type](await(ornService.retrieveORN("2024-01-01", "2024-12-31")))
     }
   }
 
@@ -177,7 +177,7 @@ class OverseasReturnNotificationServiceSpec extends UnitTestBaseSpec with ORNDat
       when(mockOverseasReturnNotificationConnector.retrieveORN(any[String], any[String])(using any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse.apply(422, Json.toJson(ORNErrorResponse("005", "No Form Bundle found")), Map.empty)))
 
-      intercept[ORNNotFoundException.type](await(ornService.retrieveORN("2024-01-01", "2024-12-31")))
+      intercept[ORNNotFoundError.type](await(ornService.retrieveORN("2024-01-01", "2024-12-31")))
     }
   }
 
@@ -195,7 +195,7 @@ class OverseasReturnNotificationServiceSpec extends UnitTestBaseSpec with ORNDat
       when(mockOverseasReturnNotificationConnector.retrieveORN(any[String], any[String])(using any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse.apply(422, Json.toJson("unexpected error response"), Map.empty)))
 
-      intercept[UnexpectedResponse.type](await(ornService.retrieveORN("2024-01-01", "2024-12-31")))
+      intercept[UnexpectedResponseError.type](await(ornService.retrieveORN("2024-01-01", "2024-12-31")))
     }
   }
 
@@ -204,7 +204,7 @@ class OverseasReturnNotificationServiceSpec extends UnitTestBaseSpec with ORNDat
       when(mockOverseasReturnNotificationConnector.retrieveORN(any[String], any[String])(using any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse.apply(500, Json.toJson(InternalServerError.toString()), Map.empty)))
 
-      intercept[UnexpectedResponse.type](await(ornService.retrieveORN("2024-01-01", "2024-12-31")))
+      intercept[UnexpectedResponseError.type](await(ornService.retrieveORN("2024-01-01", "2024-12-31")))
     }
   }
 }

--- a/test/uk/gov/hmrc/pillar2submissionapi/services/SubmitBTNServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/services/SubmitBTNServiceSpec.scala
@@ -58,7 +58,7 @@ class SubmitBTNServiceSpec extends UnitTestBaseSpec {
       when(mockSubmitBTNConnector.submitBTN(any[BTNSubmission])(using any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse.apply(201, Json.obj("success" -> "unexpected success response"), Map.empty)))
 
-      intercept[UnexpectedResponse.type](await(submitBTNService.submitBTN(validBTNSubmission)))
+      intercept[UnexpectedResponseError.type](await(submitBTNService.submitBTN(validBTNSubmission)))
     }
   }
 
@@ -81,7 +81,7 @@ class SubmitBTNServiceSpec extends UnitTestBaseSpec {
       when(mockSubmitBTNConnector.submitBTN(any[BTNSubmission])(using any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse.apply(422, Json.obj("errors" -> "unexpected error response"), Map.empty)))
 
-      intercept[UnexpectedResponse.type](await(submitBTNService.submitBTN(validBTNSubmission)))
+      intercept[UnexpectedResponseError.type](await(submitBTNService.submitBTN(validBTNSubmission)))
     }
   }
 
@@ -91,7 +91,7 @@ class SubmitBTNServiceSpec extends UnitTestBaseSpec {
       when(mockSubmitBTNConnector.submitBTN(any[BTNSubmission])(using any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse.apply(500, Json.toJson(InternalServerError.toString()), Map.empty)))
 
-      intercept[UnexpectedResponse.type](await(submitBTNService.submitBTN(validBTNSubmission)))
+      intercept[UnexpectedResponseError.type](await(submitBTNService.submitBTN(validBTNSubmission)))
     }
   }
 
@@ -100,7 +100,7 @@ class SubmitBTNServiceSpec extends UnitTestBaseSpec {
       when(mockSubmitBTNConnector.submitBTN(any[BTNSubmission])(using any[HeaderCarrier]))
         .thenReturn(Future.successful(HttpResponse.apply(400, Json.obj("code" -> "INVALID", "message" -> "Bad Request"), Map.empty)))
 
-      intercept[UnexpectedResponse.type](await(submitBTNService.submitBTN(validBTNSubmission)))
+      intercept[UnexpectedResponseError.type](await(submitBTNService.submitBTN(validBTNSubmission)))
     }
   }
 }

--- a/test/uk/gov/hmrc/pillar2submissionapi/services/UKTaxReturnServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/services/UKTaxReturnServiceSpec.scala
@@ -78,8 +78,8 @@ class UKTaxReturnServiceSpec extends UnitTestBaseSpec {
         when(mockUKTaxReturnConnector.submitUKTR(any[UKTRSubmissionData])(using any[HeaderCarrier]))
           .thenReturn(Future.successful(HttpResponse.apply(CREATED, Json.toJson("unparsable success response"), Map.empty)))
 
-        intercept[UnexpectedResponse.type](await(mockUkTaxReturnService.submitUKTR(validNilSubmission)))
-        val result = intercept[UnexpectedResponse.type](await(mockUkTaxReturnService.submitUKTR(validLiabilitySubmission)))
+        intercept[UnexpectedResponseError.type](await(mockUkTaxReturnService.submitUKTR(validNilSubmission)))
+        val result = intercept[UnexpectedResponseError.type](await(mockUkTaxReturnService.submitUKTR(validLiabilitySubmission)))
         result.code.toInt mustEqual INTERNAL_SERVER_ERROR
         result.message mustEqual "Internal Server Error"
       }
@@ -103,8 +103,8 @@ class UKTaxReturnServiceSpec extends UnitTestBaseSpec {
         when(mockUKTaxReturnConnector.submitUKTR(any[UKTRSubmissionData])(using any[HeaderCarrier]))
           .thenReturn(Future.successful(HttpResponse.apply(UNPROCESSABLE_ENTITY, Json.toJson("unparsable error response"), Map.empty)))
 
-        intercept[UnexpectedResponse.type](await(mockUkTaxReturnService.submitUKTR(validLiabilitySubmission)))
-        val result = intercept[UnexpectedResponse.type](await(mockUkTaxReturnService.submitUKTR(validLiabilitySubmission)))
+        intercept[UnexpectedResponseError.type](await(mockUkTaxReturnService.submitUKTR(validLiabilitySubmission)))
+        val result = intercept[UnexpectedResponseError.type](await(mockUkTaxReturnService.submitUKTR(validLiabilitySubmission)))
         result.code.toInt mustEqual INTERNAL_SERVER_ERROR
         result.message mustEqual "Internal Server Error"
       }
@@ -115,7 +115,7 @@ class UKTaxReturnServiceSpec extends UnitTestBaseSpec {
         when(mockUKTaxReturnConnector.submitUKTR(any[UKTRSubmissionData])(using any[HeaderCarrier]))
           .thenReturn(Future.successful(HttpResponse.apply(INTERNAL_SERVER_ERROR, Json.toJson(InternalServerError.toString()), Map.empty)))
 
-        intercept[UnexpectedResponse.type](await(mockUkTaxReturnService.submitUKTR(validLiabilitySubmission)))
+        intercept[UnexpectedResponseError.type](await(mockUkTaxReturnService.submitUKTR(validLiabilitySubmission)))
       }
     }
 
@@ -161,8 +161,8 @@ class UKTaxReturnServiceSpec extends UnitTestBaseSpec {
         when(mockUKTaxReturnConnector.amendUKTR(any[UKTRSubmissionData])(using any[HeaderCarrier]))
           .thenReturn(Future.successful(HttpResponse.apply(OK, Json.toJson("unparsable success response"), Map.empty)))
 
-        intercept[UnexpectedResponse.type](await(mockUkTaxReturnService.amendUKTR(validNilSubmission)))
-        val result = intercept[UnexpectedResponse.type](await(mockUkTaxReturnService.amendUKTR(validLiabilitySubmission)))
+        intercept[UnexpectedResponseError.type](await(mockUkTaxReturnService.amendUKTR(validNilSubmission)))
+        val result = intercept[UnexpectedResponseError.type](await(mockUkTaxReturnService.amendUKTR(validLiabilitySubmission)))
         result.code.toInt mustEqual INTERNAL_SERVER_ERROR
         result.message mustEqual "Internal Server Error"
       }
@@ -186,8 +186,8 @@ class UKTaxReturnServiceSpec extends UnitTestBaseSpec {
         when(mockUKTaxReturnConnector.amendUKTR(any[UKTRSubmissionData])(using any[HeaderCarrier]))
           .thenReturn(Future.successful(HttpResponse.apply(UNPROCESSABLE_ENTITY, Json.toJson("unparsable error response"), Map.empty)))
 
-        intercept[UnexpectedResponse.type](await(mockUkTaxReturnService.amendUKTR(validLiabilitySubmission)))
-        val result = intercept[UnexpectedResponse.type](await(mockUkTaxReturnService.amendUKTR(validLiabilitySubmission)))
+        intercept[UnexpectedResponseError.type](await(mockUkTaxReturnService.amendUKTR(validLiabilitySubmission)))
+        val result = intercept[UnexpectedResponseError.type](await(mockUkTaxReturnService.amendUKTR(validLiabilitySubmission)))
         result.code.toInt mustEqual INTERNAL_SERVER_ERROR
         result.message mustEqual "Internal Server Error"
       }
@@ -198,7 +198,7 @@ class UKTaxReturnServiceSpec extends UnitTestBaseSpec {
         when(mockUKTaxReturnConnector.amendUKTR(any[UKTRSubmissionData])(using any[HeaderCarrier]))
           .thenReturn(Future.successful(HttpResponse.apply(INTERNAL_SERVER_ERROR, Json.toJson(InternalServerError.toString()), Map.empty)))
 
-        intercept[UnexpectedResponse.type](await(mockUkTaxReturnService.amendUKTR(validLiabilitySubmission)))
+        intercept[UnexpectedResponseError.type](await(mockUkTaxReturnService.amendUKTR(validLiabilitySubmission)))
       }
     }
   }


### PR DESCRIPTION
- The `Pillar2Error` extends Exception but the `getMessage` method requires `cause` and `message`. Because Pillar2Error uses custom message and code, exceptions are not properly formatted when logged. By overriding it we log both the `code` and `message`, making debugging easier.
- Renamed `Pillar2Error`s for consistency with the naming convention on `pillar2`
- Added spec for the `Pillar2Error.getMessage`