### PR TITLE
PIL-3006 Removed duplicate "API" from spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ sbt createOpenAPISpec
 
 This command runs `routesToYamlOas` and validates the result. The spec is generated into the **`target/swagger`** directory.
 
-You will need to manually copy the generated file to replace the relevant configuration file in `resources/public/api/conf/1.0`.
+You will need to manually copy the generated file (`/target/swagger/application.yaml`) and replace the relevant
+configuration file in `resources/public/api/conf/1.0`.
 
 ### Spec Versions
 

--- a/conf/swagger.yml
+++ b/conf/swagger.yml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  title: Pillar 2 API
+  title: Pillar 2
   description: An API for managing and retrieving data in accordance with Pillar 2 tax rules.
 servers:
   - url: https://test-api.service.hmrc.gov.uk

--- a/it/test/uk/gov/hmrc/pillar2submissionapi/controllers/platform/DocumentationControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2submissionapi/controllers/platform/DocumentationControllerISpec.scala
@@ -41,7 +41,7 @@ class DocumentationControllerISpec extends IntegrationSpecBase {
       val url        = s"$baseUrl${routes.DocumentationController.definition().url}"
       val definition = Await.result(client.get(URI.create(url).toURL).execute[HttpResponse], 5.seconds)
       val json       = definition.json
-      (json \ "api" \ "name").as[String] mustEqual "Pillar 2 API"
+      (json \ "api" \ "name").as[String] mustEqual "Pillar 2"
       (json \ "api" \ "description").as[String] mustEqual "An API for managing and retrieving Pillar 2 data"
       (json \ "api" \ "context").as[String] mustEqual "organisations/pillar-two"
       (json \ "api" \ "categories").as[List[String]] must have size 1

--- a/resources/public/api/conf/1.0/application.yaml
+++ b/resources/public/api/conf/1.0/application.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
-  version: 0.210.0
-  title: Pillar 2 API
+  version: 0.226.0
+  title: Pillar 2
   description: An API for managing and retrieving data in accordance with Pillar 2 tax rules.
 tags: []
 paths:

--- a/resources/public/api/conf/1.0/testOnly/application.yaml
+++ b/resources/public/api/conf/1.0/testOnly/application.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
-  version: 0.210.0
-  title: Pillar 2 API
+  version: 0.226.0
+  title: Pillar 2
   description: An API for managing and retrieving data in accordance with Pillar 2 tax rules.
 tags: []
 paths:

--- a/resources/public/api/definition.json
+++ b/resources/public/api/definition.json
@@ -1,6 +1,6 @@
 {
   "api": {
-    "name": "Pillar 2 API",
+    "name": "Pillar 2",
     "description": "An API for managing and retrieving Pillar 2 data",
     "context": "organisations/pillar-two",
     "categories": ["CORPORATION_TAX"],


### PR DESCRIPTION
Developer Hub adds the ` API` suffix to all APIs so we change the title so it does no longer show as "Pillar 2 API API".