### PR TITLE
PIL-3006 (Not) removing the API suffix from the API name. Updated version of spec

### DIFF
--- a/resources/public/api/conf/1.0/application.yaml
+++ b/resources/public/api/conf/1.0/application.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.235.0
+  version: 0.238.0
   title: Pillar 2 API
   description: An API for managing and retrieving data in accordance with Pillar 2 tax rules.
 tags: []

--- a/resources/public/api/conf/1.0/testOnly/application.yaml
+++ b/resources/public/api/conf/1.0/testOnly/application.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.3
 info:
-  version: 0.235.0
+  version: 0.238.0
   title: Pillar 2 API
   description: An API for managing and retrieving data in accordance with Pillar 2 tax rules.
 tags: []


### PR DESCRIPTION
Initial approach was to remove the API suffix from the name of the Pillar 2 API. Platform changed their approach to adding the ` API` suffix, so no need to remove it from ours.