### PR TITLE
PIL-3057 API Platform change to "access"

### DIFF
--- a/it/test/uk/gov/hmrc/pillar2submissionapi/controllers/platform/DocumentationControllerISpec.scala
+++ b/it/test/uk/gov/hmrc/pillar2submissionapi/controllers/platform/DocumentationControllerISpec.scala
@@ -51,8 +51,7 @@ class DocumentationControllerISpec extends IntegrationSpecBase {
       (json \ "api" \ "versions" \ 0 \ "version").as[String] mustEqual "1.0"
       (json \ "api" \ "versions" \ 0 \ "status").as[String] mustEqual "BETA"
       (json \ "api" \ "versions" \ 0 \ "endpointsEnabled").as[Boolean] mustEqual true
-      (json \ "api" \ "versions" \ 0 \ "access" \ "type").as[String] mustEqual "PRIVATE"
-      (json \ "api" \ "versions" \ 0 \ "access" \ "isTrial").as[Boolean] mustEqual true
+      (json \ "api" \ "versions" \ 0 \ "access").as[String] mustEqual "CONTROLLED"
     }
 
     "return API documentation" when {

--- a/resources/public/api/definition.json
+++ b/resources/public/api/definition.json
@@ -9,10 +9,7 @@
         "version": "1.0",
         "status": "ALPHA",
         "endpointsEnabled": false,
-        "access": {
-          "type": "PRIVATE",
-          "isTrial": true
-        }
+        "access": "CONTROLLED"
       }
     ]
   }


### PR DESCRIPTION
Changed the API's `access` from object with `PRIVATE` + `isTrial` to String `CONTROLLED`.
