### PR TITLE
PIL-2905 Fixed ZAP warning - changed 500 message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ target
 test-result
 tmp
 .vscode/
+*.zip
+*.tar.gz

--- a/API Testing/pillar2/99-qa/oas/Invalid query param.bru
+++ b/API Testing/pillar2/99-qa/oas/Invalid query param.bru
@@ -27,7 +27,7 @@ tests {
   
   test("should include error details", function() {
     expect(res.body).to.not.be.undefined;
-    expect(res.body.code).to.include("003");
-    expect(res.body.message).to.include("Internal server error");
+    expect(res.body.code).to.equal("003");
+    expect(res.body.message).to.equal("An unexpected error occurred");
   });
 }

--- a/API Testing/pillar2/99-qa/orn/amend/Server Error.bru
+++ b/API Testing/pillar2/99-qa/orn/amend/Server Error.bru
@@ -34,7 +34,7 @@ tests {
   
   test("should include error details", function() {
     expect(res.body).to.not.be.undefined;
-    expect(res.body.code).to.include("003");
-    expect(res.body.message).to.include("Internal server error");
+    expect(res.body.code).to.equal("003");
+    expect(res.body.message).to.equal("An unexpected error occurred");
   });
 }

--- a/API Testing/pillar2/99-qa/orn/submit/Server Error.bru
+++ b/API Testing/pillar2/99-qa/orn/submit/Server Error.bru
@@ -35,6 +35,6 @@ tests {
   test("should include error details", function() {
     expect(res.body).to.not.be.undefined;
     expect(res.body.code).to.equal("003");
-    expect(res.body.message).to.include("Internal server error");
+    expect(res.body.message).to.equal("An unexpected error occurred");
   });
 }

--- a/app/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandler.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandler.scala
@@ -39,6 +39,7 @@ class Pillar2ErrorHandler extends HttpErrorHandler with Logging {
     }
     Future.successful(Status(statusCode)(Json.toJson(errorResponse)))
   }
+
   override def onServerError(request: RequestHeader, exception: Throwable): Future[Result] =
     exception match {
       case e: Pillar2Error =>
@@ -58,6 +59,7 @@ class Pillar2ErrorHandler extends HttpErrorHandler with Logging {
         Future.successful(ret)
       case _ =>
         logger.warn("Unhandled exception. Returning 500 status code", exception)
-        Future.successful(Results.InternalServerError(Pillar2ErrorResponse("500", "Internal Server Error")))
+        Future.successful(Results.InternalServerError(Pillar2ErrorResponse("500", "An unexpected error occurred")))
     }
+
 }

--- a/app/uk/gov/hmrc/pillar2submissionapi/models/error/Pillar2Error.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/models/error/Pillar2Error.scala
@@ -45,7 +45,7 @@ object Pillar2Error {
 
   case object UnexpectedResponse extends Pillar2Error {
     val code:    String = "500"
-    val message: String = "Internal Server Error"
+    val message: String = "An unexpected error occurred"
   }
 
   case object MissingCredentials extends Pillar2Error {

--- a/app/uk/gov/hmrc/pillar2submissionapi/models/response/Pillar2ErrorResponse.scala
+++ b/app/uk/gov/hmrc/pillar2submissionapi/models/response/Pillar2ErrorResponse.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.pillar2submissionapi.models.response
 import play.api.http.Writeable
 import play.api.libs.json.{JsValue, Json, OFormat}
 
-case class Pillar2ErrorResponse(code: String, message: String)
+final case class Pillar2ErrorResponse(code: String, message: String)
 
 object Pillar2ErrorResponse {
   given format: OFormat[Pillar2ErrorResponse] = Json.format[Pillar2ErrorResponse]

--- a/conf/swagger.yml
+++ b/conf/swagger.yml
@@ -2689,8 +2689,8 @@ components:
     errors.Submission.GenericServerError:
       summary: Generic server error
       value:
-        code: 500
-        message: Internal Server Error
+        code: "500"
+        message: An unexpected error occurred
     errors.InvalidScope:
       summary: Invalid scope
       value:

--- a/it/test/uk/gov/hmrc/pillar2submissionapi/BTNSubmissionISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2submissionapi/BTNSubmissionISpec.scala
@@ -169,7 +169,7 @@ class BTNSubmissionISpec extends IntegrationSpecBase with OptionValues {
         result.status mustEqual INTERNAL_SERVER_ERROR
         val errorResponse = result.json.as[UKTRSubmitErrorResponse]
         errorResponse.code mustEqual "500"
-        errorResponse.message mustEqual "Internal Server Error"
+        errorResponse.message mustEqual "An unexpected error occurred"
       }
 
       "return 500 INTERNAL_SERVER_ERROR for internal server error from ETMP" in {
@@ -190,7 +190,7 @@ class BTNSubmissionISpec extends IntegrationSpecBase with OptionValues {
         result.status mustEqual INTERNAL_SERVER_ERROR
         val errorResponse = result.json.as[UKTRSubmitErrorResponse]
         errorResponse.code mustEqual "500"
-        errorResponse.message mustEqual "Internal Server Error"
+        errorResponse.message mustEqual "An unexpected error occurred"
       }
     }
 

--- a/it/test/uk/gov/hmrc/pillar2submissionapi/ObligationsAndSubmissionsISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2submissionapi/ObligationsAndSubmissionsISpec.scala
@@ -112,7 +112,7 @@ class ObligationsAndSubmissionsISpec
         result.status mustEqual INTERNAL_SERVER_ERROR
         val error = result.json.as[Pillar2ErrorResponse]
         error.code mustEqual "500"
-        error.message mustEqual "Internal Server Error"
+        error.message mustEqual "An unexpected error occurred"
       }
 
       "return 400 BAD_REQUEST for invalid date range" in {
@@ -167,7 +167,7 @@ class ObligationsAndSubmissionsISpec
         result.status mustEqual INTERNAL_SERVER_ERROR
         val error = result.json.as[Pillar2ErrorResponse]
         error.code mustEqual "500"
-        error.message mustEqual "Internal Server Error"
+        error.message mustEqual "An unexpected error occurred"
       }
     }
   }

--- a/it/test/uk/gov/hmrc/pillar2submissionapi/OverseasReturnNotificationISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2submissionapi/OverseasReturnNotificationISpec.scala
@@ -251,7 +251,7 @@ class OverseasReturnNotificationISpec extends IntegrationSpecBase with OptionVal
           "POST",
           submitUrl,
           UNAUTHORIZED,
-          Json.toJson(ORNErrorResponse("500", "Internal Server Error"))
+          Json.toJson(ORNErrorResponse("500", "An unexpected error occurred"))
         )
 
         val result = Await.result(submitRequest.withBody(validRequestJson).execute[HttpResponse], 5.seconds)
@@ -259,7 +259,7 @@ class OverseasReturnNotificationISpec extends IntegrationSpecBase with OptionVal
         result.status mustEqual INTERNAL_SERVER_ERROR
         val errorResponse = result.json.as[ORNErrorResponse]
         errorResponse.code mustEqual "500"
-        errorResponse.message mustEqual "Internal Server Error"
+        errorResponse.message mustEqual "An unexpected error occurred"
       }
 
       "return 500 INTERNAL_SERVER_ERROR for internal server error from ETMP" in {
@@ -272,7 +272,7 @@ class OverseasReturnNotificationISpec extends IntegrationSpecBase with OptionVal
           "POST",
           submitUrl,
           INTERNAL_SERVER_ERROR,
-          Json.toJson(ORNErrorResponse("500", "Internal Server Error"))
+          Json.toJson(ORNErrorResponse("500", "An unexpected error occurred"))
         )
 
         val result = Await.result(submitRequest.withBody(validRequestJson).execute[HttpResponse], 5.seconds)
@@ -280,7 +280,7 @@ class OverseasReturnNotificationISpec extends IntegrationSpecBase with OptionVal
         result.status mustEqual INTERNAL_SERVER_ERROR
         val errorResponse = result.json.as[ORNErrorResponse]
         errorResponse.code mustEqual "500"
-        errorResponse.message mustEqual "Internal Server Error"
+        errorResponse.message mustEqual "An unexpected error occurred"
       }
     }
     "amendORN as a organisation" must {
@@ -475,7 +475,7 @@ class OverseasReturnNotificationISpec extends IntegrationSpecBase with OptionVal
           "PUT",
           amendUrl,
           UNAUTHORIZED,
-          Json.toJson(ORNErrorResponse("500", "Internal Server Error"))
+          Json.toJson(ORNErrorResponse("500", "An unexpected error occurred"))
         )
 
         val result = Await.result(amendRequest.withBody(validRequestJson).execute[HttpResponse], 5.seconds)
@@ -483,7 +483,7 @@ class OverseasReturnNotificationISpec extends IntegrationSpecBase with OptionVal
         result.status mustEqual INTERNAL_SERVER_ERROR
         val errorResponse = result.json.as[ORNErrorResponse]
         errorResponse.code mustEqual "500"
-        errorResponse.message mustEqual "Internal Server Error"
+        errorResponse.message mustEqual "An unexpected error occurred"
       }
 
       "return 500 INTERNAL_SERVER_ERROR for internal server error from ETMP" in {
@@ -496,7 +496,7 @@ class OverseasReturnNotificationISpec extends IntegrationSpecBase with OptionVal
           "PUT",
           amendUrl,
           INTERNAL_SERVER_ERROR,
-          Json.toJson(ORNErrorResponse("500", "Internal Server Error"))
+          Json.toJson(ORNErrorResponse("500", "An unexpected error occurred"))
         )
 
         val result = Await.result(amendRequest.withBody(validRequestJson).execute[HttpResponse], 5.seconds)
@@ -504,7 +504,7 @@ class OverseasReturnNotificationISpec extends IntegrationSpecBase with OptionVal
         result.status mustEqual INTERNAL_SERVER_ERROR
         val errorResponse = result.json.as[ORNErrorResponse]
         errorResponse.code mustEqual "500"
-        errorResponse.message mustEqual "Internal Server Error"
+        errorResponse.message mustEqual "An unexpected error occurred"
       }
     }
 
@@ -577,7 +577,7 @@ class OverseasReturnNotificationISpec extends IntegrationSpecBase with OptionVal
         result.status mustEqual INTERNAL_SERVER_ERROR
         val errorResponse = result.json.as[ORNErrorResponse]
         errorResponse.code mustEqual "500"
-        errorResponse.message mustEqual "Internal Server Error"
+        errorResponse.message mustEqual "An unexpected error occurred"
       }
 
       "return 422 UNPROCESSABLE_ENTITY for invalid parameters" in {
@@ -621,7 +621,7 @@ class OverseasReturnNotificationISpec extends IntegrationSpecBase with OptionVal
         stubGet(
           retrieveUrl(fromDate, toDate),
           INTERNAL_SERVER_ERROR,
-          Json.toJson(ORNErrorResponse("500", "Internal Server Error")).toString()
+          Json.toJson(ORNErrorResponse("500", "An unexpected error occurred")).toString()
         )
 
         val retrieveRequest = client
@@ -633,7 +633,7 @@ class OverseasReturnNotificationISpec extends IntegrationSpecBase with OptionVal
         result.status mustEqual INTERNAL_SERVER_ERROR
         val errorResponse = result.json.as[ORNErrorResponse]
         errorResponse.code mustEqual "500"
-        errorResponse.message mustEqual "Internal Server Error"
+        errorResponse.message mustEqual "An unexpected error occurred"
       }
 
       "return 500 INTERNAL_SERVER_ERROR when receiving malformed JSON on successful response" in {
@@ -661,7 +661,7 @@ class OverseasReturnNotificationISpec extends IntegrationSpecBase with OptionVal
         result.status mustEqual INTERNAL_SERVER_ERROR
         val errorResponse = result.json.as[ORNErrorResponse]
         errorResponse.code mustEqual "500"
-        errorResponse.message mustEqual "Internal Server Error"
+        errorResponse.message mustEqual "An unexpected error occurred"
       }
 
       "return 500 INTERNAL_SERVER_ERROR when receiving malformed error JSON on 422 response" in {
@@ -689,7 +689,7 @@ class OverseasReturnNotificationISpec extends IntegrationSpecBase with OptionVal
         result.status mustEqual INTERNAL_SERVER_ERROR
         val errorResponse = result.json.as[ORNErrorResponse]
         errorResponse.code mustEqual "500"
-        errorResponse.message mustEqual "Internal Server Error"
+        errorResponse.message mustEqual "An unexpected error occurred"
       }
       "return 400 BAD_REQUEST when missing parameters" in {
         stubGet(

--- a/it/test/uk/gov/hmrc/pillar2submissionapi/UKTaxReturnISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2submissionapi/UKTaxReturnISpec.scala
@@ -192,7 +192,7 @@ class UKTaxReturnISpec extends IntegrationSpecBase with OptionValues {
         result.status mustEqual INTERNAL_SERVER_ERROR
         val errorResponse = result.json.as[UKTRSubmitErrorResponse]
         errorResponse.code mustEqual "500"
-        errorResponse.message mustEqual "Internal Server Error"
+        errorResponse.message mustEqual "An unexpected error occurred"
       }
 
       "return 500 INTERNAL_SERVER_ERROR for internal server error from ETMP" in {
@@ -209,7 +209,7 @@ class UKTaxReturnISpec extends IntegrationSpecBase with OptionValues {
         result.status mustEqual INTERNAL_SERVER_ERROR
         val errorResponse = result.json.as[UKTRSubmitErrorResponse]
         errorResponse.code mustEqual "500"
-        errorResponse.message mustEqual "Internal Server Error"
+        errorResponse.message mustEqual "An unexpected error occurred"
       }
     }
 
@@ -393,7 +393,7 @@ class UKTaxReturnISpec extends IntegrationSpecBase with OptionValues {
         result.status mustEqual INTERNAL_SERVER_ERROR
         val errorResponse = result.json.as[Pillar2ErrorResponse]
         errorResponse.code mustEqual "500"
-        errorResponse.message mustEqual "Internal Server Error"
+        errorResponse.message mustEqual "An unexpected error occurred"
       }
 
       "return 500 INTERNAL_SERVER_ERROR for internal server error from ETMP" in {
@@ -410,7 +410,7 @@ class UKTaxReturnISpec extends IntegrationSpecBase with OptionValues {
         result.status mustEqual INTERNAL_SERVER_ERROR
         val errorResponse = result.json.as[Pillar2ErrorResponse]
         errorResponse.code mustEqual "500"
-        errorResponse.message mustEqual "Internal Server Error"
+        errorResponse.message mustEqual "An unexpected error occurred"
       }
     }
 

--- a/resources/public/api/conf/1.0/application.yaml
+++ b/resources/public/api/conf/1.0/application.yaml
@@ -3451,8 +3451,8 @@ components:
     errors.Submission.GenericServerError:
       summary: Generic server error
       value:
-        code: 500
-        message: Internal Server Error
+        code: '500'
+        message: An unexpected error occurred
     errors.InvalidScope:
       summary: Invalid scope
       value:

--- a/test/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandlerSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/controllers/Pillar2ErrorHandlerSpec.scala
@@ -97,7 +97,7 @@ class Pillar2ErrorHandlerSpec extends AnyFunSuite with ScalaCheckDrivenPropertyC
     status(response) mustEqual 500
     val result = contentAsJson(response).as[Pillar2ErrorResponse]
     result.code mustEqual "500"
-    result.message mustEqual "Internal Server Error"
+    result.message mustEqual "An unexpected error occurred"
   }
 
   test("EmptyRequestBody error response") {
@@ -217,6 +217,6 @@ class Pillar2ErrorHandlerSpec extends AnyFunSuite with ScalaCheckDrivenPropertyC
     status(response) mustEqual 500
     val result = contentAsJson(response).as[Pillar2ErrorResponse]
     result.code mustEqual "500"
-    result.message mustEqual "Internal Server Error"
+    result.message mustEqual "An unexpected error occurred"
   }
 }

--- a/test/uk/gov/hmrc/pillar2submissionapi/services/UKTaxReturnServiceSpec.scala
+++ b/test/uk/gov/hmrc/pillar2submissionapi/services/UKTaxReturnServiceSpec.scala
@@ -81,7 +81,7 @@ class UKTaxReturnServiceSpec extends UnitTestBaseSpec {
         intercept[UnexpectedResponse.type](await(mockUkTaxReturnService.submitUKTR(validNilSubmission)))
         val result = intercept[UnexpectedResponse.type](await(mockUkTaxReturnService.submitUKTR(validLiabilitySubmission)))
         result.code.toInt mustEqual INTERNAL_SERVER_ERROR
-        result.message mustEqual "Internal Server Error"
+        result.message mustEqual "An unexpected error occurred"
       }
     }
 
@@ -106,7 +106,7 @@ class UKTaxReturnServiceSpec extends UnitTestBaseSpec {
         intercept[UnexpectedResponse.type](await(mockUkTaxReturnService.submitUKTR(validLiabilitySubmission)))
         val result = intercept[UnexpectedResponse.type](await(mockUkTaxReturnService.submitUKTR(validLiabilitySubmission)))
         result.code.toInt mustEqual INTERNAL_SERVER_ERROR
-        result.message mustEqual "Internal Server Error"
+        result.message mustEqual "An unexpected error occurred"
       }
     }
 
@@ -164,7 +164,7 @@ class UKTaxReturnServiceSpec extends UnitTestBaseSpec {
         intercept[UnexpectedResponse.type](await(mockUkTaxReturnService.amendUKTR(validNilSubmission)))
         val result = intercept[UnexpectedResponse.type](await(mockUkTaxReturnService.amendUKTR(validLiabilitySubmission)))
         result.code.toInt mustEqual INTERNAL_SERVER_ERROR
-        result.message mustEqual "Internal Server Error"
+        result.message mustEqual "An unexpected error occurred"
       }
     }
 
@@ -189,7 +189,7 @@ class UKTaxReturnServiceSpec extends UnitTestBaseSpec {
         intercept[UnexpectedResponse.type](await(mockUkTaxReturnService.amendUKTR(validLiabilitySubmission)))
         val result = intercept[UnexpectedResponse.type](await(mockUkTaxReturnService.amendUKTR(validLiabilitySubmission)))
         result.code.toInt mustEqual INTERNAL_SERVER_ERROR
-        result.message mustEqual "Internal Server Error"
+        result.message mustEqual "An unexpected error occurred"
       }
     }
 


### PR DESCRIPTION
Replaced with "Internal server error" with "An unexpected error occurred" to fix a ZAP test warning.